### PR TITLE
Fix for sections containing multiple ORKFormItems

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -740,21 +740,11 @@
         }
         [_tableView beginUpdates];
         if (sectionsToDelete.count > 0) {
-            NSLog(@"Removing sections : %@", sectionsToDelete);
             [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
         }
         if (sectionsToInsert.count > 0) {
-            NSLog(@"Inserting sections: %@", sectionsToInsert);
             [_tableView insertSections:sectionsToInsert withRowAnimation:UITableViewRowAnimationAutomatic];
         }
-        NSMutableString *updatedSections = [NSMutableString string];
-        for (ORKTableSection *section in _sections) {
-            if (updatedSections.length > 0) {
-                [updatedSections appendString: @"\n"];
-            }
-            [updatedSections appendFormat:@"%@", section.title];
-        }
-        NSLog(@"Displaying in order: %@", updatedSections);
         
         [_tableView endUpdates];
         

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -687,6 +687,7 @@
                 if (cellItem) {
                     [_hiddenCellItems addObject:cellItem];
                 }
+                [_hiddenFormItems addObject:formItem];
             } else {
                 hideSection = NO;
             }
@@ -703,7 +704,6 @@
             if ([oldSections containsObject:section]) {
                 [sectionsToDelete addIndex:[oldSections indexOfObject:section]];
             }
-            [_hiddenFormItems addObjectsFromArray:section.formItems];
         }
     }
     


### PR DESCRIPTION
See discussion [here](https://github.com/CareEvolution/RKStudio-Participant/pull/477#issuecomment-497095923) for background.

Current implementation fails on the `ORKLoginStepViewController` which contains an two `ORKFormItems` - one for the email and one for the password. Since these types do not require an individual section as determined [here](https://github.com/CareEvolution/ResearchKit/blob/e6982d95a7a0e89456632684d573ba4e1d94bb09/ResearchKit/Common/ORKFormStepViewController.m#L566-L588), they share an `ORKTableSection`. This breaks an assumption in the current implementation of a 1:1 relationship between `ORKFormItem`s and `ORKTableSection`.

I researched which `ORKFormItem`s may be combined in one section and created a new test case (Demo - Test Mix of Single and Multiple) in the branch [Schramm/demoTestHideFormItemWithPredicate-1.x](https://github.com/CareEvolution/ResearchKit/tree/Schramm/demoTestHideFormItemWithPredicate-1.x). This demonstrates grouping behavior of hiding forms that always stay within their own section or can be combined with others in a combined section.

Once this is approved, I will graft the changes on base 2.0 and create an issue and PR against the base ResearchKit.