### PR TITLE
Add support for UITextField textContentType (On Hold until this works in iOS 12)

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -3535,7 +3535,7 @@
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ResearchKitTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3555,7 +3555,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ResearchKitTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1323,14 +1323,14 @@ ORK_CLASS_AVAILABLE
  If specified the system can improve keyboard suggestions to help with filling forms and other
  input. By default, the value of this property is `nil` meaning no specific type.
  */
-@property UITextContentType textContentType;
+@property (nonatomic, copy, nullable) UITextContentType textContentType;
 
 /**
  The password generation rules to use for Automatic Secure Passwords.
  
  If specified, overrides the default passsword generation rules for fields with secureTextEntry.
  */
-@property UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
+@property (nonatomic, copy, nullable) UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
 
 /**
  Identifies whether the text object should hide the text being entered.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1318,6 +1318,21 @@ ORK_CLASS_AVAILABLE
 @property UIKeyboardType keyboardType;
 
 /**
+ The semantic UITextContentType that applies to the user's input.
+ 
+ If specified the system can improve keyboard suggestions to help with filling forms and other
+ input. By default, the value of this property is `nil` meaning no specific type.
+ */
+@property UITextContentType textContentType;
+
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ */
+@property UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
+
+/**
  Identifies whether the text object should hide the text being entered.
  
  By default, the value of this property is NO.
@@ -1335,6 +1350,17 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKEmailAnswerFormat : ORKAnswerFormat
+
+/**
+ Identifies whether this email answer format is being used as a username.
+ 
+ For integration with iOS 12's password management functionality. Use this answer format if your
+ username is also an email address, if it is not and guaranteed to be an email address, use
+ `ORKTextAnswerFormat` and set the `textContentType` to `UITextContentTypeUsername`.
+ 
+ By default, the value of this property is NO.
+ */
+@property (nonatomic,getter=isUsernameField) BOOL usernameField;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2496,7 +2496,12 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
     _usernameField = usernameField;
     if ([self.impliedAnswerFormat isMemberOfClass:[ORKTextAnswerFormat class]]) {
         ORKTextAnswerFormat *textFormat = (ORKTextAnswerFormat *)self.impliedAnswerFormat;
-        textFormat.textContentType = usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
+        
+        if (@available(iOS 11.0, *)) {
+            textFormat.textContentType = usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
+        } else {
+            textFormat.textContentType = UITextContentTypeEmailAddress;
+        }
     }
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2294,6 +2294,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     answerFormat->_keyboardType = _keyboardType;
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
+    answerFormat->_textContentType = _textContentType;
+    
+    if (@available(iOS 12.0, *)) {
+        answerFormat->_passwordRules = _passwordRules;
+    }
+    
     return answerFormat;
 }
 
@@ -2356,6 +2362,11 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
     answerFormat->_autocapitalizationType = _autocapitalizationType;
+    answerFormat->_textContentType = _textContentType;
+    
+    if (@available(iOS 12.0, *)) {
+        answerFormat->_passwordRules = _passwordRules;
+    }
     
     // Always set to no autocorrection or spell checking
     answerFormat->_autocorrectionType = UITextAutocorrectionTypeNo;
@@ -2373,6 +2384,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_INTEGER(aDecoder, maximumLength);
         ORK_DECODE_OBJ_CLASS(aDecoder, validationRegularExpression, NSRegularExpression);
         ORK_DECODE_OBJ_CLASS(aDecoder, invalidMessage, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, textContentType, NSString);
+        if (@available(iOS 12.0, *)) {
+            ORK_DECODE_OBJ_CLASS(aDecoder, passwordRules, UITextInputPasswordRules);
+        }
         ORK_DECODE_ENUM(aDecoder, autocapitalizationType);
         ORK_DECODE_ENUM(aDecoder, autocorrectionType);
         ORK_DECODE_ENUM(aDecoder, spellCheckingType);
@@ -2388,6 +2403,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_INTEGER(aCoder, maximumLength);
     ORK_ENCODE_OBJ(aCoder, validationRegularExpression);
     ORK_ENCODE_OBJ(aCoder, invalidMessage);
+    ORK_ENCODE_OBJ(aCoder, textContentType);
+    if (@available(iOS 12.0, *)) {
+        ORK_ENCODE_OBJ(aCoder, passwordRules);
+    }
     ORK_ENCODE_ENUM(aCoder, autocapitalizationType);
     ORK_ENCODE_ENUM(aCoder, autocorrectionType);
     ORK_ENCODE_ENUM(aCoder, spellCheckingType);
@@ -2402,8 +2421,13 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
+    BOOL equalPasswordRules = YES;
     
     __typeof(self) castObject = object;
+    
+    if (@available(iOS 12.0, *)) {
+        equalPasswordRules = ORKEqualObjects(self.passwordRules, castObject.passwordRules);
+    }
     return (isParentSame &&
             (self.maximumLength == castObject.maximumLength &&
              ORKEqualObjects(self.validationRegularExpression, castObject.validationRegularExpression) &&
@@ -2412,6 +2436,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
              self.autocorrectionType == castObject.autocorrectionType &&
              self.spellCheckingType == castObject.spellCheckingType &&
              self.keyboardType == castObject.keyboardType &&
+             ORKEqualObjects(self.textContentType, castObject.textContentType) &&
+             equalPasswordRules &&
              self.multipleLines == castObject.multipleLines) &&
             self.secureTextEntry == castObject.secureTextEntry);
 }
@@ -2457,12 +2483,21 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _impliedAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         _impliedAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         _impliedAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        _impliedAnswerFormat.textContentType = UITextContentTypeEmailAddress;
     }
     return _impliedAnswerFormat;
 }
 
 - (NSString *)stringForAnswer:(id)answer {
     return [self.impliedAnswerFormat stringForAnswer:answer];
+}
+
+- (void)setUsernameField:(BOOL)usernameField {
+    _usernameField = usernameField;
+    if ([self.impliedAnswerFormat isMemberOfClass:[ORKTextAnswerFormat class]]) {
+        ORKTextAnswerFormat *textFormat = (ORKTextAnswerFormat *)self.impliedAnswerFormat;
+        textFormat.textContentType = usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
+    }
 }
 
 @end

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -592,6 +592,11 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
+    self.textField.textContentType = answerFormat.textContentType;
+    
+    if (@available(iOS 12.0, *)) {
+        self.textField.passwordRules = answerFormat.passwordRules;
+    }
     
     [self answerDidChange];
 }
@@ -812,6 +817,11 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        _textView.textContentType = textAnswerFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            _textView.passwordRules = textAnswerFormat.passwordRules;
+        }
     } else {
         _maxLength = 0;
     }

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -63,6 +63,11 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        self.textView.textContentType = textAnswerFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            self.textView.passwordRules = textAnswerFormat.passwordRules;
+        }
     } else {
         _maxLength = 0;
     }
@@ -268,6 +273,11 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
+        self.textField.textContentType = textFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            self.textField.passwordRules = textFormat.passwordRules;
+        }
     }
     NSString *displayValue = (answer && answer != ORKNullAnswerValue()) ? answer : nil;
     

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -167,19 +167,26 @@ static NSString *const _FamilyNameIdentifier = @"family";
                                                              text:self.step.text];
     formStep.useSurveyMode = NO;
     
-    ORKTextAnswerFormat *nameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
-    nameAnswerFormat.multipleLines = NO;
-    nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-    nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    ORKTextAnswerFormat *givenNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    givenNameAnswerFormat.multipleLines = NO;
+    givenNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    givenNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    givenNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    givenNameAnswerFormat.textContentType = UITextContentTypeGivenName;
     ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                               text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
-                                                      answerFormat:nameAnswerFormat];
+                                                      answerFormat:givenNameAnswerFormat];
     givenNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
+    ORKTextAnswerFormat *familyNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    familyNameAnswerFormat.multipleLines = NO;
+    familyNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    familyNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    familyNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    familyNameAnswerFormat.textContentType = UITextContentTypeFamilyName;
     ORKFormItem *familyNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_FamilyNameIdentifier
                                                              text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
-                                                     answerFormat:nameAnswerFormat];
+                                                     answerFormat:familyNameAnswerFormat];
     familyNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
     givenNameFormItem.optional = NO;

--- a/ResearchKit/Onboarding/ORKLoginStep.m
+++ b/ResearchKit/Onboarding/ORKLoginStep.m
@@ -79,6 +79,7 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -96,6 +97,7 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ResearchKit/Onboarding/ORKLoginStep.m
+++ b/ResearchKit/Onboarding/ORKLoginStep.m
@@ -97,7 +97,9 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
-        answerFormat.textContentType = UITextContentTypePassword;
+        if (@available(iOS 11.0, *)) {
+            answerFormat.textContentType = UITextContentTypePassword;
+        }
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -86,28 +86,6 @@ ORK_CLASS_AVAILABLE
  @param identifier                              The string that identifies the step (see `ORKStep`).
  @param title                                   The title of the form (see `ORKStep`).
  @param text                                    The text shown immediately below the title (see `ORKStep`).
- @param passcodeRules                           A `UITextInputPasswordRules` object used for generating an automatic secure password that conforms to the `passcodeValidationRegularExpression` if the default generated passwords do not match.
- @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
- @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
- @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
- 
- @return An initialized registration step object.
- */
-- (instancetype)initWithIdentifier:(NSString *)identifier
-                             title:(nullable NSString *)title
-                              text:(nullable NSString *)text
-                     passcodeRules:(nullable UITextInputPasswordRules *)passcodeRules
-passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeValidationRegularExpression
-            passcodeInvalidMessage:(nullable NSString *)passcodeInvalidMessage
-                           options:(ORKRegistrationStepOption)options API_AVAILABLE(ios(12.0));
-
-/**
- Returns an initialized registration step using the specified identifier,
- title, text, options, passcodeValidationRegularExpression, and passcodeInvalidMessage.
- 
- @param identifier                              The string that identifies the step (see `ORKStep`).
- @param title                                   The title of the form (see `ORKStep`).
- @param text                                    The text shown immediately below the title (see `ORKStep`).
  @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
  @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
  @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
@@ -163,11 +141,11 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
 
 /**
- The invalid message displayed if the passcode does not match the validation regular expression.
- This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ The password generation rules to use for Automatic Secure Passwords.
  
- The passcode validation regular expression property must also be set along with this property.
- By default, there is no invalid message.
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ The `passcodeRules` should match the `passcodeValidationRegularExpression` or else a passcode
+ may be generated that fails validation.
  */
 @property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules API_AVAILABLE(ios(12.0));
 

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+@import UIKit;
 #import <ResearchKit/ORKFormStep.h>
 
 
@@ -78,6 +78,28 @@ ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierDOB ORK_AVAILABLE_DE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKRegistrationStep : ORKFormStep
+
+/**
+ Returns an initialized registration step using the specified identifier,
+ title, text, options, passcodeValidationRegularExpression, and passcodeInvalidMessage.
+ 
+ @param identifier                              The string that identifies the step (see `ORKStep`).
+ @param title                                   The title of the form (see `ORKStep`).
+ @param text                                    The text shown immediately below the title (see `ORKStep`).
+ @param passcodeRules                           A `UITextInputPasswordRules` object used for generating an automatic secure password that conforms to the `passcodeValidationRegularExpression` if the default generated passwords do not match.
+ @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
+ @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
+ @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
+ 
+ @return An initialized registration step object.
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                             title:(nullable NSString *)title
+                              text:(nullable NSString *)text
+                     passcodeRules:(nullable UITextInputPasswordRules *)passcodeRules
+passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeValidationRegularExpression
+            passcodeInvalidMessage:(nullable NSString *)passcodeInvalidMessage
+                           options:(ORKRegistrationStepOption)options API_AVAILABLE(ios(12.0));
 
 /**
  Returns an initialized registration step using the specified identifier,
@@ -139,6 +161,33 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
  By default, there is no invalid message.
  */
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
+
+/**
+ The invalid message displayed if the passcode does not match the validation regular expression.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The passcode validation regular expression property must also be set along with this property.
+ By default, there is no invalid message.
+ */
+@property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules API_AVAILABLE(ios(12.0));
+
+/**
+ The regular expression used to validate the phone number form item.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number invalid message property must also be set along with this property.
+ By default, there is no validation on the phone number.
+ */
+@property (nonatomic, copy, nullable) NSRegularExpression *phoneNumberValidationRegularExpression;
+
+/**
+ The invalid message displayed if the phone number does not match the validation regular expression.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number validation regular expression property must also be set along with this property.
+ By default, there is no invalid message.
+ */
+@property (nonatomic, copy, nullable) NSString *phoneNumberInvalidMessage;
 
 @end
 

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -75,7 +75,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         
         if (@available(iOS 12.0, *)) {
             answerFormat.textContentType = UITextContentTypeNewPassword;
-        } else {
+        } else if (@available(iOS 11.0, *)) {
             answerFormat.textContentType = UITextContentTypePassword;
         }
         

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -53,6 +53,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -71,6 +72,12 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        
+        if (@available(iOS 12.0, *)) {
+            answerFormat.textContentType = UITextContentTypeNewPassword;
+        } else {
+            answerFormat.textContentType = UITextContentTypePassword;
+        }
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
@@ -100,6 +107,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeGivenName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeGivenName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierGivenName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
@@ -113,6 +121,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeFamilyName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeFamilyName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierFamilyName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
@@ -174,6 +183,25 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
 
 
 @implementation ORKRegistrationStep
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                             title:(NSString *)title
+                              text:(NSString *)text
+                     passcodeRules:(UITextInputPasswordRules *)passcodeRules
+passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
+            passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
+                           options:(ORKRegistrationStepOption)options {
+    self = [self initWithIdentifier:identifier
+                              title:title
+                               text:text
+passcodeValidationRegularExpression:passcodeValidationRegularExpression
+             passcodeInvalidMessage:passcodeInvalidMessage
+                            options:options];
+    if (self) {
+        self.passcodeRules = passcodeRules;
+    }
+    return self;
+}
 
 - (instancetype)initWithIdentifier:(NSString *)identifier
                              title:(NSString *)title
@@ -259,6 +287,14 @@ passcodeValidationRegularExpression:nil
 
 - (void)setPasscodeInvalidMessage:(NSString *)passcodeInvalidMessage {
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
+}
+
+- (UITextInputPasswordRules *)passcodeRules {
+    return [self passwordAnswerFormat].passwordRules;
+}
+
+- (void)setPasscodeRules:(UITextInputPasswordRules *)passcodeRules {
+    [self passwordAnswerFormat].passwordRules = passcodeRules;
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -187,25 +187,6 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
 - (instancetype)initWithIdentifier:(NSString *)identifier
                              title:(NSString *)title
                               text:(NSString *)text
-                     passcodeRules:(UITextInputPasswordRules *)passcodeRules
-passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
-            passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
-                           options:(ORKRegistrationStepOption)options {
-    self = [self initWithIdentifier:identifier
-                              title:title
-                               text:text
-passcodeValidationRegularExpression:passcodeValidationRegularExpression
-             passcodeInvalidMessage:passcodeInvalidMessage
-                            options:options];
-    if (self) {
-        self.passcodeRules = passcodeRules;
-    }
-    return self;
-}
-
-- (instancetype)initWithIdentifier:(NSString *)identifier
-                             title:(NSString *)title
-                              text:(NSString *)text
 passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
             passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
                            options:(ORKRegistrationStepOption)options {

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -92,6 +92,11 @@
     answerFormat.multipleLines = NO;
     answerFormat.secureTextEntry = YES;
     answerFormat.keyboardType = UIKeyboardTypeASCIICapable;
+    if (@available(iOS 12.0, *)) {
+        answerFormat.textContentType = UITextContentTypeNewPassword;
+    } else {
+        answerFormat.textContentType = UITextContentTypePassword;
+    }
     answerFormat.maximumLength = 12;
     NSRegularExpression *validationRegularExpression =
     [NSRegularExpression regularExpressionWithPattern:@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{10,}"
@@ -133,6 +138,11 @@
     XCTAssertFalse(confirmAnswer.multipleLines);
     XCTAssertTrue(confirmAnswer.secureTextEntry);
     XCTAssertEqual(confirmAnswer.keyboardType, UIKeyboardTypeASCIICapable);
+    if (@available(iOS 12.0, *)) {
+        XCTAssertEqual(confirmAnswer.textContentType, UITextContentTypeNewPassword);
+    } else {
+        XCTAssertEqual(confirmAnswer.textContentType, UITextContentTypePassword);
+    }
     XCTAssertEqual(confirmAnswer.maximumLength, 12);
     
     // This property should match the input answer format so that cases that

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -225,7 +225,24 @@ static NSRegularExpression *regularExpressionsFromDictionary(NSDictionary *dict)
     return regularExpression;
 }
 
-static NSMutableDictionary *ORKESerializationEncodingTable();
+static NSDictionary *dictionaryFromPasswordRules(UITextInputPasswordRules *passwordRules) {
+    NSDictionary *dictionary = passwordRules ?
+    @{
+      @"rules": passwordRules.passwordRulesDescriptor ?: @""
+      } :
+    @{};
+    return dictionary;
+}
+
+static UITextInputPasswordRules *passwordRulesFromDictionary(NSDictionary *dict) {
+    UITextInputPasswordRules *passwordRules;
+    if (dict.count == 1) {
+        passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:dict[@"rules"]];
+    }
+    return passwordRules;
+}
+
+static NSMutableDictionary *ORKESerializationEncodingTable(void);
 static id propFromDict(NSDictionary *dict, NSString *propName);
 static NSArray *classEncodingsForClass(Class c) ;
 static id objectForJsonObject(id input, Class expectedClass, ORKESerializationJSONToObjectBlock converterBlock) ;
@@ -1117,7 +1134,11 @@ encondingTable =
           PROPERTY(spellCheckingType, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(keyboardType, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(multipleLines, NSNumber, NSObject, YES, nil, nil),
-          PROPERTY(secureTextEntry, NSNumber, NSObject, YES, nil, nil)
+          PROPERTY(secureTextEntry, NSNumber, NSObject, YES, nil, nil),
+          PROPERTY(textContentType, NSString, NSObject, YES, nil, nil),
+          PROPERTY(passwordRules, UITextInputPasswordRules, NSObject, YES,
+                   ^id(id value) { return dictionaryFromPasswordRules((UITextInputPasswordRules *)value); },
+                   ^id(id dict) { return passwordRulesFromDictionary(dict); } )
           })),
    ENTRY(ORKEmailAnswerFormat,
          nil,

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -410,6 +410,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKTextAnswerFormat.autocapitalizationType",
                                               @"ORKTextAnswerFormat.autocorrectionType",
                                               @"ORKTextAnswerFormat.spellCheckingType",
+                                              @"ORKTextAnswerFormat.textContentType",
+                                              @"ORKTextAnswerFormat.passwordRules",
                                               @"ORKInstructionStep.image",
                                               @"ORKInstructionStep.auxiliaryImage",
                                               @"ORKInstructionStep.iconImage",

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1004,7 +1004,8 @@ enum TaskListRow: Int, CustomStringConvertible {
         answerFormatDomain.autocapitalizationType = UITextAutocapitalizationType.none
         answerFormatDomain.autocorrectionType = UITextAutocorrectionType.no
         answerFormatDomain.spellCheckingType = UITextSpellCheckingType.no
-        let stepDomain = ORKQuestionStep(identifier: String(describing:Identifier.validatedTextQuestionStepDomain), title: NSLocalizedString("URL", comment: ""), answer: answerFormatDomain)
+        answerFormatDomain.textContentType = UITextContentType.URL
+        let stepDomain = ORKQuestionStep(identifier: String(describing:Identifier.validatedTextQuestionStepDomain), title: NSLocalizedString("Validated Text", comment: ""), question: NSLocalizedString("URL", comment: ""), answer: answerFormatDomain)
         stepDomain.text = exampleDetailText
         
         return ORKOrderedTask(identifier: String(describing:Identifier.validatedTextQuestionTask), steps: [stepEmail, stepDomain])


### PR DESCRIPTION
**Don't Merge This Until The Password Management Stuff Works**

This was [merged into master](https://github.com/ResearchKit/ResearchKit/pull/1188) of the ResearchKit repository, this is a back-port for our use. Just wanted to put it here so it doesn't get lost.

The code is good, the functionality is still flakey in iOS 12.1. 