### PR TITLE
Fix navigation breakdown after validation rule aborts an immediateNavigation answer

### DIFF
--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -383,8 +383,8 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (void)updateButtonStates {
     if ([self isStepImmediateNavigation]) {
-        _continueSkipView.neverHasContinueButton = YES;
-        _continueSkipView.continueButtonItem = nil;
+//        _continueSkipView.neverHasContinueButton = YES;
+//        _continueSkipView.continueButtonItem = nil;
     }
     _questionView.continueSkipContainer.continueEnabled = [self continueButtonEnabled];
     _continueSkipView.continueEnabled = [self continueButtonEnabled];
@@ -547,12 +547,10 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKAnswerFormat *impliedAnswerFormat = [_answerFormat impliedAnswerFormat];
     
     if (section == ORKQuestionSectionAnswer) {
-        if (_choiceCellGroup == nil) {
-            _choiceCellGroup = [[ORKTextChoiceCellGroup alloc] initWithTextChoiceAnswerFormat:(ORKTextChoiceAnswerFormat *)impliedAnswerFormat
-                                                                                       answer:self.answer
-                                                                           beginningIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
-                                                                          immediateNavigation:[self isStepImmediateNavigation]];
-        }
+        _choiceCellGroup = [[ORKTextChoiceCellGroup alloc] initWithTextChoiceAnswerFormat:(ORKTextChoiceAnswerFormat *)impliedAnswerFormat
+                                                                                   answer:self.answer
+                                                                       beginningIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]
+                                                                      immediateNavigation:[self isStepImmediateNavigation]];
         return _choiceCellGroup.size;
     }
     return 0;
@@ -630,11 +628,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     
     identifier = [NSStringFromClass([self class]) stringByAppendingFormat:@"%@", @(indexPath.row)];
     
-    ORKChoiceViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier];
-    
-    if (cell == nil) {
-        cell = [_choiceCellGroup cellAtIndexPath:indexPath withReuseIdentifier:identifier];
-    }
+    ORKChoiceViewCell *cell = [_choiceCellGroup cellAtIndexPath:indexPath withReuseIdentifier:identifier];
     
     cell.userInteractionEnabled = !self.readOnlyMode;
     return cell;


### PR DESCRIPTION
Fixes [CEVResearchKit 135](https://github.com/CareEvolution/CEVResearchKit/issues/135). Below is a simple example to demonstrate the bug. The validation rule should prevent an answer of "No" on the first question. Since a Boolean question type constitutes an `immediateNavigation`-style navigation where the answer saves a tap by auto-advancing, the abort by the validation rule leaves the tableview architecture in a strange state. When I staged this JSON against the current stable branch of ResearchKit 2.0, I noted that the view reverted to an answered mode with a checkmark. So I diffed our branch against that one and narrowed the cause down to a change in 2.0 where tableview pieces are NOT recycled and forced to redraw from scratch. I copied the code pieces verbatim to hopefully make future merging less difficult.

Have done a little regression testing using a few other surveys that have immediateNavigation. These are question steps that are non-Optional, of type `ORKBooleanAnswerFormat` or `ORKTextChoiceAnswerFormat` of `.style == ORKChoiceAnswerStyle.singleChoice`) and are "virgin" - meaning first answering attempt - i.e. not reverse-navigated or loaded from a saved result.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "QuestionStep",
      "text": "",
      "title": "Question 1",
      "identifier": "QUESTION 1",
      "answerFormat": {
        "type": "BooleanAnswerFormat"
      },
      "optional": false,
      "placeholder": "Enter Text",
      "validationRules": [
        {
          "type": "ValidationRule",
          "errorMessage": "Error, cannot be No",
          "resultPredicate": {
            "resultIdentifier": "QUESTION 1",
            "stepIdentifier": null,
            "type": "BooleanQuestionResultPredicate",
            "expectedAnswer": false
          }
        }
      ]
    },
    {
      "type": "QuestionStep",
      "text": "",
      "title": "Question 2",
      "identifier": "QUESTION 2",
      "answerFormat": {
        "type": "NumericAnswerFormat",
        "style": "Integer"
      },
      "optional": true,
      "placeholder": "Enter Number"
    }
  ]
}
```