### PR TITLE
Add ORKWeightAnswerFormat

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		BC13CE421B066A990044153C /* ORKStepNavigationRule_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = BC13CE411B066A990044153C /* ORKStepNavigationRule_Internal.h */; };
 		BC1C032C1CA301E300869355 /* ORKHeightPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = BC1C032A1CA301E300869355 /* ORKHeightPicker.h */; };
 		BC1C032D1CA301E300869355 /* ORKHeightPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = BC1C032B1CA301E300869355 /* ORKHeightPicker.m */; };
+		BC2908BC1FBD628F0030AB89 /* ORKTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = BC2908BB1FBD628F0030AB89 /* ORKTypes.m */; };
 		BC4194291AE8453A00073D6B /* ORKObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4194271AE8453A00073D6B /* ORKObserver.h */; };
 		BC41942A1AE8453A00073D6B /* ORKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = BC4194281AE8453A00073D6B /* ORKObserver.m */; };
 		BC4A213F1C85FC0000BFC271 /* ORKBarGraphChartView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4A213D1C85FC0000BFC271 /* ORKBarGraphChartView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1139,6 +1140,7 @@
 		BC13CE411B066A990044153C /* ORKStepNavigationRule_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKStepNavigationRule_Internal.h; sourceTree = "<group>"; };
 		BC1C032A1CA301E300869355 /* ORKHeightPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKHeightPicker.h; sourceTree = "<group>"; };
 		BC1C032B1CA301E300869355 /* ORKHeightPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHeightPicker.m; sourceTree = "<group>"; };
+		BC2908BB1FBD628F0030AB89 /* ORKTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKTypes.m; sourceTree = "<group>"; };
 		BC4194271AE8453A00073D6B /* ORKObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKObserver.h; sourceTree = "<group>"; };
 		BC4194281AE8453A00073D6B /* ORKObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKObserver.m; sourceTree = "<group>"; };
 		BC4A213D1C85FC0000BFC271 /* ORKBarGraphChartView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKBarGraphChartView.h; path = Charts/ORKBarGraphChartView.h; sourceTree = "<group>"; };
@@ -1981,6 +1983,7 @@
 		B12EFF3D1AB2121000A80147 /* Definitions */ = {
 			isa = PBXGroup;
 			children = (
+				BC2908BB1FBD628F0030AB89 /* ORKTypes.m */,
 				BCB8133B1C98367A00346561 /* ORKTypes.h */,
 				86C40B7B1A8D7C5C00081FAC /* ORKDefines.h */,
 				86C40B7D1A8D7C5C00081FAC /* ORKErrors.h */,
@@ -3121,6 +3124,7 @@
 				2433C9E41B9A506F0052D375 /* ORKKeychainWrapper.m in Sources */,
 				86C40CA61A8D7C5C00081FAC /* ORKLocationRecorder.m in Sources */,
 				86C40CB61A8D7C5C00081FAC /* ORKTouchRecorder.m in Sources */,
+				BC2908BC1FBD628F0030AB89 /* ORKTypes.m in Sources */,
 				B12EA0161B0D73A500F9F554 /* ORKToneAudiometryPracticeStep.m in Sources */,
 				CBD34A5B1BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.m in Sources */,
 				959A2C011D68B9DA00841B04 /* ORKRangeOfMotionStepViewController.m in Sources */,

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		147503BA1AEE807C004B17F3 /* ORKToneAudiometryStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 147503B41AEE807C004B17F3 /* ORKToneAudiometryStep.m */; };
 		147503BB1AEE807C004B17F3 /* ORKToneAudiometryStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 147503B51AEE807C004B17F3 /* ORKToneAudiometryStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		147503BC1AEE807C004B17F3 /* ORKToneAudiometryStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 147503B61AEE807C004B17F3 /* ORKToneAudiometryStepViewController.m */; };
+		1B4B95B81F5F012E006B629F /* ORKWeightPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B4B95B71F5F012E006B629F /* ORKWeightPicker.m */; };
+		1B4B95BA1F5F014E006B629F /* ORKWeightPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B4B95B91F5F014E006B629F /* ORKWeightPicker.h */; };
 		241A2E871B94FD8800ED3B39 /* ORKPasscodeStepViewController_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 241A2E861B94FD8800ED3B39 /* ORKPasscodeStepViewController_Internal.h */; };
 		2429D5721BBB5397003A512F /* ORKRegistrationStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2429D5701BBB5397003A512F /* ORKRegistrationStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2429D5731BBB5397003A512F /* ORKRegistrationStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 2429D5711BBB5397003A512F /* ORKRegistrationStep.m */; };
@@ -656,6 +658,8 @@
 		147503B41AEE807C004B17F3 /* ORKToneAudiometryStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKToneAudiometryStep.m; sourceTree = "<group>"; };
 		147503B51AEE807C004B17F3 /* ORKToneAudiometryStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKToneAudiometryStepViewController.h; sourceTree = "<group>"; };
 		147503B61AEE807C004B17F3 /* ORKToneAudiometryStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKToneAudiometryStepViewController.m; sourceTree = "<group>"; };
+		1B4B95B71F5F012E006B629F /* ORKWeightPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKWeightPicker.m; sourceTree = "<group>"; };
+		1B4B95B91F5F014E006B629F /* ORKWeightPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKWeightPicker.h; sourceTree = "<group>"; };
 		241A2E861B94FD8800ED3B39 /* ORKPasscodeStepViewController_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKPasscodeStepViewController_Internal.h; sourceTree = "<group>"; };
 		2429D5701BBB5397003A512F /* ORKRegistrationStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKRegistrationStep.h; path = Onboarding/ORKRegistrationStep.h; sourceTree = "<group>"; };
 		2429D5711BBB5397003A512F /* ORKRegistrationStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORKRegistrationStep.m; path = Onboarding/ORKRegistrationStep.m; sourceTree = "<group>"; };
@@ -2026,6 +2030,8 @@
 			children = (
 				BC1C032A1CA301E300869355 /* ORKHeightPicker.h */,
 				BC1C032B1CA301E300869355 /* ORKHeightPicker.m */,
+				1B4B95B91F5F014E006B629F /* ORKWeightPicker.h */,
+				1B4B95B71F5F012E006B629F /* ORKWeightPicker.m */,
 				86B781B71AA668ED00688151 /* ORKTimeIntervalPicker.h */,
 				86B781B81AA668ED00688151 /* ORKTimeIntervalPicker.m */,
 				86B781B91AA668ED00688151 /* ORKValuePicker.h */,
@@ -2728,6 +2734,7 @@
 				86C40D101A8D7C5C00081FAC /* ORKDefaultFont.h in Headers */,
 				86C40E301A8D7C5C00081FAC /* ORKVisualConsentStepViewController.h in Headers */,
 				86C40DCA1A8D7C5C00081FAC /* ORKTaskViewController.h in Headers */,
+				1B4B95BA1F5F014E006B629F /* ORKWeightPicker.h in Headers */,
 				86C40C7E1A8D7C5C00081FAC /* ORKActiveStep.h in Headers */,
 				BCB6E65E1B7D534C000D5B34 /* ORKGraphChartView.h in Headers */,
 				86C40DD21A8D7C5C00081FAC /* ORKTextButton.h in Headers */,
@@ -3167,6 +3174,7 @@
 				86C40DB81A8D7C5C00081FAC /* ORKSurveyAnswerCellForText.m in Sources */,
 				86C40CF01A8D7C5C00081FAC /* ORKAnswerTextView.m in Sources */,
 				86C40D3E1A8D7C5C00081FAC /* ORKImageChoiceLabel.m in Sources */,
+				1B4B95B81F5F012E006B629F /* ORKWeightPicker.m in Sources */,
 				250F94051B4C5A6600FA23EB /* ORKTowerOfHanoiStep.m in Sources */,
 				86C40E0A1A8D7C5C00081FAC /* ORKConsentReviewStep.m in Sources */,
 				BCD192E81B81243900FCC08A /* ORKPieChartLegendView.m in Sources */,

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1478,10 +1478,10 @@ ORK_CLASS_AVAILABLE
                                     `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
                                     increments for the metric measurement system and whole pound
                                     increments for the USC measurement system, which mimics the
-                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    default iOS behavior. If you pass `ORKNumericPrecisionLow`, the
                                     picker will use 1 kg increments for the metric measurement
                                     system and whole pound increments for the USC measurement
-                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    system. If you pass `ORKNumericPrecisionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
  
@@ -1500,10 +1500,10 @@ ORK_CLASS_AVAILABLE
                                     `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
                                     increments for the metric measurement system and whole pound
                                     increments for the USC measurement system, which mimics the
-                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    default iOS behavior. If you pass `ORKNumericPrecisionLow`, the
                                     picker will use 1 kg increments for the metric measurement
                                     system and whole pound increments for the USC measurement
-                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    system. If you pass `ORKNumericPrecisionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
  @param minimumValue            The minimum value that is displayed in the picker. If you specify
@@ -1538,15 +1538,15 @@ ORK_CLASS_AVAILABLE
  
  An `ORKNumericPrecisionDefault` value indicates that the picker will use 0.5 kg increments for the
  metric measurement system and whole pound increments for the USC measurement system, which mimics
- the default iOS behavior. An `ORKNumericPrecissionLow` value indicates that the picker will use
+ the default iOS behavior. An `ORKNumericPrecisionLow` value indicates that the picker will use
  1 kg increments for the metric measurement system and whole pound increments for the USC
- measurement system. An `ORKNumericPrecissionHigher` value indicates that the picker will use
+ measurement system. An `ORKNumericPrecisionHigher` value indicates that the picker will use
  0.01 gr increments for the metric measurement system and ounce increments for the USC measurement
  system.
  
  The default value of this property is `ORKNumericPrecisionDefault`.
  */
-@property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecission;
+@property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecision;
 
 /**
  The minimum value that is displayed in the picker.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -166,6 +166,11 @@ ORK_CLASS_AVAILABLE
 
 + (ORKWeightAnswerFormat *)weightAnswerFormat;
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
+                                                 minimumValue:(nullable NSNumber *)minimumValue
+                                                 maximumValue:(nullable NSNumber *)maximumValue
+                                          additionalPrecision:(BOOL)additionalPrecision
+                                            measurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1457,9 +1462,59 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
 
 /**
+ Returns an initialized weight answer format using the specified default/minimum/maximum values, 
+ additional precision, and measurement system.
+ 
+ @param defaultValue            The default value to display. When the value of this parameter is `nil`, the
+ picker displays 60 kg (or 133 lbs).
+ @param minimumValue            The minimum value that is accessible in the picker. If the value of this
+ parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
+ @param maximumValue            The maximum value that is accessible in the picker. If the value of this
+ parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param additionalPrecision     Pass `YES` to allow additional precision; for the default, pass `NO`.
+ @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
+ accepted values.
+ 
+ @return An initialized weight answer format.
+ */
+- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
+                        minimumValue:(nullable NSNumber *)minimumValue
+                        maximumValue:(nullable NSNumber *)maximumValue
+                 additionalPrecision:(BOOL)additionalPrecision
+                   measurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+
+/**
  Indicates the measurement system used by the answer format.
  */
 @property (readonly) ORKMeasurementSystem measurementSystem;
+
+/**
+ The value to use as the default in the specified measurement system.
+ 
+ When the value of this property is `nil`, 60 kg (or 133 lbs) is used as the default.
+ */
+@property (copy, readonly, nullable) NSNumber *defaultValue;
+
+/**
+ The minimum allowed value in the specified measurement system.
+ 
+ When the value of this property is `nil`, 0 kg (or 0 lbs) is the minimum.
+ */
+@property (copy, readonly, nullable) NSNumber *minimumValue;
+
+/**
+ The maximum allowed value in the specified measurement system.
+ 
+ When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ */
+@property (copy, readonly, nullable) NSNumber *maximumValue;
+
+/**
+ A Boolean value indicating whether the value picker will display additional precision. (read-only)
+
+ By default, the value of this property is `NO`.
+ */
+@property (readonly, getter=isAdditionalPrecision) BOOL additionalPrecision;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -169,6 +169,7 @@ ORK_CLASS_AVAILABLE
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
                                                  minimumValue:(nullable NSNumber *)minimumValue
                                                  maximumValue:(nullable NSNumber *)maximumValue
+                                                valueInterval:(nullable NSNumber *)valueInterval
                                           additionalPrecision:(BOOL)additionalPrecision
                                             measurementSystem:(ORKMeasurementSystem)measurementSystem;
 
@@ -1471,6 +1472,8 @@ ORK_CLASS_AVAILABLE
  parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
  @param maximumValue            The maximum value that is accessible in the picker. If the value of this
  parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param valueInterval           The interval at which the picker should display kilograms. The default is .5 
+ otherwise zero. If value interval is non-zero or if 'nil' the default is used.
  @param additionalPrecision     Pass `YES` to allow additional precision; for the default, pass `NO`.
  @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
  accepted values.
@@ -1480,6 +1483,7 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
                         minimumValue:(nullable NSNumber *)minimumValue
                         maximumValue:(nullable NSNumber *)maximumValue
+                       valueInterval:(nullable NSNumber *)valueInterval
                  additionalPrecision:(BOOL)additionalPrecision
                    measurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
 
@@ -1508,6 +1512,13 @@ ORK_CLASS_AVAILABLE
  When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
  */
 @property (copy, readonly, nullable) NSNumber *maximumValue;
+
+/**
+ The interval at which the picker should display kilograms. (ignored for USC and additionalPrecision=YES)
+ 
+ The default is .5 otherwise zero. If value is non-zero or if 'nil' the default is used.
+ */
+@property (copy, readonly, nullable) NSNumber *valueInterval;
 
 /**
  A Boolean value indicating whether the value picker will display additional precision. (read-only)

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -175,9 +175,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      minimumValue:(nullable NSNumber *)minimumValue
-                                                      maximumValue:(nullable NSNumber *)maximumValue
-                                                      defaultValue:(nullable NSNumber *)defaultValue;
+                                                      minimumValue:(double)minimumValue
+                                                      maximumValue:(double)maximumValue
+                                                      defaultValue:(double)defaultValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1506,20 +1506,27 @@ ORK_CLASS_AVAILABLE
                                     system. If you pass `ORKNumericPrecissionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
- @param minimumValue            The minimum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
- @param maximumValue            The maximum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
- @param defaultValue            The default value to display. When the value of this parameter is
-                                    `nil`, the picker displays 60 kg (or 133 lbs).
+ @param minimumValue            The minimum value that is displayed in the picker. If you specify
+                                    `ORKDefaultValue`, the minimum values are 0 kg when using the
+                                    metric measurement system and 0 lbs when using the USC
+                                    measurement system.
+ @param maximumValue            The maximum value that is displayed in the picker. If you specify
+                                    `ORKDefaultValue`, the maximum values are 657 kg when using the
+                                    metric measurement system and 1,450 lbs when using the USC
+                                    measurement system.
+ @param defaultValue            The default value to be initially selected in the picker. If you
+                                    specify `ORKDefaultValue`, the initally selected values are
+                                    60 kg when using the metric measurement system and 133 lbs when
+                                    using the USC measurement system. This value must be between
+                                    `minimumValue` and `maximumValue`.
  
  @return An initialized weight answer format.
  */
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             minimumValue:(nullable NSNumber *)minimumValue
-                             maximumValue:(nullable NSNumber *)maximumValue
-                             defaultValue:(nullable NSNumber *)defaultValue NS_DESIGNATED_INITIALIZER;
+                             minimumValue:(double)minimumValue
+                             maximumValue:(double)maximumValue
+                             defaultValue:(double)defaultValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.
@@ -1542,25 +1549,29 @@ ORK_CLASS_AVAILABLE
 @property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecission;
 
 /**
- The value to use as the default in the specified measurement system.
+ The minimum value that is displayed in the picker.
  
- When the value of this property is `nil`, 60 kg (or 133 lbs) is used as the default.
+ When this property has a value equal to `ORKDefaultValue`, the minimum values are 0 kg when using
+ the metric measurement system and 0 lbs when using the USC measurement system.
  */
-@property (copy, readonly, nullable) NSNumber *defaultValue;
+@property (readonly) double minimumValue;
 
 /**
- The minimum allowed value in the specified measurement system.
+ The maximum value that is displayed in the picker.
  
- When the value of this property is `nil`, 0 kg (or 0 lbs) is the minimum.
+ When this property has a value equal to `ORKDefaultValue`, the maximum values are 657 kg when using
+ the metric measurement system and 1,450 lbs when using the USC measurement system.
  */
-@property (copy, readonly, nullable) NSNumber *minimumValue;
+@property (readonly) double maximumValue;
 
 /**
- The maximum allowed value in the specified measurement system.
+ The default value to initially selected in the picker.
  
- When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ When this property has a value equal to `ORKDefaultValue`, the initally selected values are 60 kg
+ when using the metric measurement system and 133 lbs when using the USC measurement system. This
+ value must be between `minimumValue` and `maximumValue`.
  */
-@property (copy, readonly, nullable) NSNumber *maximumValue;
+@property (readonly) double defaultValue;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -158,20 +158,26 @@ ORK_CLASS_AVAILABLE
 + (ORKEmailAnswerFormat *)emailAnswerFormat;
 
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormat;
+
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormatWithDefaultInterval:(NSTimeInterval)defaultInterval
                                                                         step:(NSInteger)step;
 
 + (ORKHeightAnswerFormat *)heightAnswerFormat;
+
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 + (ORKWeightAnswerFormat *)weightAnswerFormat;
+
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
-+ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
-                                                 minimumValue:(nullable NSNumber *)minimumValue
-                                                 maximumValue:(nullable NSNumber *)maximumValue
-                                                valueInterval:(nullable NSNumber *)valueInterval
-                                          additionalPrecision:(BOOL)additionalPrecision
-                                            measurementSystem:(ORKMeasurementSystem)measurementSystem;
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision;
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision
+                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      maximumValue:(nullable NSNumber *)maximumValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1425,7 +1431,7 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
 
 /**
- Indicates the measurement system used by the answer format.
+ The measurement system used by the answer format.
  */
 @property (readonly) ORKMeasurementSystem measurementSystem;
 
@@ -1460,37 +1466,80 @@ ORK_CLASS_AVAILABLE
  
  @return An initialized weight answer format.
  */
-- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 /**
- Returns an initialized weight answer format using the specified default/minimum/maximum values, 
- additional precision, and measurement system.
+ Returns an initialized weight answer format using the specified measurement system and numeric
+ precision.
  
- @param defaultValue            The default value to display. When the value of this parameter is `nil`, the
- picker displays 60 kg (or 133 lbs).
- @param minimumValue            The minimum value that is accessible in the picker. If the value of this
- parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
- @param maximumValue            The maximum value that is accessible in the picker. If the value of this
- parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
- @param valueInterval           The interval at which the picker should display kilograms. The default is .5 
- otherwise zero. If value interval is non-zero or if 'nil' the default is used.
- @param additionalPrecision     Pass `YES` to allow additional precision; for the default, pass `NO`.
  @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
- accepted values.
+                                    accepted values.
+ @param numericPrecision        The numeric precision used by the picker. If you pass
+                                    `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
+                                    increments for the metric measurement system and whole pound
+                                    increments for the USC measurement system, which mimics the
+                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    picker will use 1 kg increments for the metric measurement
+                                    system and whole pound increments for the USC measurement
+                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    use 0.01 gr increments for the metric measurement system,
+                                    and ounce increments for the USC measurement system.
  
  @return An initialized weight answer format.
  */
-- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
-                        minimumValue:(nullable NSNumber *)minimumValue
-                        maximumValue:(nullable NSNumber *)maximumValue
-                       valueInterval:(nullable NSNumber *)valueInterval
-                 additionalPrecision:(BOOL)additionalPrecision
-                   measurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision;
+
+/**
+ Returns an initialized weight answer format using the specified measurement system, numeric
+ precision, and default, minimum and maximum values.
+ 
+ @param measurementSystem       The measurement system to use. See `ORKMeasurementSystem` for the
+                                    accepted values.
+ @param numericPrecision        The numeric precision used by the picker. If you pass
+                                    `ORKNumericPrecisionDefault`, the picker will use 0.5 kg
+                                    increments for the metric measurement system and whole pound
+                                    increments for the USC measurement system, which mimics the
+                                    default iOS behavior. If you pass `ORKNumericPrecissionLow`, the
+                                    picker will use 1 kg increments for the metric measurement
+                                    system and whole pound increments for the USC measurement
+                                    system. If you pass `ORKNumericPrecissionHigher`, the picker
+                                    use 0.01 gr increments for the metric measurement system,
+                                    and ounce increments for the USC measurement system.
+ @param defaultValue            The default value to display. When the value of this parameter is
+                                    `nil`, the picker displays 60 kg (or 133 lbs).
+ @param maximumValue            The maximum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param minimumValue            The minimum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
+ 
+ @return An initialized weight answer format.
+ */
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision
+                             defaultValue:(nullable NSNumber *)defaultValue
+                             maximumValue:(nullable NSNumber *)maximumValue
+                             minimumValue:(nullable NSNumber *)minimumValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.
  */
 @property (readonly) ORKMeasurementSystem measurementSystem;
+
+/**
+ The numeric precision used by the picker.
+ 
+ An `ORKNumericPrecisionDefault` value indicates that the picker will use 0.5 kg increments for the
+ metric measurement system and whole pound increments for the USC measurement system, which mimics
+ the default iOS behavior. An `ORKNumericPrecissionLow` value indicates that the picker will use
+ 1 kg increments for the metric measurement system and whole pound increments for the USC
+ measurement system. An `ORKNumericPrecissionHigher` value indicates that the picker will use
+ 0.01 gr increments for the metric measurement system and ounce increments for the USC measurement
+ system.
+ 
+ The default value of this property is `ORKNumericPrecisionDefault`.
+ */
+@property (readonly, getter=isAdditionalPrecision) ORKNumericPrecision numericPrecission;
 
 /**
  The value to use as the default in the specified measurement system.
@@ -1512,20 +1561,6 @@ ORK_CLASS_AVAILABLE
  When the value of this property is `nil`, 657 kg (or 1,450 lbs) is the maximum.
  */
 @property (copy, readonly, nullable) NSNumber *maximumValue;
-
-/**
- The interval at which the picker should display kilograms. (ignored for USC and additionalPrecision=YES)
- 
- The default is .5 otherwise zero. If value is non-zero or if 'nil' the default is used.
- */
-@property (copy, readonly, nullable) NSNumber *valueInterval;
-
-/**
- A Boolean value indicating whether the value picker will display additional precision. (read-only)
-
- By default, the value of this property is `NO`.
- */
-@property (readonly, getter=isAdditionalPrecision) BOOL additionalPrecision;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -175,9 +175,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue
                                                       maximumValue:(nullable NSNumber *)maximumValue
-                                                      minimumValue:(nullable NSNumber *)minimumValue;
+                                                      defaultValue:(nullable NSNumber *)defaultValue;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1506,20 +1506,20 @@ ORK_CLASS_AVAILABLE
                                     system. If you pass `ORKNumericPrecissionHigher`, the picker
                                     use 0.01 gr increments for the metric measurement system,
                                     and ounce increments for the USC measurement system.
- @param defaultValue            The default value to display. When the value of this parameter is
-                                    `nil`, the picker displays 60 kg (or 133 lbs).
- @param maximumValue            The maximum value that is accessible in the picker. If the value of
-                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
  @param minimumValue            The minimum value that is accessible in the picker. If the value of
                                     this parameter is `nil`, 0 kg (or 0 lbs) is the minimum.
+ @param maximumValue            The maximum value that is accessible in the picker. If the value of
+                                    this parameter is `nil`, 657 kg (or 1,450 lbs) is the maximum.
+ @param defaultValue            The default value to display. When the value of this parameter is
+                                    `nil`, the picker displays 60 kg (or 133 lbs).
  
  @return An initialized weight answer format.
  */
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             defaultValue:(nullable NSNumber *)defaultValue
+                             minimumValue:(nullable NSNumber *)minimumValue
                              maximumValue:(nullable NSNumber *)maximumValue
-                             minimumValue:(nullable NSNumber *)minimumValue NS_DESIGNATED_INITIALIZER;
+                             defaultValue:(nullable NSNumber *)defaultValue NS_DESIGNATED_INITIALIZER;
 
 /**
  Indicates the measurement system used by the answer format.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORKEmailAnswerFormat;
 @class ORKTimeIntervalAnswerFormat;
 @class ORKHeightAnswerFormat;
+@class ORKWeightAnswerFormat;
 @class ORKLocationAnswerFormat;
 
 @class ORKTextChoice;
@@ -162,6 +163,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKHeightAnswerFormat *)heightAnswerFormat;
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
+
++ (ORKWeightAnswerFormat *)weightAnswerFormat;
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem;
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat;
 
@@ -1411,6 +1415,44 @@ ORK_CLASS_AVAILABLE
                                 accepted values.
  
  @return An initialized height answer format.
+ */
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
+
+/**
+ Indicates the measurement system used by the answer format.
+ */
+@property (readonly) ORKMeasurementSystem measurementSystem;
+
+@end
+
+
+/**
+ The `ORKWeightAnswerFormat` class represents the answer format for questions that require users
+ to enter a weight.
+ 
+ A weight answer format produces an `ORKNumericQuestionResult` object. The result is always reported
+ in the metric system using the `kg` unit.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKWeightAnswerFormat : ORKAnswerFormat
+
+/**
+ Returns an initialized weight answer format using the measurement system specified in the current
+ locale.
+ 
+ @return An initialized weight answer format.
+ */
+- (instancetype)init;
+
+/**
+ Returns an initialized weight answer format using the specified measurement system.
+ 
+ This method is the designated initializer.
+ 
+ @param measurementSystem   The measurement system to use. See `ORKMeasurementSystem` for the
+ accepted values.
+ 
+ @return An initialized weight answer format.
  */
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem NS_DESIGNATED_INITIALIZER;
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -425,11 +425,13 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
                                                  minimumValue:(nullable NSNumber *)minimumValue
                                                  maximumValue:(nullable NSNumber *)maximumValue
+                                                valueInterval:(nullable NSNumber *)valueInterval
                                           additionalPrecision:(BOOL)additionalPrecision
                                             measurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [[ORKWeightAnswerFormat alloc] initWithDefaultValue:defaultValue
                                                   minimumValue:minimumValue
                                                   maximumValue:maximumValue
+                                                 valueInterval:valueInterval
                                            additionalPrecision:additionalPrecision
                                              measurementSystem:measurementSystem];
 }
@@ -2781,6 +2783,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
                         minimumValue:(nullable NSNumber *)minimumValue
                         maximumValue:(nullable NSNumber *)maximumValue
+                       valueInterval:(nullable NSNumber *)valueInterval
                  additionalPrecision:(BOOL)additionalPrecision
                    measurementSystem:(ORKMeasurementSystem)measurementSystem {
     self = [super init];
@@ -2788,6 +2791,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _defaultValue = defaultValue;
         _minimumValue = minimumValue;
         _maximumValue = maximumValue;
+        _valueInterval = valueInterval;
         _additionalPrecision = additionalPrecision;
         _measurementSystem = measurementSystem;
     }
@@ -2841,7 +2845,10 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
             NSString *wholeString = [formatter stringFromNumber:@(whole)];
             NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            if (!self.additionalPrecision) {
+            if (!self.additionalPrecision && fraction == 0.0) {
+                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+            } else if (!self.additionalPrecision && fraction == 50.0) {
+                wholeString = [formatter stringFromNumber:@(whole + 0.5)];
                 answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
             } else {
                 answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -430,14 +430,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue
                                                       maximumValue:(nullable NSNumber *)maximumValue
-                                                      minimumValue:(nullable NSNumber *)minimumValue {
+                                                    defaultValue:(nullable NSNumber *)defaultValue {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
                                                    numericPrecision:numericPrecision
-                                                       defaultValue:defaultValue
+                                                       minimumValue:minimumValue
                                                        maximumValue:maximumValue
-                                                       minimumValue:minimumValue];
+                                                       defaultValue:defaultValue];
 }
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
@@ -2773,40 +2773,40 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)init {
     return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
                           numericPrecision:ORKNumericPrecisionDefault
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:ORKNumericPrecisionDefault
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:numericPrecision
-                              defaultValue:nil
+                              minimumValue:nil
                               maximumValue:nil
-                              minimumValue:nil];
+                              defaultValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             defaultValue:(nullable NSNumber *)defaultValue
+                             minimumValue:(nullable NSNumber *)minimumValue
                              maximumValue:(nullable NSNumber *)maximumValue
-                             minimumValue:(nullable NSNumber *)minimumValue {
+                             defaultValue:(nullable NSNumber *)defaultValue {
     self = [super init];
     if (self) {
         _measurementSystem = measurementSystem;
         _numericPrecission = numericPrecision;
-        _defaultValue = defaultValue;
-        _maximumValue = maximumValue;
         _minimumValue = minimumValue;
+        _maximumValue = maximumValue;
+        _defaultValue = defaultValue;
     }
     return self;
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -76,6 +76,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType) {
             SQT_CASE(Date);
             SQT_CASE(TimeInterval);
             SQT_CASE(Height);
+            SQT_CASE(Weight);
             SQT_CASE(Location);
     }
 #undef SQT_CASE
@@ -411,6 +412,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [[ORKHeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem];
+}
+
++ (ORKWeightAnswerFormat *)weightAnswerFormat {
+    return [[ORKWeightAnswerFormat alloc] init];
+}
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
+    return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem];
 }
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
@@ -2716,6 +2725,101 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             NSString *inchesString = [formatter stringFromNumber:@(inches)];
             answerString = [NSString stringWithFormat:@"%@ %@, %@ %@",
                             feetString, ORKLocalizedString(@"MEASURING_UNIT_FT", nil), inchesString, ORKLocalizedString(@"MEASURING_UNIT_IN", nil)];
+        }
+    }
+    return answerString;
+}
+
+@end
+
+
+#pragma mark - ORKWeightAnswerFormat
+
+@implementation ORKWeightAnswerFormat
+
+- (Class)questionResultClass {
+    return [ORKNumericQuestionResult class];
+}
+
+- (NSString *)canonicalUnitString {
+    return @"kg";
+}
+
+- (ORKNumericQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(NSNumber *)answer {
+    ORKNumericQuestionResult *questionResult = (ORKNumericQuestionResult *)[super resultWithIdentifier:identifier answer:answer];
+    // Use canonical unit because we expect results to be consistent regardless of the user locale
+    questionResult.unit = [self canonicalUnitString];
+    return questionResult;
+}
+
+- (instancetype)init {
+    self = [self initWithMeasurementSystem:ORKMeasurementSystemLocal];
+    return self;
+}
+
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
+    self = [super init];
+    if (self) {
+        _measurementSystem = measurementSystem;
+    }
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            (self.measurementSystem == castObject.measurementSystem));
+}
+
+- (NSUInteger)hash {
+    return super.hash ^ _measurementSystem;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK_DECODE_ENUM(aDecoder, measurementSystem);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_ENUM(aCoder, measurementSystem);
+}
+
+- (ORKQuestionType)questionType {
+    return ORKQuestionTypeWeight;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (BOOL)useMetricSystem {
+    return _measurementSystem == ORKMeasurementSystemMetric
+    || (_measurementSystem == ORKMeasurementSystemLocal && ((NSNumber *)[[NSLocale currentLocale] objectForKey:NSLocaleUsesMetricSystem]).boolValue);
+}
+
+- (NSString *)stringForAnswer:(id)answer {
+    NSString *answerString = nil;
+    
+    if (!ORKIsAnswerEmpty(answer)) {
+        NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
+        if (self.useMetricSystem) {
+            double whole, fraction;
+            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
+            NSString *wholeString = [formatter stringFromNumber:@(whole)];
+            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
+            answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+        } else {
+            double whole, fraction;
+            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
+            NSString *wholeString = [formatter stringFromNumber:@(whole)];
+            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
+            answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), fractionString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
         }
     }
     return answerString;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2848,12 +2848,14 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             }
         } else {
             double pounds, ounces;
-            ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
-            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-            NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
             if (!self.additionalPrecision) {
+                ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
+                NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
             } else {
+                ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
+                NSString *poundsString = [formatter stringFromNumber:@(pounds)];
+                NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
                 answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
             }
         }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -407,7 +407,7 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 }
 
 + (ORKHeightAnswerFormat *)heightAnswerFormat {
-    return [[ORKHeightAnswerFormat alloc] init];
+    return [ORKHeightAnswerFormat new];
 }
 
 + (ORKHeightAnswerFormat *)heightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
@@ -415,25 +415,29 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 }
 
 + (ORKWeightAnswerFormat *)weightAnswerFormat {
-    return [[ORKWeightAnswerFormat alloc] init];
+    return [ORKWeightAnswerFormat new];
 }
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem];
 }
 
-+ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
-                                                 minimumValue:(nullable NSNumber *)minimumValue
-                                                 maximumValue:(nullable NSNumber *)maximumValue
-                                                valueInterval:(nullable NSNumber *)valueInterval
-                                          additionalPrecision:(BOOL)additionalPrecision
-                                            measurementSystem:(ORKMeasurementSystem)measurementSystem {
-    return [[ORKWeightAnswerFormat alloc] initWithDefaultValue:defaultValue
-                                                  minimumValue:minimumValue
-                                                  maximumValue:maximumValue
-                                                 valueInterval:valueInterval
-                                           additionalPrecision:additionalPrecision
-                                             measurementSystem:measurementSystem];
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision {
+    return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
+                                                   numericPrecision:numericPrecision];
+}
+
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                                                  numericPrecision:(ORKNumericPrecision)numericPrecision
+                                                      defaultValue:(nullable NSNumber *)defaultValue
+                                                      maximumValue:(nullable NSNumber *)maximumValue
+                                                      minimumValue:(nullable NSNumber *)minimumValue {
+    return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
+                                                   numericPrecision:numericPrecision
+                                                       defaultValue:defaultValue
+                                                       maximumValue:maximumValue
+                                                       minimumValue:minimumValue];
 }
 
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
@@ -2767,33 +2771,42 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 }
 
 - (instancetype)init {
-    self = [self initWithMeasurementSystem:ORKMeasurementSystemLocal];
-    return self;
+    return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
+                          numericPrecision:ORKNumericPrecisionDefault
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
-    self = [super init];
-    if (self) {
-        _additionalPrecision = NO;
-        _measurementSystem = measurementSystem;
-    }
-    return self;
+    return [self initWithMeasurementSystem:measurementSystem
+                          numericPrecision:ORKNumericPrecisionDefault
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
 }
 
-- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
-                        minimumValue:(nullable NSNumber *)minimumValue
-                        maximumValue:(nullable NSNumber *)maximumValue
-                       valueInterval:(nullable NSNumber *)valueInterval
-                 additionalPrecision:(BOOL)additionalPrecision
-                   measurementSystem:(ORKMeasurementSystem)measurementSystem {
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision {
+    return [self initWithMeasurementSystem:measurementSystem
+                          numericPrecision:numericPrecision
+                              defaultValue:nil
+                              maximumValue:nil
+                              minimumValue:nil];
+}
+
+- (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
+                         numericPrecision:(ORKNumericPrecision)numericPrecision
+                             defaultValue:(nullable NSNumber *)defaultValue
+                             maximumValue:(nullable NSNumber *)maximumValue
+                             minimumValue:(nullable NSNumber *)minimumValue {
     self = [super init];
     if (self) {
-        _defaultValue = defaultValue;
-        _minimumValue = minimumValue;
-        _maximumValue = maximumValue;
-        _valueInterval = valueInterval;
-        _additionalPrecision = additionalPrecision;
         _measurementSystem = measurementSystem;
+        _numericPrecission = numericPrecision;
+        _defaultValue = defaultValue;
+        _maximumValue = maximumValue;
+        _minimumValue = minimumValue;
     }
     return self;
 }
@@ -2844,7 +2857,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
             double pounds, ounces;
-            if (!self.additionalPrecision) {
+            if (self.numericPrecission != ORKNumericPrecisionHigh) {
                 ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -430,9 +430,9 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 + (ORKWeightAnswerFormat *)weightAnswerFormatWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                                                   numericPrecision:(ORKNumericPrecision)numericPrecision
-                                                      minimumValue:(nullable NSNumber *)minimumValue
-                                                      maximumValue:(nullable NSNumber *)maximumValue
-                                                    defaultValue:(nullable NSNumber *)defaultValue {
+                                                      minimumValue:(double)minimumValue
+                                                      maximumValue:(double)maximumValue
+                                                    defaultValue:(double)defaultValue {
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem
                                                    numericPrecision:numericPrecision
                                                        minimumValue:minimumValue
@@ -2773,33 +2773,39 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)init {
     return [self initWithMeasurementSystem:ORKMeasurementSystemLocal
                           numericPrecision:ORKNumericPrecisionDefault
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:ORKNumericPrecisionDefault
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision {
     return [self initWithMeasurementSystem:measurementSystem
                           numericPrecision:numericPrecision
-                              minimumValue:nil
-                              maximumValue:nil
-                              defaultValue:nil];
+                              minimumValue:ORKDoubleDefaultValue
+                              maximumValue:ORKDoubleDefaultValue
+                              defaultValue:ORKDoubleDefaultValue];
 }
 
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem
                          numericPrecision:(ORKNumericPrecision)numericPrecision
-                             minimumValue:(nullable NSNumber *)minimumValue
-                             maximumValue:(nullable NSNumber *)maximumValue
-                             defaultValue:(nullable NSNumber *)defaultValue {
+                             minimumValue:(double)minimumValue
+                             maximumValue:(double)maximumValue
+                             defaultValue:(double)defaultValue {
+    if ((defaultValue != ORKDoubleDefaultValue) && ((defaultValue < minimumValue) || (defaultValue > maximumValue))) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"defaultValue must be between minimumValue and maximumValue."
+                                     userInfo:nil];
+    }
+
     self = [super init];
     if (self) {
         _measurementSystem = measurementSystem;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2841,18 +2841,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     if (!ORKIsAnswerEmpty(answer)) {
         NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
         if (self.useMetricSystem) {
-            double whole, fraction;
-            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
-            NSString *wholeString = [formatter stringFromNumber:@(whole)];
-            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            if (!self.additionalPrecision && fraction == 0.0) {
-                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            } else if (!self.additionalPrecision && fraction == 50.0) {
-                wholeString = [formatter stringFromNumber:@(whole + 0.5)];
-                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            } else {
-                answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-            }
+            answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
             double pounds, ounces;
             if (!self.additionalPrecision) {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2862,12 +2862,12 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         if (self.useMetricSystem) {
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
-            double pounds, ounces;
             if (self.numericPrecission != ORKNumericPrecisionHigh) {
-                ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
+                double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
             } else {
+                double pounds, ounces;
                 ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 NSString *ouncesString = [formatter stringFromNumber:@(ounces)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2809,7 +2809,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     self = [super init];
     if (self) {
         _measurementSystem = measurementSystem;
-        _numericPrecission = numericPrecision;
+        _numericPrecision = numericPrecision;
         _minimumValue = minimumValue;
         _maximumValue = maximumValue;
         _defaultValue = defaultValue;
@@ -2823,7 +2823,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     __typeof(self) castObject = object;
     return (isParentSame &&
             (self.measurementSystem == castObject.measurementSystem) &&
-            (self.numericPrecission == castObject.numericPrecission) &&
+            (self.numericPrecision == castObject.numericPrecision) &&
             (self.minimumValue == castObject.minimumValue) &&
             (self.maximumValue == castObject.maximumValue) &&
             (self.defaultValue == castObject.defaultValue));
@@ -2831,14 +2831,14 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 
 - (NSUInteger)hash {
     // Ignore minimumValue, maximumValue and defaultValue as they're unimportant
-    return super.hash ^ _measurementSystem ^ _numericPrecission;
+    return super.hash ^ _measurementSystem ^ _numericPrecision;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_ENUM(aDecoder, measurementSystem);
-        ORK_DECODE_ENUM(aDecoder, numericPrecission);
+        ORK_DECODE_ENUM(aDecoder, numericPrecision);
         ORK_DECODE_DOUBLE(aDecoder, minimumValue);
         ORK_DECODE_DOUBLE(aDecoder, maximumValue);
         ORK_DECODE_DOUBLE(aDecoder, defaultValue);
@@ -2849,7 +2849,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_ENUM(aCoder, measurementSystem);
-    ORK_ENCODE_ENUM(aCoder, numericPrecission);
+    ORK_ENCODE_ENUM(aCoder, numericPrecision);
     ORK_ENCODE_DOUBLE(aCoder, minimumValue);
     ORK_ENCODE_DOUBLE(aCoder, maximumValue);
     ORK_ENCODE_DOUBLE(aCoder, defaultValue);
@@ -2875,7 +2875,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         if (self.useMetricSystem) {
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
-            if (self.numericPrecission != ORKNumericPrecisionHigh) {
+            if (self.numericPrecision != ORKNumericPrecisionHigh) {
                 double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LB", nil)];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2878,13 +2878,13 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             if (self.numericPrecission != ORKNumericPrecisionHigh) {
                 double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-                answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+                answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LB", nil)];
             } else {
                 double pounds, ounces;
                 ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
                 NSString *poundsString = [formatter stringFromNumber:@(pounds)];
                 NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
-                answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+                answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LB", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
             }
         }
     }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -422,6 +422,18 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
     return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:measurementSystem];
 }
 
++ (ORKWeightAnswerFormat *)weightAnswerFormatWithDefaultValue:(nullable NSNumber *)defaultValue
+                                                 minimumValue:(nullable NSNumber *)minimumValue
+                                                 maximumValue:(nullable NSNumber *)maximumValue
+                                          additionalPrecision:(BOOL)additionalPrecision
+                                            measurementSystem:(ORKMeasurementSystem)measurementSystem {
+    return [[ORKWeightAnswerFormat alloc] initWithDefaultValue:defaultValue
+                                                  minimumValue:minimumValue
+                                                  maximumValue:maximumValue
+                                           additionalPrecision:additionalPrecision
+                                             measurementSystem:measurementSystem];
+}
+
 + (ORKLocationAnswerFormat *)locationAnswerFormat {
     return [ORKLocationAnswerFormat new];
 }
@@ -2760,6 +2772,23 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (instancetype)initWithMeasurementSystem:(ORKMeasurementSystem)measurementSystem {
     self = [super init];
     if (self) {
+        _additionalPrecision = NO;
+        _measurementSystem = measurementSystem;
+    }
+    return self;
+}
+
+- (instancetype)initWithDefaultValue:(nullable NSNumber *)defaultValue
+                        minimumValue:(nullable NSNumber *)minimumValue
+                        maximumValue:(nullable NSNumber *)maximumValue
+                 additionalPrecision:(BOOL)additionalPrecision
+                   measurementSystem:(ORKMeasurementSystem)measurementSystem {
+    self = [super init];
+    if (self) {
+        _defaultValue = defaultValue;
+        _minimumValue = minimumValue;
+        _maximumValue = maximumValue;
+        _additionalPrecision = additionalPrecision;
         _measurementSystem = measurementSystem;
     }
     return self;
@@ -2799,8 +2828,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 }
 
 - (BOOL)useMetricSystem {
-    return _measurementSystem == ORKMeasurementSystemMetric
-    || (_measurementSystem == ORKMeasurementSystemLocal && ((NSNumber *)[[NSLocale currentLocale] objectForKey:NSLocaleUsesMetricSystem]).boolValue);
+    return _measurementSystem == ORKMeasurementSystemMetric || (_measurementSystem == ORKMeasurementSystemLocal && ((NSNumber *)[[NSLocale currentLocale] objectForKey:NSLocaleUsesMetricSystem]).boolValue);
 }
 
 - (NSString *)stringForAnswer:(id)answer {
@@ -2813,13 +2841,21 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
             NSString *wholeString = [formatter stringFromNumber:@(whole)];
             NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+            if (!self.additionalPrecision) {
+                answerString = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+            } else {
+                answerString = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+            }
         } else {
-            double whole, fraction;
-            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
-            NSString *wholeString = [formatter stringFromNumber:@(whole)];
-            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), fractionString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+            double pounds, ounces;
+            ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &pounds, &ounces);
+            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
+            NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
+            if (!self.additionalPrecision) {
+                answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+            } else {
+                answerString = [NSString stringWithFormat:@"%@ %@, %@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+            }
         }
     }
     return answerString;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2822,17 +2822,26 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            (self.measurementSystem == castObject.measurementSystem));
+            (self.measurementSystem == castObject.measurementSystem) &&
+            (self.numericPrecission == castObject.numericPrecission) &&
+            (self.minimumValue == castObject.minimumValue) &&
+            (self.maximumValue == castObject.maximumValue) &&
+            (self.defaultValue == castObject.defaultValue));
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ _measurementSystem;
+    // Ignore minimumValue, maximumValue and defaultValue as they're unimportant
+    return super.hash ^ _measurementSystem ^ _numericPrecission;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_ENUM(aDecoder, measurementSystem);
+        ORK_DECODE_ENUM(aDecoder, numericPrecission);
+        ORK_DECODE_DOUBLE(aDecoder, minimumValue);
+        ORK_DECODE_DOUBLE(aDecoder, maximumValue);
+        ORK_DECODE_DOUBLE(aDecoder, defaultValue);
     }
     return self;
 }
@@ -2840,6 +2849,10 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_ENUM(aCoder, measurementSystem);
+    ORK_ENCODE_ENUM(aCoder, numericPrecission);
+    ORK_ENCODE_DOUBLE(aCoder, minimumValue);
+    ORK_ENCODE_DOUBLE(aCoder, maximumValue);
+    ORK_ENCODE_DOUBLE(aCoder, defaultValue);
 }
 
 - (ORKQuestionType)questionType {

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -65,6 +65,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTextScaleAnswerFormat)
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTextAnswerFormat)
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKHeightAnswerFormat)
+ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKWeightAnswerFormat)
 
 
 @class ORKQuestionResult;
@@ -222,6 +223,13 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKHeightAnswerFormat)
 
 
 @interface ORKHeightAnswerFormat ()
+
+@property (nonatomic, readonly) BOOL useMetricSystem;
+
+@end
+
+
+@interface ORKWeightAnswerFormat ()
 
 @property (nonatomic, readonly) BOOL useMetricSystem;
 

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -1073,8 +1073,9 @@ static const CGFloat HorizontalMargin = 15.0;
           [answerFormat isKindOfClass:[ORKTimeIntervalAnswerFormat class]] ||
           [answerFormat isKindOfClass:[ORKValuePickerAnswerFormat class]] ||
           [answerFormat isKindOfClass:[ORKMultipleValuePickerAnswerFormat class]] ||
-          [answerFormat isKindOfClass:[ORKHeightAnswerFormat class]])) {
-        @throw [NSException exceptionWithName:NSGenericException reason:@"formItem.answerFormat should be an ORKDateAnswerFormat, ORKTimeOfDayAnswerFormat, ORKTimeIntervalAnswerFormat, ORKValuePicker, ORKMultipleValuePickerAnswerFormat, or ORKHeightAnswerFormat instance" userInfo:nil];
+          [answerFormat isKindOfClass:[ORKHeightAnswerFormat class]] ||
+          [answerFormat isKindOfClass:[ORKWeightAnswerFormat class]])) {
+        @throw [NSException exceptionWithName:NSGenericException reason:@"formItem.answerFormat should be an ORKDateAnswerFormat, ORKTimeOfDayAnswerFormat, ORKTimeIntervalAnswerFormat, ORKValuePicker, ORKMultipleValuePickerAnswerFormat, ORKHeightAnswerFormat, or ORKWeightAnswerFormat instance" userInfo:nil];
     }
     [super setFormItem:formItem];
 }

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -804,7 +804,8 @@
                 case ORKQuestionTypeTimeOfDay:
                 case ORKQuestionTypeTimeInterval:
                 case ORKQuestionTypeMultiplePicker:
-                case ORKQuestionTypeHeight: {
+                case ORKQuestionTypeHeight:
+                case ORKQuestionTypeWeight: {
                     class = [ORKFormItemPickerCell class];
                     break;
                 }

--- a/ResearchKit/Common/ORKHealthAnswerFormat.m
+++ b/ResearchKit/Common/ORKHealthAnswerFormat.m
@@ -328,15 +328,20 @@ NSString *ORKHKBloodTypeString(HKBloodType bloodType) {
     
     if (_quantityType) {
         if ([_quantityType.identifier isEqualToString:HKQuantityTypeIdentifierHeight]) {
-            ORKHeightAnswerFormat *format = [ORKDateAnswerFormat heightAnswerFormat];
+            ORKHeightAnswerFormat *format = [ORKHeightAnswerFormat heightAnswerFormat];
             _impliedAnswerFormat = format;
+            _unit = [HKUnit meterUnitWithMetricPrefix:(HKMetricPrefixCenti)];
+        } else if ([_quantityType.identifier isEqualToString:HKQuantityTypeIdentifierBodyMass]) {
+            ORKWeightAnswerFormat *format = [ORKWeightAnswerFormat weightAnswerFormat];
+            _impliedAnswerFormat = format;
+            _unit = [HKUnit gramUnitWithMetricPrefix:(HKMetricPrefixKilo)];
         } else {
-        ORKNumericAnswerFormat *format = nil;
+            ORKNumericAnswerFormat *format = nil;
             HKUnit *unit = [self healthKitUserUnit];
-        if (_numericAnswerStyle == ORKNumericAnswerStyleDecimal) {
-            format = [ORKNumericAnswerFormat decimalAnswerFormatWithUnit:[unit localizedUnitString]];
-        } else {
-            format = [ORKNumericAnswerFormat integerAnswerFormatWithUnit:[unit localizedUnitString]];
+            if (_numericAnswerStyle == ORKNumericAnswerStyleDecimal) {
+                format = [ORKNumericAnswerFormat decimalAnswerFormatWithUnit:[unit localizedUnitString]];
+            } else {
+                format = [ORKNumericAnswerFormat integerAnswerFormatWithUnit:[unit localizedUnitString]];
             }
             _impliedAnswerFormat = format;
         }

--- a/ResearchKit/Common/ORKHeightPicker.m
+++ b/ResearchKit/Common/ORKHeightPicker.m
@@ -134,24 +134,7 @@
 }
 
 - (NSString *)selectedLabelText {
-    if (_answer == nil || _answer == ORKNullAnswerValue()) {
-        return nil;
-    }
-
-    NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
-    NSString *selectedLabelText = nil;
-    if (_answerFormat.useMetricSystem) {
-        selectedLabelText = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:_answer], ORKLocalizedString(@"MEASURING_UNIT_CM", nil)];
-    } else {
-        double feet, inches;
-        ORKCentimetersToFeetAndInches(((NSNumber *)_answer).doubleValue, &feet, &inches);
-        NSString *feetString = [formatter stringFromNumber:@(feet)];
-        NSString *inchesString = [formatter stringFromNumber:@(inches)];
-
-        selectedLabelText = [NSString stringWithFormat:@"%@ %@, %@ %@",
-         feetString, ORKLocalizedString(@"MEASURING_UNIT_FT", nil), inchesString, ORKLocalizedString(@"MEASURING_UNIT_IN", nil)];
-    }
-    return selectedLabelText;
+    return [_answerFormat stringForAnswer:_answer];
 }
 
 - (void)pickerWillAppear {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -300,6 +300,33 @@ ORK_INLINE double ORKFeetAndInchesToCentimeters(double feet, double inches) {
     return ORKInchesToCentimeters(ORKFeetAndInchesToInches(feet, inches));
 }
 
+ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWhole, double *outFraction) {
+    if (outWhole == NULL || outFraction == NULL) {
+        return;
+    }
+    *outWhole = floor(kilograms);
+    *outFraction = floor((kilograms - floor(kilograms)) * 100);
+}
+
+ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outWhole, double *outFraction) {
+    if (outWhole == NULL || outFraction == NULL) {
+        return;
+    }
+    double lbs = kilograms * 2.2046;
+    *outWhole = floor(lbs);
+    *outFraction = floor((lbs - floor(lbs)) * 100);
+}
+
+ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
+    double kg = (whole + (fraction / 100));
+    return (floor(100*kg)/100);
+}
+
+ORK_INLINE double ORKPoundsAndOuncesToKilograms(double whole, double fraction) {
+    double kg = (whole + (fraction * 0.0625)) * 0.4536;
+    return (floor(100*kg)/100);
+}
+
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {
     UIColor *color = baseColor;
     if (totalColors > 1) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -308,42 +308,43 @@ ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWho
     *outFraction = round((kilograms - floor(kilograms)) * 100);
 }
 
-ORK_INLINE void ORKKilogramsToPounds(double kilograms, double *outPounds) {
-    if (outPounds == NULL) {
-        return;
+ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double * _Nullable outPounds, double * _Nullable outOunces) {
+    const double ORKPoundsPerKilogram = 2.20462262;
+    double fractionalPounds = kilograms * ORKPoundsPerKilogram;
+    double pounds = floor(fractionalPounds);
+    double ounces = round((fractionalPounds - pounds) * 16);
+    if (ounces == 16) {
+        pounds += 1;
+        ounces = 0;
     }
-    double lbs = kilograms * 2.2046;
-    *outPounds = round(lbs);
+    if (outPounds != NULL) {
+        *outPounds = pounds;
+    }
+    if (outOunces != NULL) {
+        *outOunces = ounces;
+    }
 }
 
-ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outPounds, double *outOunces) {
-    if (outPounds == NULL || outOunces == NULL) {
-        return;
-    }
-    double lbs = kilograms * 2.2046;
-    *outPounds = floor(lbs);
-    double oz = (lbs - floor(lbs)) * 16;
-    *outOunces = round(oz);
-    
-    if (round(oz) == 16) {
-        *outPounds += 1;
-        *outOunces = 0;
-    }
+ORK_INLINE double ORKKilogramsToPounds(double kilograms) {
+    double pounds;
+    ORKKilogramsToPoundsAndOunces(kilograms, &pounds, NULL);
+    return pounds;
 }
 
 ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
     double kg = (whole + (fraction / 100));
-    return (round(100*kg)/100);
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE double ORKPoundsToKilograms(double pounds) {
-    double kg = pounds * 0.4536;
-    return (round(100*kg)/100);
+    const double ORKKilogramsPerPound = 0.45359237;
+    double kg = pounds * ORKKilogramsPerPound;
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
     double kg = (pounds + (ounces / 16)) * 0.4536;
-    return (round(100*kg)/100);
+    return (round(100 * kg) / 100);
 }
 
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -336,15 +336,14 @@ ORK_INLINE double ORKWholeAndFractionToKilograms(double whole, double fraction) 
     return (round(100 * kg) / 100);
 }
 
-ORK_INLINE double ORKPoundsToKilograms(double pounds) {
+ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
     const double ORKKilogramsPerPound = 0.45359237;
-    double kg = pounds * ORKKilogramsPerPound;
+    double kg = (pounds + (ounces / 16)) * ORKKilogramsPerPound;
     return (round(100 * kg) / 100);
 }
 
-ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
-    double kg = (pounds + (ounces / 16)) * 0.4536;
-    return (round(100 * kg) / 100);
+ORK_INLINE double ORKPoundsToKilograms(double pounds) {
+    return ORKPoundsAndOuncesToKilograms(pounds, 0);
 }
 
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -305,7 +305,15 @@ ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWho
         return;
     }
     *outWhole = floor(kilograms);
-    *outFraction = floor((kilograms - floor(kilograms)) * 100);
+    *outFraction = round((kilograms - floor(kilograms)) * 100);
+}
+
+ORK_INLINE void ORKKilogramsToPounds(double kilograms, double *outPounds) {
+    if (outPounds == NULL) {
+        return;
+    }
+    double lbs = kilograms * 2.2046;
+    *outPounds = round(lbs);
 }
 
 ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outPounds, double *outOunces) {
@@ -315,17 +323,27 @@ ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outPound
     double lbs = kilograms * 2.2046;
     *outPounds = floor(lbs);
     double oz = (lbs - floor(lbs)) * 16;
-    *outOunces = floor(oz);
+    *outOunces = round(oz);
+    
+    if (round(oz) == 16) {
+        *outPounds += 1;
+        *outOunces = 0;
+    }
 }
 
 ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
     double kg = (whole + (fraction / 100));
-    return (floor(100*kg)/100);
+    return (round(100*kg)/100);
+}
+
+ORK_INLINE double ORKPoundsToKilograms(double pounds) {
+    double kg = pounds * 0.4536;
+    return (round(100*kg)/100);
 }
 
 ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
     double kg = (pounds + (ounces / 16)) * 0.4536;
-    return (floor(100*kg)/100);
+    return (round(100*kg)/100);
 }
 
 ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseColor, NSUInteger colorIndex, NSUInteger totalColors) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -308,13 +308,14 @@ ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWho
     *outFraction = floor((kilograms - floor(kilograms)) * 100);
 }
 
-ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outWhole, double *outFraction) {
-    if (outWhole == NULL || outFraction == NULL) {
+ORK_INLINE void ORKKilogramsToPoundsAndOunces(double kilograms, double *outPounds, double *outOunces) {
+    if (outPounds == NULL || outOunces == NULL) {
         return;
     }
     double lbs = kilograms * 2.2046;
-    *outWhole = floor(lbs);
-    *outFraction = floor((lbs - floor(lbs)) * 100);
+    *outPounds = floor(lbs);
+    double oz = (lbs - floor(lbs)) * 16;
+    *outOunces = floor(oz);
 }
 
 ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
@@ -322,8 +323,8 @@ ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction)
     return (floor(100*kg)/100);
 }
 
-ORK_INLINE double ORKPoundsAndOuncesToKilograms(double whole, double fraction) {
-    double kg = (whole + (fraction * 0.0625)) * 0.4536;
+ORK_INLINE double ORKPoundsAndOuncesToKilograms(double pounds, double ounces) {
+    double kg = (pounds + (ounces / 16)) * 0.4536;
     return (floor(100*kg)/100);
 }
 

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -300,7 +300,7 @@ ORK_INLINE double ORKFeetAndInchesToCentimeters(double feet, double inches) {
     return ORKInchesToCentimeters(ORKFeetAndInchesToInches(feet, inches));
 }
 
-ORK_INLINE void ORKKilogramsToWholeAndFractions(double kilograms, double *outWhole, double *outFraction) {
+ORK_INLINE void ORKKilogramsToWholeAndFraction(double kilograms, double *outWhole, double *outFraction) {
     if (outWhole == NULL || outFraction == NULL) {
         return;
     }
@@ -331,7 +331,7 @@ ORK_INLINE double ORKKilogramsToPounds(double kilograms) {
     return pounds;
 }
 
-ORK_INLINE double ORKWholeAndFractionsToKilograms(double whole, double fraction) {
+ORK_INLINE double ORKWholeAndFractionToKilograms(double whole, double fraction) {
     double kg = (whole + (fraction / 100));
     return (round(100 * kg) / 100);
 }

--- a/ResearchKit/Common/ORKPicker.m
+++ b/ResearchKit/Common/ORKPicker.m
@@ -33,6 +33,7 @@
 
 #import "ORKDateTimePicker.h"
 #import "ORKHeightPicker.h"
+#import "ORKWeightPicker.h"
 #import "ORKTimeIntervalPicker.h"
 #import "ORKValuePicker.h"
 #import "ORKMultipleValuePicker.h"
@@ -59,6 +60,8 @@ id<ORKPicker> createORKPicker(ORKAnswerFormat *answerFormat, id answer, id<ORKPi
         picker = [[ORKDateTimePicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     } else if ([answerFormat isKindOfClass:[ORKHeightAnswerFormat class]]) {
         picker = [[ORKHeightPicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
+    } else if ([answerFormat isKindOfClass:[ORKWeightAnswerFormat class]]) {
+        picker = [[ORKWeightPicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     } else if ([answerFormat isKindOfClass:[ORKMultipleValuePickerAnswerFormat class]]) {
         picker = [[ORKMultipleValuePicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     }
@@ -89,6 +92,8 @@ id<ORKPicker> createORKPicker(ORKAnswerFormat *answerFormat, id answer, id<ORKPi
         picker = [[ORKDateTimePicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     } else if ([answerFormat isKindOfClass:[ORKHeightAnswerFormat class]]) {
         picker = [[ORKHeightPicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
+    } else if ([answerFormat isKindOfClass:[ORKWeightAnswerFormat class]]) {
+        picker = [[ORKWeightPicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     } else if ([answerFormat isKindOfClass:[ORKMultipleValuePickerAnswerFormat class]]) {
         picker = [[ORKMultipleValuePicker alloc] initWithAnswerFormat:answerFormat answer:answer pickerDelegate:delegate];
     }

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -572,6 +572,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
                                @(ORKQuestionTypeDateAndTime): [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeTimeInterval): [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeHeight) : [ORKSurveyAnswerCellForPicker class],
+                               @(ORKQuestionTypeWeight) : [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeMultiplePicker) : [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeInteger): [ORKSurveyAnswerCellForNumber class],
                                @(ORKQuestionTypeLocation): [ORKSurveyAnswerCellForLocation class]};

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -114,6 +114,11 @@ typedef NS_ENUM(NSInteger, ORKQuestionType) {
     ORKQuestionTypeHeight,
 
     /**
+     In a weight question, the participant can enter a weight by using a weight picker.
+     */
+    ORKQuestionTypeWeight,
+    
+    /**
      In a location question, the participant can enter a location using a map view.
      */
     ORKQuestionTypeLocation
@@ -262,7 +267,7 @@ typedef NS_ENUM(NSInteger, ORKProgressIndicatorType) {
 /**
  System of measurements.
  
- Used mainly by ORKHeightAnswerFormat.
+ Used mainly by ORKHeightAnswerFormat and ORKWeightAnswerFormat.
  */
 typedef NS_ENUM(NSInteger, ORKMeasurementSystem) {
     /// Measurement system in use by the current locale.

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -298,4 +298,7 @@ typedef NS_ENUM(NSInteger, ORKNumericPrecision) {
 } ORK_ENUM_AVAILABLE;
 
 
+extern const double ORKDoubleDefaultValue ORK_AVAILABLE_DECL;
+
+
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -265,9 +265,9 @@ typedef NS_ENUM(NSInteger, ORKProgressIndicatorType) {
 
 
 /**
- System of measurements.
+ Measurement system.
  
- Used mainly by ORKHeightAnswerFormat and ORKWeightAnswerFormat.
+ Used by ORKHeightAnswerFormat and ORKWeightAnswerFormat.
  */
 typedef NS_ENUM(NSInteger, ORKMeasurementSystem) {
     /// Measurement system in use by the current locale.
@@ -279,5 +279,23 @@ typedef NS_ENUM(NSInteger, ORKMeasurementSystem) {
     /// United States customary system.
     ORKMeasurementSystemUSC,
 } ORK_ENUM_AVAILABLE;
+
+
+/**
+ Numeric precision.
+ 
+ Used by ORKWeightAnswerFormat.
+ */
+typedef NS_ENUM(NSInteger, ORKNumericPrecision) {
+    /// Default numeric precision.
+    ORKNumericPrecisionDefault = 0,
+    
+    /// Low numeric precision.
+    ORKNumericPrecisionLow,
+    
+    /// High numeric preicision.
+    ORKNumericPrecisionHigh,
+} ORK_ENUM_AVAILABLE;
+
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTypes.m
+++ b/ResearchKit/Common/ORKTypes.m
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2017, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKTypes.h"
+
+
+const double ORKDoubleDefaultValue = DBL_MAX;

--- a/ResearchKit/Common/ORKWeightPicker.h
+++ b/ResearchKit/Common/ORKWeightPicker.h
@@ -1,0 +1,42 @@
+/*
+ Copyright (c) 2017, Nino Guba.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+@import UIKit;
+#import <ResearchKit/ORKPicker.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORKWeightPicker : NSObject <ORKPicker>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -269,7 +269,7 @@
         }
     } else {
         if (component == 0) {
-            title = [NSString stringWithFormat:@"%@ %@", _majorValues[row], ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+            title = [NSString stringWithFormat:@"%@ %@", _majorValues[row], ORKLocalizedString(@"MEASURING_UNIT_LB", nil)];
         } else {
             title = [NSString stringWithFormat:@"%@ %@", _minorValues[row], ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
         }

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -123,8 +123,7 @@
         }
     } else {
         if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
-            double pounds;
-            ORKKilogramsToPounds(((NSNumber *)answer).doubleValue, &pounds);
+            double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
             NSUInteger poundsIndex = [_majorValues indexOfObject:@((NSInteger)pounds)];
             if (poundsIndex == NSNotFound) {
                 [self setAnswer:[self defaultAnswerValue]];

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -1,0 +1,290 @@
+/*
+ Copyright (c) 2017, Nino Guba.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKWeightPicker.h"
+#import "ORKResult_Private.h"
+#import "ORKAnswerFormat_Internal.h"
+#import "ORKAccessibilityFunctions.h"
+
+
+@interface ORKWeightPicker () <UIPickerViewDataSource, UIPickerViewDelegate>
+
+@end
+
+
+@implementation ORKWeightPicker {
+    UIPickerView *_pickerView;
+    ORKWeightAnswerFormat *_answerFormat;
+    id _answer;
+    __weak id<ORKPickerDelegate> _pickerDelegate;
+}
+
+@synthesize pickerDelegate = _pickerDelegate;
+
+- (instancetype)initWithAnswerFormat:(ORKWeightAnswerFormat *)answerFormat answer:(id)answer pickerDelegate:(id<ORKPickerDelegate>)delegate {
+    self = [super init];
+    if (self) {
+        NSAssert([answerFormat isKindOfClass:[ORKWeightAnswerFormat class]], @"answerFormat should be ORKWeightAnswerFormat");
+        
+        // Take into account locale changes so unit string can be updated
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(currentLocaleDidChange:)
+                                                     name:NSCurrentLocaleDidChangeNotification object:nil];
+        
+        _answerFormat = answerFormat;
+        _pickerDelegate = delegate;
+        self.answer = answer;
+    }
+    return self;
+}
+
+- (UIView *)pickerView {
+    if (_pickerView == nil) {
+        _pickerView = [[UIPickerView alloc] init];
+        _pickerView.dataSource = self;
+        _pickerView.delegate = self;
+        [self setAnswer:_answer];
+    }
+    return _pickerView;
+}
+
+- (void)setAnswer:(id)answer {
+    _answer = answer;
+    
+    if (ORKIsAnswerEmpty(answer)) {
+        answer = [self defaultAnswerValue];
+    }
+    
+    if (_answerFormat.useMetricSystem) {
+        double whole, fraction;
+        ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
+        NSUInteger wholeIndex = [[self kilogramValues] indexOfObject:@((NSInteger)whole)];
+        NSUInteger fractionIndex = [[self fractionValues] indexOfObject:@((NSInteger)fraction)];
+        if (wholeIndex == NSNotFound || fractionIndex == NSNotFound) {
+            [self setAnswer:[self defaultAnswerValue]];
+            return;
+        }
+        [_pickerView selectRow:wholeIndex inComponent:0 animated:NO];
+        [_pickerView selectRow:fractionIndex inComponent:1 animated:NO];
+        [_pickerView selectRow:0 inComponent:2 animated:NO];
+    } else {
+        double whole, fraction;
+        ORKKilogramsToPoundsAndOunces(((NSNumber *)answer).doubleValue, &whole, &fraction);
+        NSUInteger wholeIndex = [[self poundValues] indexOfObject:@((NSInteger)whole)];
+        NSUInteger fractionIndex = [[self fractionValues] indexOfObject:@((NSInteger)fraction)];
+        if (wholeIndex == NSNotFound || fractionIndex == NSNotFound) {
+            [self setAnswer:[self defaultAnswerValue]];
+            return;
+        }
+        [_pickerView selectRow:wholeIndex inComponent:0 animated:NO];
+        [_pickerView selectRow:fractionIndex inComponent:1 animated:NO];
+    }
+}
+
+- (id)answer {
+    return _answer;
+}
+
+- (NSNumber *)defaultAnswerValue {
+    NSNumber *defaultAnswerValue = nil;
+    defaultAnswerValue = @(54.432); // Default metric weight: 54.432 kg (120 lbs)
+    return defaultAnswerValue;
+}
+
+- (NSNumber *)selectedAnswerValue {
+    NSNumber *answer = nil;
+    if (_answerFormat.useMetricSystem) {
+        NSInteger wholeRow = [_pickerView selectedRowInComponent:0];
+        NSInteger fractionRow = [_pickerView selectedRowInComponent:1];
+        NSNumber *whole = [self kilogramValues][wholeRow];
+        NSNumber *fraction = [self fractionValues][fractionRow];
+        answer = @( ORKWholeAndFractionsToKilograms(whole.doubleValue, fraction.doubleValue) );
+    } else {
+        NSInteger wholeRow = [_pickerView selectedRowInComponent:0];
+        NSInteger fractionRow = [_pickerView selectedRowInComponent:1];
+        NSNumber *whole = [self poundValues][wholeRow];
+        NSNumber *fraction = [self fractionValues][fractionRow];
+        answer = @( ORKPoundsAndOuncesToKilograms(whole.doubleValue, fraction.doubleValue) );
+    }
+    return answer;
+}
+
+- (NSString *)selectedLabelText {
+    if (_answer == nil || _answer == ORKNullAnswerValue()) {
+        return nil;
+    }
+    
+    NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
+    NSString *selectedLabelText = nil;
+    if (_answerFormat.useMetricSystem) {
+        double whole, fraction;
+        ORKKilogramsToWholeAndFractions(((NSNumber *)_answer).doubleValue, &whole, &fraction);
+        NSString *wholeString = [formatter stringFromNumber:@(whole)];
+        formatter.minimumIntegerDigits = 2;
+        formatter.maximumFractionDigits = 0;
+        NSString *fractionString = [formatter stringFromNumber:@(fraction)];
+        selectedLabelText = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+    } else {
+        double whole, fraction;
+        ORKKilogramsToPoundsAndOunces(((NSNumber *)_answer).doubleValue, &whole, &fraction);
+        NSString *wholeString = [formatter stringFromNumber:@(whole)];
+        NSString *fractionString = [formatter stringFromNumber:@(fraction)];
+        selectedLabelText = [NSString stringWithFormat:@"%@ %@, %@ %@",
+                             wholeString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), fractionString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+    }    
+    return selectedLabelText;
+}
+
+- (void)pickerWillAppear {
+    // Report current value, since ORKWeightPicker always has a value
+    [self pickerView];
+    [self valueDidChange:self];
+    [self accessibilityFocusOnPickerElement];
+}
+
+- (void)valueDidChange:(id)sender {
+    _answer = [self selectedAnswerValue];
+    if ([self.pickerDelegate respondsToSelector:@selector(picker:answerDidChangeTo:)]) {
+        [self.pickerDelegate picker:self answerDidChangeTo:_answer];
+    }
+}
+
+#pragma mark - Accessibility
+
+- (void)accessibilityFocusOnPickerElement {
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        ORKAccessibilityPerformBlockAfterDelay(0.75, ^{
+            NSArray *axElements = [self.pickerView accessibilityElements];
+            if ([axElements count] > 0) {
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, [axElements objectAtIndex:0]);
+            }
+        });
+    }
+}
+
+#pragma mark - UIPickerViewDataSource
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView {
+    return _answerFormat.useMetricSystem ? 3 : 2;
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
+    NSInteger numberOfRows = 0;
+    if (component == 0) {
+        if (_answerFormat.useMetricSystem) {
+            numberOfRows = [self kilogramValues].count;
+        } else {
+            numberOfRows = [self poundValues].count;
+        }
+    } else if (component == 1) {
+        numberOfRows = [self fractionValues].count;
+    } else {
+        numberOfRows = 1;
+    }
+    return numberOfRows;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component {
+    NSString *title = nil;
+    if (_answerFormat.useMetricSystem) {
+        if (component == 0) {
+            title = [NSString stringWithFormat:@"%@", [self kilogramValues][row]];
+        } else if (component == 1) {
+            NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
+            formatter.minimumIntegerDigits = 2;
+            formatter.maximumFractionDigits = 0;
+            title = [NSString stringWithFormat:@".%@", [formatter stringFromNumber:[self fractionValues][row]]];
+        } else {
+            title = ORKLocalizedString(@"MEASURING_UNIT_KG", nil);
+        }
+    } else {
+        if (component == 0) {
+            title = [NSString stringWithFormat:@"%@ %@", [self poundValues][row], ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
+        } else {
+            title = [NSString stringWithFormat:@"%@ %@", [self fractionValues][row], ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
+        }
+    }    
+    return title;
+}
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component {
+    [self valueDidChange:self];
+}
+
+- (NSArray *)kilogramValues {
+    static NSArray *wholeValues = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableArray *mutableWholeValues = [[NSMutableArray alloc] init];
+        for (NSInteger i = 0; i <= 150; i++) {
+            [mutableWholeValues addObject:[NSNumber numberWithInteger:i]];
+        }
+        wholeValues = [mutableWholeValues copy];
+    });
+    return wholeValues;
+}
+
+- (NSArray *)poundValues {
+    static NSArray *wholeValues = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableArray *mutableWholeValues = [[NSMutableArray alloc] init];
+        for (NSInteger i = 0; i <= 300; i++) {
+            [mutableWholeValues addObject:[NSNumber numberWithInteger:i]];
+        }
+        wholeValues = [mutableWholeValues copy];
+    });
+    return wholeValues;
+}
+
+- (NSArray *)fractionValues {
+    static NSArray *fractionValues = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableArray *mutableFractionValues = [[NSMutableArray alloc] init];
+        for (NSInteger i = 0; i <= 99; i++) {
+            [mutableFractionValues addObject:[NSNumber numberWithInteger:i]];
+        }
+        fractionValues = [mutableFractionValues copy];
+    });
+    return fractionValues;
+}
+
+- (void)currentLocaleDidChange:(NSNotification *)notification {
+    [_pickerView reloadAllComponents];
+    [self setAnswer:[self defaultAnswerValue]];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+@end

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -107,7 +107,12 @@
             [self setAnswer:[self defaultAnswerValue]];
             return;
         }
-        [_pickerView selectRow:wholeIndex inComponent:0 animated:NO];
+        if (_answerFormat.additionalPrecision || fraction == 0.0) {
+            [_pickerView selectRow:wholeIndex inComponent:0 animated:NO];
+        } else if (!_answerFormat.additionalPrecision && fraction == 50.0) {
+            wholeIndex = [kilogramValues indexOfObject:@((NSInteger)whole + 0.5)];
+            [_pickerView selectRow:wholeIndex inComponent:0 animated:NO];
+        }
         if (_answerFormat.additionalPrecision) {
             [_pickerView selectRow:fractionIndex inComponent:1 animated:NO];
             [_pickerView selectRow:0 inComponent:2 animated:NO];
@@ -201,7 +206,10 @@
         double whole, fraction;
         ORKKilogramsToWholeAndFractions(((NSNumber *)_answer).doubleValue, &whole, &fraction);
         NSString *wholeString = [formatter stringFromNumber:@(whole)];
-        if (!_answerFormat.additionalPrecision) {
+        if (!_answerFormat.additionalPrecision && fraction == 0.0) {
+            selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
+        } else if (!_answerFormat.additionalPrecision && fraction == 50.0) {
+            wholeString = [formatter stringFromNumber:@(whole + 0.5)];
             selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
             formatter.minimumIntegerDigits = 2;
@@ -323,6 +331,11 @@
     
     for (NSInteger i = min; i <= max; i++) {
         [mutableWholeValues addObject:[NSNumber numberWithInteger:i]];
+        if (!_answerFormat.additionalPrecision) {
+            if (!_answerFormat.valueInterval || [_answerFormat.valueInterval integerValue] != 0) {
+                [mutableWholeValues addObject:[NSNumber numberWithDouble:i + 0.5]];
+            }
+        }
     }
     wholeValues = [mutableWholeValues copy];
     return wholeValues;

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -196,42 +196,7 @@
 }
 
 - (NSString *)selectedLabelText {
-    if (_answer == nil || _answer == ORKNullAnswerValue()) {
-        return nil;
-    }
-    
-    NSNumberFormatter *formatter = ORKDecimalNumberFormatter();
-    NSString *selectedLabelText = nil;
-    if (_answerFormat.useMetricSystem) {
-        double whole, fraction;
-        ORKKilogramsToWholeAndFractions(((NSNumber *)_answer).doubleValue, &whole, &fraction);
-        NSString *wholeString = [formatter stringFromNumber:@(whole)];
-        if (!_answerFormat.additionalPrecision && fraction == 0.0) {
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        } else if (!_answerFormat.additionalPrecision && fraction == 50.0) {
-            wholeString = [formatter stringFromNumber:@(whole + 0.5)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", wholeString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        } else {
-            formatter.minimumIntegerDigits = 2;
-            formatter.maximumFractionDigits = 0;
-            NSString *fractionString = [formatter stringFromNumber:@(fraction)];
-            selectedLabelText = [NSString stringWithFormat:@"%@.%@ %@", wholeString, fractionString, ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
-        }
-    } else {
-        double pounds, ounces;
-        if (!_answerFormat.additionalPrecision) {
-            ORKKilogramsToPounds(((NSNumber *)_answer).doubleValue, &pounds);
-            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@", poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil)];
-        } else {
-            ORKKilogramsToPoundsAndOunces(((NSNumber *)_answer).doubleValue, &pounds, &ounces);
-            NSString *poundsString = [formatter stringFromNumber:@(pounds)];
-            NSString *ouncesString = [formatter stringFromNumber:@(ounces)];
-            selectedLabelText = [NSString stringWithFormat:@"%@ %@, %@ %@",
-                                 poundsString, ORKLocalizedString(@"MEASURING_UNIT_LBS", nil), ouncesString, ORKLocalizedString(@"MEASURING_UNIT_OZ", nil)];
-        }
-    }
-    return selectedLabelText;
+    return [_answerFormat stringForAnswer:_answer];
 }
 
 - (void)pickerWillAppear {

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -110,7 +110,7 @@
             [_pickerView selectRow:index inComponent:0 animated:NO];
         } else {
             double whole, fraction;
-            ORKKilogramsToWholeAndFractions(((NSNumber *)answer).doubleValue, &whole, &fraction);
+            ORKKilogramsToWholeAndFraction(((NSNumber *)answer).doubleValue, &whole, &fraction);
             NSUInteger wholeIndex = [_majorValues indexOfObject:@((NSInteger)whole)];
             NSUInteger fractionIndex = [_minorValues indexOfObject:@((NSInteger)fraction)];
             if (wholeIndex == NSNotFound || fractionIndex == NSNotFound) {
@@ -184,7 +184,7 @@
         } else {
             NSInteger fractionRow = [_pickerView selectedRowInComponent:1];
             NSNumber *fraction = _minorValues[fractionRow];
-            answer = @( ORKWholeAndFractionsToKilograms(whole.doubleValue, fraction.doubleValue) );
+            answer = @( ORKWholeAndFractionToKilograms(whole.doubleValue, fraction.doubleValue) );
         }
     } else {
         NSInteger poundsRow = [_pickerView selectedRowInComponent:0];

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -285,11 +285,11 @@
     NSMutableArray *mutableWholeValues = [[NSMutableArray alloc] init];
 
     NSInteger min = 0;
-    if (_answerFormat.minimumValue) {
+    NSInteger max = 657;
+    if (_answerFormat.minimumValue && [_answerFormat.minimumValue integerValue] <= max) {
         min = [_answerFormat.minimumValue integerValue];
     }
-    NSInteger max = 657;
-    if (_answerFormat.maximumValue) {
+    if (_answerFormat.maximumValue && [_answerFormat.maximumValue integerValue] >= min) {
         max = [_answerFormat.maximumValue integerValue];
     }
     
@@ -305,11 +305,11 @@
     NSMutableArray *mutableWholeValues = [[NSMutableArray alloc] init];
 
     NSInteger min = 0;
-    if (_answerFormat.minimumValue) {
+    NSInteger max = 1450;
+    if (_answerFormat.minimumValue && [_answerFormat.minimumValue integerValue] <= max) {
         min = [_answerFormat.minimumValue integerValue];
     }
-    NSInteger max = 1450;
-    if (_answerFormat.maximumValue) {
+    if (_answerFormat.maximumValue && [_answerFormat.maximumValue integerValue] >= min) {
         max = [_answerFormat.maximumValue integerValue];
     }
     

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -76,7 +76,7 @@
             _majorValues = [self poundValues];
         }
         
-        if (_answerFormat.numericPrecission == ORKNumericPrecisionHigh) {
+        if (_answerFormat.numericPrecision == ORKNumericPrecisionHigh) {
             _minorValues = [self _minorValues];
         }
     }
@@ -101,7 +101,7 @@
     }
     
     if (_answerFormat.useMetricSystem) {
-        if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
+        if (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) {
             NSUInteger index = [_majorValues indexOfObject:@((NSInteger)((NSNumber *)answer).doubleValue)];
             if (index == NSNotFound) {
                 [self setAnswer:[self defaultAnswerValue]];
@@ -122,7 +122,7 @@
             [_pickerView selectRow:0 inComponent:2 animated:NO];
         }
     } else {
-        if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
+        if (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) {
             double pounds = ORKKilogramsToPounds(((NSNumber *)answer).doubleValue);
             NSUInteger poundsIndex = [_majorValues indexOfObject:@((NSInteger)pounds)];
             if (poundsIndex == NSNotFound) {
@@ -179,7 +179,7 @@
     if (_answerFormat.useMetricSystem) {
         NSInteger wholeRow = [_pickerView selectedRowInComponent:0];
         NSNumber *whole = _majorValues[wholeRow];
-        if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
+        if (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) {
             answer = @( whole.doubleValue );
         } else {
             NSInteger fractionRow = [_pickerView selectedRowInComponent:1];
@@ -189,7 +189,7 @@
     } else {
         NSInteger poundsRow = [_pickerView selectedRowInComponent:0];
         NSNumber *pounds = _majorValues[poundsRow];
-        if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
+        if (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) {
             answer = @( ORKPoundsToKilograms(pounds.doubleValue) );
         } else {
             NSInteger ouncesRow = [_pickerView selectedRowInComponent:1];
@@ -235,7 +235,7 @@
 #pragma mark - UIPickerViewDataSource
 
 - (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView {
-    return (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) ? 1 : (_answerFormat.useMetricSystem ? 3 : 2);
+    return (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) ? 1 : (_answerFormat.useMetricSystem ? 3 : 2);
 }
 
 - (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
@@ -254,7 +254,7 @@
     NSString *title = nil;
     if (_answerFormat.useMetricSystem) {
         if (component == 0) {
-            if (_answerFormat.numericPrecission != ORKNumericPrecisionHigh) {
+            if (_answerFormat.numericPrecision != ORKNumericPrecisionHigh) {
                 title = [NSString stringWithFormat:@"%@ %@", _majorValues[row], ORKLocalizedString(@"MEASURING_UNIT_KG", nil)];
             } else {
                 title = [NSString stringWithFormat:@"%@", _majorValues[row]];
@@ -298,7 +298,7 @@
     
     for (double i = minimumValue; i <= maximumValue; i++) {
         [mutableWholeValues addObject:@(i)];
-        if (_answerFormat.numericPrecission == ORKNumericPrecisionDefault) {
+        if (_answerFormat.numericPrecision == ORKNumericPrecisionDefault) {
             [mutableWholeValues addObject:@(i + 0.5)];
         }
     }

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -180,6 +180,9 @@
 "MEASURING_UNIT_CM" = "cm";
 "MEASURING_UNIT_FT" = "ft";
 "MEASURING_UNIT_IN" = "in";
+"MEASURING_UNIT_KG" = "kg";
+"MEASURING_UNIT_LBS" = "lbs";
+"MEASURING_UNIT_OZ" = "oz";
 
 /* Limb values. */
 "LIMB_LEFT" = "left";

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -181,7 +181,7 @@
 "MEASURING_UNIT_FT" = "ft";
 "MEASURING_UNIT_IN" = "in";
 "MEASURING_UNIT_KG" = "kg";
-"MEASURING_UNIT_LBS" = "lbs";
+"MEASURING_UNIT_LB" = "lb";
 "MEASURING_UNIT_OZ" = "oz";
 
 /* Limb values. */

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1921,7 +1921,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_003" text:@"Weight"
                                                            answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC]];
-            item.placeholder = @"Pick a weight (imperial system)";
+            item.placeholder = @"Pick a weight (USC system)";
             [items addObject:item];
         }
 
@@ -1932,7 +1932,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (metric system, low precision)";
             [items addObject:item];
         }
 
@@ -1943,7 +1943,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (USC system, low precision)";
             [items addObject:item];
         }
 
@@ -1954,7 +1954,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (metric system, high precision)";
             [items addObject:item];
         }
         
@@ -1965,7 +1965,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                                                                                     minimumValue:10
                                                                                                                     maximumValue:20
                                                                                                                     defaultValue:11.5]];
-            item.placeholder = @"Pick a weight (metric system)";
+            item.placeholder = @"Pick a weight (USC system, high precision)";
             [items addObject:item];
         }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1905,6 +1905,27 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         }
 
         {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_001" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormat]];
+            item.placeholder = @"Pick a weight (local system)";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_002" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemMetric]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_003" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC]];
+            item.placeholder = @"Pick a weight (imperial system)";
+            [items addObject:item];
+        }
+        
+        {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_date_001" text:@"Birthdate"
                                                          answerFormat:[ORKAnswerFormat dateAnswerFormat]];
             item.placeholder = @"Pick a date";
@@ -3798,10 +3819,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     ORKQuestionStep *step13 = [ORKQuestionStep questionStepWithIdentifier:@"step13" title:@"How many hours did you sleep last night?" answer:[ORKAnswerFormat timeIntervalAnswerFormat]];
     // ORKHeightAnswerFormat
     ORKQuestionStep *step14 = [ORKQuestionStep questionStepWithIdentifier:@"step14" title:@"What is your height?" answer:[ORKAnswerFormat heightAnswerFormat]];
+    // ORKWeightAnswerFormat
+    ORKQuestionStep *step15 = [ORKQuestionStep questionStepWithIdentifier:@"step15" title:@"What is your weight?" answer:[ORKAnswerFormat weightAnswerFormat]];
     // ORKLocationAnswerFormat
-    ORKQuestionStep *step15 = [ORKQuestionStep questionStepWithIdentifier:@"step15" title:@"Where do you live?" answer:[ORKAnswerFormat locationAnswerFormat]];
+    ORKQuestionStep *step16 = [ORKQuestionStep questionStepWithIdentifier:@"step16" title:@"Where do you live?" answer:[ORKAnswerFormat locationAnswerFormat]];
 
-    return @[instructionStep, step1, step2, step3, step4, step5, step6, formStep, reviewStep, step7, step8, step9, step10, step11, step12, step13, step14, step15];
+    return @[instructionStep, step1, step2, step3, step4, step5, step6, formStep, reviewStep, step7, step8, step9, step10, step11, step12, step13, step14, step15, step16];
 }
 
 - (id<ORKTask>)makeEmbeddedReviewTask {

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1917,14 +1917,58 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             item.placeholder = @"Pick a weight (metric system)";
             [items addObject:item];
         }
-        
+
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_003" text:@"Weight"
                                                            answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC]];
             item.placeholder = @"Pick a weight (imperial system)";
             [items addObject:item];
         }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_004" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemMetric
+                                                                                                                numericPrecision:ORKNumericPrecisionLow
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_005" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC
+                                                                                                                numericPrecision:ORKNumericPrecisionLow
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_006" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemMetric
+                                                                                                                numericPrecision:ORKNumericPrecisionHigh
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
         
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_weight_007" text:@"Weight"
+                                                           answerFormat:[ORKAnswerFormat weightAnswerFormatWithMeasurementSystem:ORKMeasurementSystemUSC
+                                                                                                                numericPrecision:ORKNumericPrecisionHigh
+                                                                                                                    minimumValue:10
+                                                                                                                    maximumValue:20
+                                                                                                                    defaultValue:11.5]];
+            item.placeholder = @"Pick a weight (metric system)";
+            [items addObject:item];
+        }
+
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_date_001" text:@"Birthdate"
                                                          answerFormat:[ORKAnswerFormat dateAnswerFormat]];

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -1155,6 +1155,13 @@ encondingTable =
          (@{
             PROPERTY(measurementSystem, NSNumber, NSObject, NO, nil, nil),
             })),
+   ENTRY(ORKWeightAnswerFormat,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKWeightAnswerFormat alloc] initWithMeasurementSystem:((NSNumber *)GETPROP(dict, measurementSystem)).integerValue];
+         },
+         (@{
+            PROPERTY(measurementSystem, NSNumber, NSObject, NO, nil, nil),
+            })),
   ENTRY(ORKLocationAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKLocationAnswerFormat alloc] init];

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -432,6 +432,7 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKContinuousScaleAnswerFormat.minimumImage",
                                               @"ORKContinuousScaleAnswerFormat.maximumImage",
                                               @"ORKHeightAnswerFormat.useMetricSystem",
+                                              @"ORKWeightAnswerFormat.useMetricSystem",
                                               @"ORKDataResult.data",
                                               @"ORKVerificationStep.verificationViewControllerClass",
                                               @"ORKLoginStep.loginViewControllerClass",
@@ -847,6 +848,7 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                        
                                        // For a specific class
                                        @"ORKHeightAnswerFormat.useMetricSystem",
+                                       @"ORKWeightAnswerFormat.useMetricSystem",
                                        @"ORKNavigablePageStep.steps",
                                        @"ORKPageStep.steps",
                                        @"ORKResult.saveable",

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -100,6 +100,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     case twoFingerTappingInterval
     case walkBackAndForth
     case heightQuestion
+    case weightQuestion
     case kneeRangeOfMotion
     case shoulderRangeOfMotion
     case trailMaking
@@ -130,6 +131,7 @@ enum TaskListRow: Int, CustomStringConvertible {
                     .dateQuestion,
                     .dateTimeQuestion,
                     .heightQuestion,
+                    .weightQuestion,
                     .imageChoiceQuestion,
                     .locationQuestion,
                     .numericQuestion,
@@ -204,6 +206,9 @@ enum TaskListRow: Int, CustomStringConvertible {
         case .heightQuestion:
             return NSLocalizedString("Height Question", comment: "")
     
+        case .weightQuestion:
+            return NSLocalizedString("Weight Question", comment: "")
+            
         case .imageChoiceQuestion:
             return NSLocalizedString("Image Choice Question", comment: "")
             
@@ -363,6 +368,12 @@ enum TaskListRow: Int, CustomStringConvertible {
         case heightQuestionStep2
         case heightQuestionStep3
 
+        // Task with an example of weight entry.
+        case weightQuestionTask
+        case weightQuestionStep1
+        case weightQuestionStep2
+        case weightQuestionStep3
+        
         // Task with an image choice question.
         case imageChoiceQuestionTask
         case imageChoiceQuestionStep
@@ -506,6 +517,9 @@ enum TaskListRow: Int, CustomStringConvertible {
 
         case .heightQuestion:
             return heightQuestionTask
+            
+        case .weightQuestion:
+            return weightQuestionTask
             
         case .imageChoiceQuestion:
             return imageChoiceQuestionTask
@@ -757,6 +771,29 @@ enum TaskListRow: Int, CustomStringConvertible {
         return ORKOrderedTask(identifier: String(describing:Identifier.heightQuestionTask), steps: [step1, step2, step3])
     }
 
+    /// This task demonstrates a question asking for the user weight.
+    private var weightQuestionTask: ORKTask {
+        let answerFormat1 = ORKAnswerFormat.weightAnswerFormat()
+        
+        let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight (local system)", answer: answerFormat1)
+        
+        step1.text = exampleDetailText
+        
+        let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
+        
+        let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight (metric system)", answer: answerFormat2)
+        
+        step2.text = exampleDetailText
+        
+        let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
+        
+        let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight (USC system)", answer: answerFormat3)
+        
+        step2.text = exampleDetailText
+        
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3])
+    }
+    
     /**
     This task demonstrates a survey question involving picking from a series of
     image choices. A more realistic applciation of this type of question might be to

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -788,45 +788,45 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight", answer: answerFormat1)
         
-        step1.text = "local system"
+        step1.text = "local system, default precision"
         
         let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = "metric system, default"
+        step2.text = "metric system, default precision"
         
-        let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
+        let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.low, minimumValue: ORKDoubleDefaultValue, maximumValue: ORKDoubleDefaultValue, defaultValue: ORKDoubleDefaultValue)
         
         let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight", answer: answerFormat3)
         
-        step3.text = "USC system"
-        
-        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
+        step3.text = "metric system, low precision"
+
+        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.high, minimumValue: 20.0, maximumValue: 100.0, defaultValue:  45.50)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
-        step4.text = "metric system, additional precision"
-        
-        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
+        step4.text = "metric system, high precision"
+
+        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         
         let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight", answer: answerFormat5)
         
-        step5.text = "USC system, additional precision"
-
-        let answerFormat6 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gramUnit(with: .kilo), style: .decimal)
+        step5.text = "USC system, default precision"
+        
+        let answerFormat6 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC, numericPrecision: ORKNumericPrecision.high, minimumValue: 50.0, maximumValue: 150.0, defaultValue: 100.0)
         
         let step6 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep6), title: "Weight", answer: answerFormat6)
         
-        step6.text = "HealthKit, body mass"
-        
-        let answerFormat7 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: nil, minimumValue: nil, maximumValue: nil, valueInterval: 0.0, additionalPrecision: false, measurementSystem: ORKMeasurementSystem.metric)
+        step6.text = "USC system, high precision"
+
+        let answerFormat7 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gramUnit(with: .kilo), style: .decimal)
         
         let step7 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep7), title: "Weight", answer: answerFormat7)
         
-        step7.text = "metric system, no decimal places"
-                
-        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step7, step3, step4, step5, step6])
+        step7.text = "HealthKit, body mass"
+
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5, step6, step7])
     }
     
     /**

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -377,6 +377,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         case weightQuestionStep4
         case weightQuestionStep5
         case weightQuestionStep6
+        case weightQuestionStep7
         
         // Task with an image choice question.
         case imageChoiceQuestionTask
@@ -793,7 +794,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = "metric system"
+        step2.text = "metric system, default"
         
         let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         
@@ -801,13 +802,13 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step3.text = "USC system"
         
-        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
+        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
         step4.text = "metric system, additional precision"
         
-        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
+        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, valueInterval: nil, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
         
         let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight", answer: answerFormat5)
         
@@ -819,7 +820,13 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step6.text = "HealthKit, body mass"
         
-        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5, step6])
+        let answerFormat7 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: nil, minimumValue: nil, maximumValue: nil, valueInterval: 0.0, additionalPrecision: false, measurementSystem: ORKMeasurementSystem.metric)
+        
+        let step7 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep7), title: "Weight", answer: answerFormat7)
+        
+        step7.text = "metric system, no decimal places"
+                
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step7, step3, step4, step5, step6])
     }
     
     /**

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -759,13 +759,13 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep1), title: "Height", answer: answerFormat1)
         
-        step1.text = "local system"
+        step1.text = "Local system"
 
         let answerFormat2 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep2), title: "Height", answer: answerFormat2)
         
-        step2.text = "metric system"
+        step2.text = "Metric system"
 
         let answerFormat3 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.USC)
         
@@ -788,25 +788,25 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight", answer: answerFormat1)
         
-        step1.text = "local system, default precision"
+        step1.text = "Local system, default precision"
         
         let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
         
         let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = "metric system, default precision"
+        step2.text = "Metric system, default precision"
         
         let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.low, minimumValue: ORKDoubleDefaultValue, maximumValue: ORKDoubleDefaultValue, defaultValue: ORKDoubleDefaultValue)
         
         let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight", answer: answerFormat3)
         
-        step3.text = "metric system, low precision"
+        step3.text = "Metric system, low precision"
 
         let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric, numericPrecision: ORKNumericPrecision.high, minimumValue: 20.0, maximumValue: 100.0, defaultValue:  45.50)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
-        step4.text = "metric system, high precision"
+        step4.text = "Metric system, high precision"
 
         let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -772,7 +772,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step3.text = "USC system"
 
-        let answerFormat4 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.height)!, unit: HKUnit.foot(), style: .decimal)
+        let answerFormat4 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.height)!, unit: HKUnit.meterUnit(with: .centi), style: .decimal)
         
         let step4 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep4), title: "Height", answer: answerFormat4)
         
@@ -813,7 +813,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step5.text = "USC system, additional precision"
 
-        let answerFormat6 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gram(), style: .decimal)
+        let answerFormat6 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gramUnit(with: .kilo), style: .decimal)
         
         let step6 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep6), title: "Weight", answer: answerFormat6)
         

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -373,6 +373,8 @@ enum TaskListRow: Int, CustomStringConvertible {
         case weightQuestionStep1
         case weightQuestionStep2
         case weightQuestionStep3
+        case weightQuestionStep4
+        case weightQuestionStep5
         
         // Task with an image choice question.
         case imageChoiceQuestionTask
@@ -789,9 +791,21 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight (USC system)", answer: answerFormat3)
         
-        step2.text = exampleDetailText
+        step3.text = exampleDetailText
         
-        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3])
+        let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
+        
+        let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight (metric system, additional precision)", answer: answerFormat4)
+        
+        step4.text = exampleDetailText
+        
+        let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
+        
+        let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight (USC system, additional precision)", answer: answerFormat5)
+        
+        step5.text = exampleDetailText
+        
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5])
     }
     
     /**

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -367,6 +367,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         case heightQuestionStep1
         case heightQuestionStep2
         case heightQuestionStep3
+        case heightQuestionStep4
 
         // Task with an example of weight entry.
         case weightQuestionTask
@@ -375,6 +376,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         case weightQuestionStep3
         case weightQuestionStep4
         case weightQuestionStep5
+        case weightQuestionStep6
         
         // Task with an image choice question.
         case imageChoiceQuestionTask
@@ -754,58 +756,70 @@ enum TaskListRow: Int, CustomStringConvertible {
     private var heightQuestionTask: ORKTask {
         let answerFormat1 = ORKAnswerFormat.heightAnswerFormat()
         
-        let step1 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep1), title: "Height (local system)", answer: answerFormat1)
+        let step1 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep1), title: "Height", answer: answerFormat1)
         
-        step1.text = exampleDetailText
+        step1.text = "local system"
 
         let answerFormat2 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.metric)
         
-        let step2 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep2), title: "Height (metric system)", answer: answerFormat2)
+        let step2 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep2), title: "Height", answer: answerFormat2)
         
-        step2.text = exampleDetailText
+        step2.text = "metric system"
 
         let answerFormat3 = ORKAnswerFormat.heightAnswerFormat(with: ORKMeasurementSystem.USC)
         
-        let step3 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep3), title: "Height (USC system)", answer: answerFormat3)
+        let step3 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep3), title: "Height", answer: answerFormat3)
         
-        step2.text = exampleDetailText
+        step3.text = "USC system"
 
-        return ORKOrderedTask(identifier: String(describing:Identifier.heightQuestionTask), steps: [step1, step2, step3])
+        let answerFormat4 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.height)!, unit: HKUnit.foot(), style: .decimal)
+        
+        let step4 = ORKQuestionStep(identifier: String(describing:Identifier.heightQuestionStep4), title: "Height", answer: answerFormat4)
+        
+        step4.text = "HealthKit, height"
+        
+        return ORKOrderedTask(identifier: String(describing:Identifier.heightQuestionTask), steps: [step1, step2, step3, step4])
     }
 
     /// This task demonstrates a question asking for the user weight.
     private var weightQuestionTask: ORKTask {
         let answerFormat1 = ORKAnswerFormat.weightAnswerFormat()
         
-        let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight (local system)", answer: answerFormat1)
+        let step1 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep1), title: "Weight", answer: answerFormat1)
         
-        step1.text = exampleDetailText
+        step1.text = "local system"
         
         let answerFormat2 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.metric)
         
-        let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight (metric system)", answer: answerFormat2)
+        let step2 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep2), title: "Weight", answer: answerFormat2)
         
-        step2.text = exampleDetailText
+        step2.text = "metric system"
         
         let answerFormat3 = ORKAnswerFormat.weightAnswerFormat(with: ORKMeasurementSystem.USC)
         
-        let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight (USC system)", answer: answerFormat3)
+        let step3 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep3), title: "Weight", answer: answerFormat3)
         
-        step3.text = exampleDetailText
+        step3.text = "USC system"
         
         let answerFormat4 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 45.50, minimumValue: 20.0, maximumValue: 100.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.metric)
         
-        let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight (metric system, additional precision)", answer: answerFormat4)
+        let step4 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep4), title: "Weight", answer: answerFormat4)
         
-        step4.text = exampleDetailText
+        step4.text = "metric system, additional precision"
         
         let answerFormat5 = ORKAnswerFormat.weightAnswerFormat(withDefaultValue: 100.0, minimumValue: 50.0, maximumValue: 150.0, additionalPrecision: true, measurementSystem: ORKMeasurementSystem.USC)
         
-        let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight (USC system, additional precision)", answer: answerFormat5)
+        let step5 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep5), title: "Weight", answer: answerFormat5)
         
-        step5.text = exampleDetailText
+        step5.text = "USC system, additional precision"
+
+        let answerFormat6 = ORKHealthKitQuantityTypeAnswerFormat(quantityType: HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!, unit: HKUnit.gram(), style: .decimal)
         
-        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5])
+        let step6 = ORKQuestionStep(identifier: String(describing:Identifier.weightQuestionStep6), title: "Weight", answer: answerFormat6)
+        
+        step6.text = "HealthKit, body mass"
+        
+        return ORKOrderedTask(identifier: String(describing:Identifier.weightQuestionTask), steps: [step1, step2, step3, step4, step5, step6])
     }
     
     /**


### PR DESCRIPTION
Cherrypicking commits from [this ResearchKit PR](
https://github.com/ResearchKit/ResearchKit/pull/1010), this addresses [this CEVResearchKit issue]
(https://github.com/CareEvolution/CEVResearchKit/issues/53) by adding the pieces to implement `ORKWeightAnswerFormat` with the associated pieces (e.g. `ORKWeightPicker`, etc).  This replaces my initial PR which had a few commits that were not necessary for this functionality and pulled additional dependencies causing Xcode warnings.