### PR TITLE
Mock PR: Conditionally Hide an ORKFormItem based on an NSPredicate

### DIFF
--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -203,7 +203,7 @@ ORK_CLASS_AVAILABLE
 /**
  A predicate that when true, hides the item from display.
  */
-@property (nonatomic, nullable) NSPredicate *hideItemPredicate;
+@property (nonatomic, nullable) NSPredicate *hidePredicate;
 
 /**
  Returns an form item that can be used for confirming a text entry.

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -201,6 +201,11 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, readonly, nullable) ORKAnswerFormat *answerFormat;
 
 /**
+ A predicate that when true, hides the item from display.
+ */
+@property (nonatomic, nullable) NSPredicate *hideItemPredicate;
+
+/**
  Returns an form item that can be used for confirming a text entry.
  
  This form item is intended to be used with an `ORKFormStep` in order to confirm a previous

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -216,7 +216,7 @@
     ORKFormItem *item = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy] text:[_text copy] answerFormat:[_answerFormat copy]];
     item.optional = _optional;
     item.placeholder = _placeholder;
-    item.hideItemPredicate = _hideItemPredicate;
+    item.hidePredicate = _hidePredicate;
     return item;
 }
 
@@ -229,7 +229,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, step, ORKFormStep);
-        ORK_DECODE_OBJ_CLASS(aDecoder, hideItemPredicate, NSPredicate);
+        ORK_DECODE_OBJ_CLASS(aDecoder, hidePredicate, NSPredicate);
     }
     return self;
 }
@@ -241,7 +241,7 @@
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, step);
-    ORK_ENCODE_OBJ(aCoder, hideItemPredicate);
+    ORK_ENCODE_OBJ(aCoder, hidePredicate);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -256,12 +256,12 @@
             && ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.placeholder, castObject.placeholder)
             && ORKEqualObjects(self.answerFormat, castObject.answerFormat)
-            && ORKEqualObjects(self.hideItemPredicate, castObject.hideItemPredicate));
+            && ORKEqualObjects(self.hidePredicate, castObject.hidePredicate));
 }
 
 - (NSUInteger)hash {
      // Ignore the step reference - it's not part of the content of this item
-    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hideItemPredicate.hash;
+    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hidePredicate.hash;
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -216,6 +216,7 @@
     ORKFormItem *item = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy] text:[_text copy] answerFormat:[_answerFormat copy]];
     item.optional = _optional;
     item.placeholder = _placeholder;
+    item.hideItemPredicate = _hideItemPredicate;
     return item;
 }
 
@@ -228,6 +229,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, step, ORKFormStep);
+        ORK_DECODE_OBJ_CLASS(aDecoder, hideItemPredicate, NSPredicate);
     }
     return self;
 }
@@ -239,7 +241,7 @@
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, step);
-
+    ORK_ENCODE_OBJ(aCoder, hideItemPredicate);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -253,12 +255,13 @@
             && self.optional == castObject.optional
             && ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.placeholder, castObject.placeholder)
-            && ORKEqualObjects(self.answerFormat, castObject.answerFormat));
+            && ORKEqualObjects(self.answerFormat, castObject.answerFormat)
+            && ORKEqualObjects(self.hideItemPredicate, castObject.hideItemPredicate));
 }
 
 - (NSUInteger)hash {
      // Ignore the step reference - it's not part of the content of this item
-    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0);
+    return _identifier.hash ^ _text.hash ^ _placeholder.hash ^ _answerFormat.hash ^ (_optional ? 0xf : 0x0) ^ _hideItemPredicate.hash;
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -774,8 +774,12 @@
     }];
     
     if (animated) {
-        [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
-        [_tableView insertSections:sectionsToInsert withRowAnimation:UITableViewRowAnimationAutomatic];
+        if (sectionsToDelete.count > 0) {
+            [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
+        }
+        if (sectionsToInsert.count > 0) {
+            [_tableView insertSections:sectionsToInsert withRowAnimation:UITableViewRowAnimationAutomatic];
+        }
         [_tableView endUpdates];
     }
 }
@@ -1065,7 +1069,7 @@
         [tableView endEditing:NO];
         
         ORKTableSection *section = _sections[indexPath.section];
-        [section.textChoiceCellGroup didSelectCellAtIndexPath:indexPath];
+        [section.textChoiceCellGroup didSelectCellAtIndexPath:[self unfilteredIndexPathForIndexPath:indexPath]];
     }
     [self filterSections:YES];
 }

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -750,10 +750,6 @@
     ORKTaskResult *taskResult = self.taskViewController.result;
     NSArray<ORKFormItem *> *formItems = [self allFormItems];
     
-    if (animated) {
-        [_tableView beginUpdates];
-    }
-    
     NSMutableIndexSet *sectionsToInsert = [NSMutableIndexSet indexSet];
     NSMutableIndexSet *sectionsToDelete = [NSMutableIndexSet indexSet];
     
@@ -774,6 +770,10 @@
     }];
     
     if (animated) {
+        if (sectionsToInsert.count == 0 && sectionsToDelete.count == 0) {
+            return;
+        }
+        [_tableView beginUpdates];
         if (sectionsToDelete.count > 0) {
             [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
         }

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -710,8 +710,8 @@
 - (BOOL)allNonOptionalFormItemsHaveAnswers {
     ORKTaskResult *taskResult = self.taskViewController.result;
     for (ORKFormItem *item in [self formItems]) {
-        BOOL hideFormItem = [item.hideItemPredicate evaluateWithObject:@[taskResult]
-                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        BOOL hideFormItem = [item.hidePredicate evaluateWithObject:@[taskResult]
+                                             substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
         if (!item.optional && !hideFormItem) {
             id answer = _savedAnswers[item.identifier];
             if (ORKIsAnswerEmpty(answer) || ![item.impliedAnswerFormat isAnswerValid:answer]) {
@@ -759,8 +759,8 @@
     NSMutableIndexSet *sectionsToDelete = [NSMutableIndexSet indexSet];
     
     [formItems enumerateObjectsUsingBlock:^(ORKFormItem * _Nonnull formItem, NSUInteger idx, BOOL * _Nonnull stop) {
-        BOOL hideFormItem = [formItem.hideItemPredicate evaluateWithObject:@[taskResult]
-                                                     substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        BOOL hideFormItem = [formItem.hidePredicate evaluateWithObject:@[taskResult]
+                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
         ORKTableSection *section = _allSections[idx];
         if (!hideFormItem) {
             [_sections addObject:section];

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -775,7 +775,7 @@
         }
     }];
     
-    if (_tableView) {
+    if (_tableView != nil) {
         if (sectionsToInsert.count == 0 && sectionsToDelete.count == 0) {
             return;
         }

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -791,6 +791,10 @@
     return [NSIndexPath indexPathForRow:filteredIndexPath.row inSection:[_allSections indexOfObject:_sections[filteredIndexPath.section]]];
 }
 
+- (NSIndexPath *)filteredIndexPathForIndexPath:(NSIndexPath *)unfilteredIndexPath {
+    return [NSIndexPath indexPathForRow:unfilteredIndexPath.row inSection:[_sections indexOfObject:_allSections[unfilteredIndexPath.section]]];
+}
+
 #pragma mark Helpers
 
 - (ORKFormStep *)formStep {
@@ -1199,8 +1203,9 @@ static NSString *const _ORKOriginalAnswersRestoreKey = @"originalAnswers";
 #pragma mark ORKTextChoiceCellGroupDelegate
 
 - (void)answerChangedForIndexPath:(NSIndexPath *)indexPath {
-    ORKTableSection *section = _sections[indexPath.section];
-    ORKTableCellItem *cellItem = section.items[indexPath.row];
+    NSIndexPath *filteredIndexPath = [self filteredIndexPathForIndexPath:indexPath];
+    ORKTableSection *section = _sections[filteredIndexPath.section];
+    ORKTableCellItem *cellItem = section.items[filteredIndexPath.row];
     id answer = ([cellItem.formItem.answerFormat isKindOfClass:[ORKBooleanAnswerFormat class]]) ? [section.textChoiceCellGroup answerForBoolean] : [section.textChoiceCellGroup answer];
     NSString *formItemIdentifier = cellItem.formItem.identifier;
     if (answer && formItemIdentifier) {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -297,7 +297,7 @@
     NSMutableSet *_formItemCells;
     NSMutableArray<ORKTableSection *> *_sections;
     NSMutableArray<ORKTableSection *> *_allSections;
-    NSMutableArray<ORKFormItem *> *_filteredForms;
+    NSMutableArray<ORKFormItem *> *_hiddenFormItems;
     BOOL _skipped;
     UITableViewCell *_currentFirstResponderCell;
     NSArray<NSLayoutConstraint *> *_constraints;
@@ -507,7 +507,7 @@
     
     if (self.isViewLoaded && self.step) {
         [self buildSections];
-        [self filterSections:NO];
+        [self hideSections];
         
         _formItemCells = [NSMutableSet new];
         
@@ -746,11 +746,11 @@
     _navigationFooterView.skipEnabled = [self skipButtonEnabled];
 }
 
-- (void)filterSections:(BOOL)animated {
+- (void)hideSections {
     
     NSArray<ORKTableSection *> *oldSections = _sections;
     _sections = [NSMutableArray new];
-    _filteredForms = [NSMutableArray new];
+    _hiddenFormItems = [NSMutableArray new];
     
     ORKTaskResult *taskResult = self.taskViewController.result;
     NSArray<ORKFormItem *> *formItems = [self allFormItems];
@@ -771,11 +771,11 @@
             if ([oldSections containsObject:section]) {
                 [sectionsToDelete addIndex:[oldSections indexOfObject:section]];
             }
-            [_filteredForms addObject:formItem];
+            [_hiddenFormItems addObject:formItem];
         }
     }];
     
-    if (animated) {
+    if (_tableView) {
         if (sectionsToInsert.count == 0 && sectionsToDelete.count == 0) {
             return;
         }
@@ -842,7 +842,7 @@
     NSMutableArray *qResults = [NSMutableArray new];
     for (ORKFormItem *item in items) {
         
-        if ([_filteredForms containsObject:item]) {
+        if ([_hiddenFormItems containsObject:item]) {
             continue;
         }
         
@@ -1085,7 +1085,7 @@
         ORKTableSection *section = _sections[indexPath.section];
         [section.textChoiceCellGroup didSelectCellAtIndexPath:[self unfilteredIndexPathForIndexPath:indexPath]];
     }
-    [self filterSections:YES];
+    [self hideSections];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -790,12 +790,12 @@
     }
 }
 
-- (NSIndexPath *)unfilteredIndexPathForIndexPath:(NSIndexPath *)filteredIndexPath {
-    return [NSIndexPath indexPathForRow:filteredIndexPath.row inSection:[_allSections indexOfObject:_sections[filteredIndexPath.section]]];
+- (NSIndexPath *)unhiddenIndexPathForIndexPath:(NSIndexPath *)hiddenIndexPath {
+    return [NSIndexPath indexPathForRow:hiddenIndexPath.row inSection:[_allSections indexOfObject:_sections[hiddenIndexPath.section]]];
 }
 
-- (NSIndexPath *)filteredIndexPathForIndexPath:(NSIndexPath *)unfilteredIndexPath {
-    return [NSIndexPath indexPathForRow:unfilteredIndexPath.row inSection:[_sections indexOfObject:_allSections[unfilteredIndexPath.section]]];
+- (NSIndexPath *)hiddenIndexPathForIndexPath:(NSIndexPath *)unhiddenIndexPath {
+    return [NSIndexPath indexPathForRow:unhiddenIndexPath.row inSection:[_sections indexOfObject:_allSections[unhiddenIndexPath.section]]];
 }
 
 #pragma mark Helpers
@@ -923,8 +923,8 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSIndexPath *unfilteredIndexPath = [self unfilteredIndexPathForIndexPath:indexPath];
-    NSString *identifier = [NSString stringWithFormat:@"%ld-%ld",(long)unfilteredIndexPath.section, (long)unfilteredIndexPath.row];
+    NSIndexPath *unhiddenIndexPath = [self unhiddenIndexPathForIndexPath:indexPath];
+    NSString *identifier = [NSString stringWithFormat:@"%ld-%ld",(long)unhiddenIndexPath.section, (long)unhiddenIndexPath.row];
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier];
     
@@ -940,7 +940,7 @@
             [section.textChoiceCellGroup setAnswer:answer];
             section.textChoiceCellGroup.delegate = self;
             ORKChoiceViewCell *choiceViewCell = nil;
-            choiceViewCell = [section.textChoiceCellGroup cellAtIndexPath:unfilteredIndexPath withReuseIdentifier:identifier];
+            choiceViewCell = [section.textChoiceCellGroup cellAtIndexPath:unhiddenIndexPath withReuseIdentifier:identifier];
             if ([choiceViewCell isKindOfClass:[ORKChoiceOtherViewCell class]]) {
                 ORKChoiceOtherViewCell *choiceOtherViewCell = (ORKChoiceOtherViewCell *)choiceViewCell;
                 choiceOtherViewCell.delegate = self;
@@ -1083,7 +1083,7 @@
         [tableView endEditing:NO];
         
         ORKTableSection *section = _sections[indexPath.section];
-        [section.textChoiceCellGroup didSelectCellAtIndexPath:[self unfilteredIndexPathForIndexPath:indexPath]];
+        [section.textChoiceCellGroup didSelectCellAtIndexPath:[self unhiddenIndexPathForIndexPath:indexPath]];
     }
     [self hideSections];
 }
@@ -1210,9 +1210,9 @@ static NSString *const _ORKOriginalAnswersRestoreKey = @"originalAnswers";
 #pragma mark ORKTextChoiceCellGroupDelegate
 
 - (void)answerChangedForIndexPath:(NSIndexPath *)indexPath {
-    NSIndexPath *filteredIndexPath = [self filteredIndexPathForIndexPath:indexPath];
-    ORKTableSection *section = _sections[filteredIndexPath.section];
-    ORKTableCellItem *cellItem = section.items[filteredIndexPath.row];
+    NSIndexPath *hiddenIndexPath = [self hiddenIndexPathForIndexPath:indexPath];
+    ORKTableSection *section = _sections[hiddenIndexPath.section];
+    ORKTableCellItem *cellItem = section.items[hiddenIndexPath.row];
     id answer = ([cellItem.formItem.answerFormat isKindOfClass:[ORKBooleanAnswerFormat class]]) ? [section.textChoiceCellGroup answerForBoolean] : [section.textChoiceCellGroup answer];
     NSString *formItemIdentifier = cellItem.formItem.identifier;
     if (answer && formItemIdentifier) {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -297,6 +297,7 @@
     NSMutableSet *_formItemCells;
     NSMutableArray<ORKTableSection *> *_sections;
     NSMutableArray<ORKTableSection *> *_allSections;
+    NSMutableArray<ORKFormItem *> *_filteredForms;
     BOOL _skipped;
     UITableViewCell *_currentFirstResponderCell;
     NSArray<NSLayoutConstraint *> *_constraints;
@@ -749,6 +750,7 @@
     
     NSArray<ORKTableSection *> *oldSections = _sections;
     _sections = [NSMutableArray new];
+    _filteredForms = [NSMutableArray new];
     
     ORKTaskResult *taskResult = self.taskViewController.result;
     NSArray<ORKFormItem *> *formItems = [self allFormItems];
@@ -769,6 +771,7 @@
             if ([oldSections containsObject:section]) {
                 [sectionsToDelete addIndex:[oldSections indexOfObject:section]];
             }
+            [_filteredForms addObject:formItem];
         }
     }];
     
@@ -838,7 +841,11 @@
     
     NSMutableArray *qResults = [NSMutableArray new];
     for (ORKFormItem *item in items) {
-
+        
+        if ([_filteredForms containsObject:item]) {
+            continue;
+        }
+        
         // Skipped forms report a "null" value for every item -- by skipping, the user has explicitly said they don't want
         // to report any values from this form.
         

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -707,8 +707,11 @@
 }
 
 - (BOOL)allNonOptionalFormItemsHaveAnswers {
+    ORKTaskResult *taskResult = self.taskViewController.result;
     for (ORKFormItem *item in [self formItems]) {
-        if (!item.optional) {
+        BOOL hideFormItem = [item.hideItemPredicate evaluateWithObject:@[taskResult]
+                                                 substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
+        if (!item.optional && !hideFormItem) {
             id answer = _savedAnswers[item.identifier];
             if (ORKIsAnswerEmpty(answer) || ![item.impliedAnswerFormat isAnswerValid:answer]) {
                 return NO;


### PR DESCRIPTION
Below is what I plan to use to submit this PR against base ResearchKit. Any feedback would be awesome 😀.  Note - you can easily test the functionality using one of the demo branches in [this PR](https://github.com/CareEvolution/ResearchKit/pull/14) and building ORKCatalog.  NOT MEANT TO BE MERGED.

NOTE: This Mock PR as opposed to the last one is based on a copy of current Apple master for ResearchKit so it shows an accurate depiction of the diffs.

---

Implements an enhancement [discussed here recently](https://github.com/ResearchKit/ResearchKit/pull/1264/files#diff-f953f90e65bcefc4e8aefb2a8a587851) where an `ORKFormItem` can be hidden via an `NSPredicate`. This can be useful for a showing/hiding later `ORKFormItem`s based on answers in the same `ORKFormStep`. This is demonstrated below. It can also be used to simply provide conditional display of various items in a lengthy `ORKFormStep` as well based on previous responses.

In this implementation, a `ORKFormItem` where `isOptional` is `false` will NOT be required to move to the next step. This prevents an unsatisfiable condition in validation where a required step is not visible to the user.

Furthermore, results for hidden form items at the time the step is completed are removed, similarly to skipped steps (via rules) in a task.

![showHide2](https://user-images.githubusercontent.com/1008462/57145125-28437480-6d88-11e9-856a-136c7a75418c.gif)