### PR TITLE
Implement a hideItemPredicate on ORKFormItem to make each hideable

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -2962,6 +2962,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 				tr,
@@ -3010,6 +3011,7 @@
 				"en-GB",
 				"en-AU",
 				nb,
+				"es-419",
 			);
 			mainGroup = 3FFF18341829DB1D00167070;
 			productRefGroup = 3FFF183E1829DB1D00167070 /* Products */;

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -198,7 +198,7 @@ ORK_CLASS_AVAILABLE
 /**
  A predicate that when true, hides the item from display.
  */
-@property (nonatomic, nullable) NSPredicate *hideItemPredicate;
+@property (nonatomic, nullable) NSPredicate *hidePredicate;
 
 /**
  Returns an form item that can be used for confirming a text entry.

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -196,6 +196,11 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, readonly, nullable) ORKAnswerFormat *answerFormat;
 
 /**
+ A predicate that when true, hides the item from display.
+ */
+@property (nonatomic, nullable) NSPredicate *hideItemPredicate;
+
+/**
  Returns an form item that can be used for confirming a text entry.
  
  This form item is intended to be used with an `ORKFormStep` in order to confirm a previous

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -212,6 +212,7 @@
     ORKFormItem *item = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy] text:[_text copy] answerFormat:[_answerFormat copy]];
     item.optional = _optional;
     item.placeholder = _placeholder;
+    item.hideItemPredicate = _hideItemPredicate;
     return item;
 }
 
@@ -224,6 +225,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, step, ORKFormStep);
+        ORK_DECODE_OBJ_CLASS(aDecoder, hideItemPredicate, NSPredicate);
     }
     return self;
 }
@@ -235,7 +237,7 @@
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, step);
-
+    ORK_ENCODE_OBJ(aCoder, hideItemPredicate);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -249,12 +251,13 @@
             && self.optional == castObject.optional
             && ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.placeholder, castObject.placeholder)
-            && ORKEqualObjects(self.answerFormat, castObject.answerFormat));
+            && ORKEqualObjects(self.answerFormat, castObject.answerFormat)
+            && ORKEqualObjects(self.hideItemPredicate, castObject.hideItemPredicate));
 }
 
 - (NSUInteger)hash {
      // Ignore the step reference - it's not part of the content of this item
-    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0);
+    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hideItemPredicate.hash;
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -212,7 +212,7 @@
     ORKFormItem *item = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy] text:[_text copy] answerFormat:[_answerFormat copy]];
     item.optional = _optional;
     item.placeholder = _placeholder;
-    item.hideItemPredicate = _hideItemPredicate;
+    item.hidePredicate = _hidePredicate;
     return item;
 }
 
@@ -225,7 +225,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, step, ORKFormStep);
-        ORK_DECODE_OBJ_CLASS(aDecoder, hideItemPredicate, NSPredicate);
+        ORK_DECODE_OBJ_CLASS(aDecoder, hidePredicate, NSPredicate);
     }
     return self;
 }
@@ -237,7 +237,7 @@
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, step);
-    ORK_ENCODE_OBJ(aCoder, hideItemPredicate);
+    ORK_ENCODE_OBJ(aCoder, hidePredicate);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -252,12 +252,12 @@
             && ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.placeholder, castObject.placeholder)
             && ORKEqualObjects(self.answerFormat, castObject.answerFormat)
-            && ORKEqualObjects(self.hideItemPredicate, castObject.hideItemPredicate));
+            && ORKEqualObjects(self.hidePredicate, castObject.hidePredicate));
 }
 
 - (NSUInteger)hash {
      // Ignore the step reference - it's not part of the content of this item
-    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hideItemPredicate.hash;
+    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hidePredicate.hash;
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -620,8 +620,8 @@
 - (BOOL)allNonOptionalFormItemsHaveAnswers {
     ORKTaskResult *taskResult = self.taskViewController.result;
     for (ORKFormItem *item in [self formItems]) {
-        BOOL hideFormItem = [item.hideItemPredicate evaluateWithObject:@[taskResult]
-                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        BOOL hideFormItem = [item.hidePredicate evaluateWithObject:@[taskResult]
+                                             substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
         if (!item.optional && !hideFormItem) {
             id answer = _savedAnswers[item.identifier];
             if (ORKIsAnswerEmpty(answer) || ![item.impliedAnswerFormat isAnswerValid:answer]) {
@@ -663,8 +663,8 @@
     NSMutableIndexSet *sectionsToDelete = [NSMutableIndexSet indexSet];
     
     [formItems enumerateObjectsUsingBlock:^(ORKFormItem * _Nonnull formItem, NSUInteger idx, BOOL * _Nonnull stop) {
-        BOOL hideFormItem = [formItem.hideItemPredicate evaluateWithObject:@[taskResult]
-                                                     substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        BOOL hideFormItem = [formItem.hidePredicate evaluateWithObject:@[taskResult]
+                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
         ORKTableSection *section = _allSections[idx];
         if (!hideFormItem) {
             [_sections addObject:section];

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -294,6 +294,7 @@
     NSMutableSet *_formItemCells;
     NSMutableArray<ORKTableSection *> *_sections;
     NSMutableArray<ORKTableSection *> *_allSections;
+    NSMutableArray<ORKFormItem *> *_filteredForms;
     BOOL _skipped;
     ORKFormItemCell *_currentFirstResponderCell;
 }
@@ -650,6 +651,7 @@
     
     NSArray<ORKTableSection *> *oldSections = _sections;
     _sections = [NSMutableArray new];
+    _filteredForms = [NSMutableArray new];
     
     ORKTaskResult *taskResult = self.taskViewController.result;
     NSArray<ORKFormItem *> *formItems = [self allFormItems];
@@ -670,6 +672,7 @@
             if ([oldSections containsObject:section]) {
                 [sectionsToDelete addIndex:[oldSections indexOfObject:section]];
             }
+            [_filteredForms addObject:formItem];
         }
     }];
     
@@ -740,6 +743,10 @@
     
     NSMutableArray *qResults = [NSMutableArray new];
     for (ORKFormItem *item in items) {
+        
+        if ([_filteredForms containsObject:item]) {
+            continue;
+        }
 
         // Skipped forms report a "null" value for every item -- by skipping, the user has explicitly said they don't want
         // to report any values from this form.

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -618,8 +618,11 @@
 }
 
 - (BOOL)allNonOptionalFormItemsHaveAnswers {
+    ORKTaskResult *taskResult = self.taskViewController.result;
     for (ORKFormItem *item in [self formItems]) {
-        if (!item.optional) {
+        BOOL hideFormItem = [item.hideItemPredicate evaluateWithObject:@[taskResult]
+                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        if (!item.optional && !hideFormItem) {
             id answer = _savedAnswers[item.identifier];
             if (ORKIsAnswerEmpty(answer) || ![item.impliedAnswerFormat isAnswerValid:answer]) {
                 return NO;


### PR DESCRIPTION
This adds the pieces needed for https://github.com/CareEvolution/CEVResearchKit/issues/134.

Here an `NSPredicate` can be set on an `ORKFormItem` which  if true will cause it to be hidden in an `ORKFormStepViewController`. Due to the differences between CEVRelease-1.x and the base ResearchKit 2.0, I needed to apply the changes manually in both versions. Note the following branches:

- [Schramm/hideFormItemWIthPredicate-1.x](https://github.com/CareEvolution/ResearchKit/tree/Schramm/hideFormItemWIthPredicate-1.x) - implementation for our local use based on [CEVRelease-1.x](https://github.com/CareEvolution/ResearchKit/tree/CEVRelease-1.x). This is what I'm requested to be merged in this PR.
- [Schramm/demoTestHideFormItemWIthPredicate-1.x](https://github.com/CareEvolution/ResearchKit/tree/Schramm/demoTestHideFormItemWIthPredicate-1.x) - a convenient branch with 5 cases built out in ORKCatalog to test/demo changes in [Schramm/hideFormItemWIthPredicate-1.x](https://github.com/CareEvolution/ResearchKit/tree/Schramm/hideFormItemWIthPredicate-1.x)
- [Schramm/hideFormItemWIthPredicate-2.0](https://github.com/CareEvolution/ResearchKit/tree/Schramm/hideFormItemWIthPredicate-2.0) - implementation to submit PR against [ResearchKit/ResearchKit/master](https://github.com/ResearchKit/ResearchKit/tree/master). I would appreciate feedback on this as well prior to submitting the PR.
- [Schramm/demoTestHideFormItemWIthPredicate-2.0](https://github.com/CareEvolution/ResearchKit/tree/Schramm/demoTestHideFormItemWIthPredicate-2.0) - a convenient branch with the same 5 cases built out in ORKCatalog to test/demo changes in [Schramm/hideFormItemWIthPredicate-2.0](https://github.com/CareEvolution/ResearchKit/tree/Schramm/hideFormItemWIthPredicate-2.0)

In a nutshell, I'm attempting to preserve the full unfiltered `ORKFormStep` with all the `ORKFormItems`, but modify the state of the tableview based on the hide predicates and respond to live changes.