### PR TITLE
Support hyperlinks in ORKWebViewSteps

### DIFF
--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -91,25 +91,27 @@
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-    if (navigationAction.navigationType == WKNavigationTypeLinkActivated
-        && ([navigationAction.request.URL.scheme isEqualToString:@"http"]
-            || [navigationAction.request.URL.scheme isEqualToString:@"https"])) {
-        if (navigationAction.targetFrame != nil) {
-            if (@available(iOS 11.0, *)) {
-                SFSafariViewControllerConfiguration *cfg = [[SFSafariViewControllerConfiguration alloc] init];
-                cfg.barCollapsingEnabled = YES;
-                SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:navigationAction.request.URL configuration:cfg];
-                safari.preferredBarTintColor = self.navigationController.navigationBar.barTintColor;
-                safari.preferredControlTintColor = self.view.tintColor;
-                [self presentViewController:safari animated:YES completion:NULL];
-                decisionHandler(WKNavigationActionPolicyCancel);
-                return;
+    if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
+        if (navigationAction.targetFrame != nil
+            && ([navigationAction.request.URL.scheme isEqualToString:@"http"]
+                || [navigationAction.request.URL.scheme isEqualToString:@"https"])) {
+                if (@available(iOS 11.0, *)) {
+                    SFSafariViewControllerConfiguration *cfg = [[SFSafariViewControllerConfiguration alloc] init];
+                    cfg.barCollapsingEnabled = YES;
+                    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:navigationAction.request.URL configuration:cfg];
+                    safari.preferredBarTintColor = self.navigationController.navigationBar.barTintColor;
+                    safari.preferredControlTintColor = self.view.tintColor;
+                    [self presentViewController:safari animated:YES completion:NULL];
+                    decisionHandler(WKNavigationActionPolicyCancel);
+                    return;
+                }
             }
-        }
         
-        [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
-        decisionHandler(WKNavigationActionPolicyCancel);
-        return;
+        if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
+            [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        }
     }
     decisionHandler(WKNavigationActionPolicyAllow);
 }

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -31,6 +31,7 @@
 #import "ORKWebViewStepViewController.h"
 #import "ORKWebViewStep.h"
 #import <ResearchKit/ORKResult.h>
+@import SafariServices;
 
 @implementation ORKWebViewStepViewController {
     WKWebView *_webView;
@@ -87,6 +88,30 @@
         parentResult.results = @[childResult];
     }
     return parentResult;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    if (navigationAction.navigationType == WKNavigationTypeLinkActivated
+        && ([navigationAction.request.URL.scheme isEqualToString:@"http"]
+            || [navigationAction.request.URL.scheme isEqualToString:@"https"])) {
+        if (navigationAction.targetFrame != nil) {
+            if (@available(iOS 11.0, *)) {
+                SFSafariViewControllerConfiguration *cfg = [[SFSafariViewControllerConfiguration alloc] init];
+                cfg.barCollapsingEnabled = YES;
+                SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:navigationAction.request.URL configuration:cfg];
+                safari.preferredBarTintColor = self.navigationController.navigationBar.barTintColor;
+                safari.preferredControlTintColor = self.view.tintColor;
+                [self presentViewController:safari animated:YES completion:NULL];
+                decisionHandler(WKNavigationActionPolicyCancel);
+                return;
+            }
+        }
+        
+        [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
+    }
+    decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(null_unspecified WKNavigation *)navigation {


### PR DESCRIPTION
Hyperlinks in ORKWebViewStep's HTML are not currently supported by ORKWebViewStepViewController. Tapping on them does nothing.

This adds support for links in two different ways:

- Plain `<a>` element will open the link within the app, using SFSafariViewController
- `<a target="_blank">` will open leave the current app and open the link in Safari (or whatever app responds to `UIApplication.openURL`)

In order to get some feedback first, and to allow us to deploy a MyDataHelps release faster if needed for client needs, I'm starting with a pull request in our fork. But we should certainly consider contributing this to the main ResearchKit repository. Note that ORKWebViewStepViewController was created at CareEvolution (originally by @chrisnowak).