### PR TITLE
ConsentMustScroll Improvements - short consents, accessibility

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -184,16 +184,24 @@
     return YES;
 }
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (!_agreeButton.isEnabled) {
-        CGPoint offset = scrollView.contentOffset;
-        CGRect bounds = scrollView.bounds;
-        UIEdgeInsets inset = scrollView.contentInset;
-        CGFloat currentOffset = offset.y + bounds.size.height - inset.bottom;
-        if (currentOffset - scrollView.contentSize.height >= 0) {
-            _agreeButton.enabled = YES;
-        }
+- (void)webViewDidFinishLoad:(UIWebView *)webView {
+    if (!_agreeButton.isEnabled && [self scrolledToBottom:_webView.scrollView]) {
+        [_agreeButton setEnabled:YES];
     }
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (!_agreeButton.isEnabled && [self scrolledToBottom:scrollView]) {
+        _agreeButton.enabled = YES;
+    }
+}
+
+- (BOOL)scrolledToBottom:(UIScrollView *)scrollView {
+    CGPoint offset = scrollView.contentOffset;
+    CGRect bounds = scrollView.bounds;
+    UIEdgeInsets inset = scrollView.contentInset;
+    CGFloat currentOffset = offset.y + bounds.size.height - inset.bottom;
+    return (currentOffset - scrollView.contentSize.height >= 0);
 }
 
 @end


### PR DESCRIPTION
Enhances shortcomings from https://github.com/CareEvolution/ResearchKit/pull/4. If the consent document was short and did not require scrolling, the button would inexplicably be disabled. Now when the web view finishes loading, after a short delay to mitigate a race condition with view rendering on screen, the scroll position will be checked and if it's determined to be at the bottom, the button will be enabled.

Also, addressed a potential rough edge for accessibility where the disabled Agree button could confuse/frustrate a vision-impaired user.  Before the change when VoiceOver was on, and the button encountered, it would simply read "Agree. Dim. Button".  Now with the hint added while the button is disabled, it reads "Agree. Dim. Button.  Must scroll to the bottom to enable this button".  Then if the user 3-finger swipes up, the `UIScrollView` in the `UIWebView` will scroll up in a paginated fashion until it reaches the bottom at which point the button becomes enabled and the hint is removed.  Then the button reads "Agree. Button".