### PR TITLE
Delegates for visual consent and consent review

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.h
@@ -38,6 +38,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ORKConsentReviewStep;
 @class ORKConsentSignatureResult;
+@class ORKConsentReviewStepViewController;
+
+/**
+ Implement this delegate in order to observe the user's interaction with a consent review step.
+ */
+ORK_CLASS_AVAILABLE
+@protocol ORKConsentReviewStepViewControllerDelegate<NSObject>
+
+@optional
+
+/**
+ Tells the delegate when various phases of consent review are displayed.
+ 
+ @param stepViewController The step view controller providing the callback.
+ @param index              A value indicating the phase of consent review. May not be contiguous (some phases may be skipped), depending on the signature requirements.
+ */
+- (void)consentReviewStepViewController:(ORKConsentReviewStepViewController *)stepViewController didShowPhaseIndex:(NSInteger)index;
+
+@end
+
 
 /**
  The `ORKConsentReviewStepViewController` class is a step view controller subclass
@@ -58,6 +78,11 @@ ORK_CLASS_AVAILABLE
  */
 - (instancetype)initWithConsentReviewStep:(ORKConsentReviewStep *)consentReviewStep
                                    result:(nullable ORKConsentSignatureResult *)result;
+
+/**
+ The delegate for consent review interactions. This delegate is optional.
+ */
+@property (nonatomic, weak, nullable) id<ORKConsentReviewStepViewControllerDelegate> consentReviewDelegate;
 
 @end
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -377,6 +377,7 @@ static NSString *const _SignatureStepIdentifier = @"signatureStep";
         if (finished) {
             ORKStrongTypeOf(weakSelf) strongSelf = weakSelf;
             [strongSelf updateBackButton];
+            [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:page];
             
             //register ScrollView to update hairline
             if ([viewController isKindOfClass:[ORKConsentReviewController class]]) {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -377,7 +377,9 @@ static NSString *const _SignatureStepIdentifier = @"signatureStep";
         if (finished) {
             ORKStrongTypeOf(weakSelf) strongSelf = weakSelf;
             [strongSelf updateBackButton];
-            [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:page];
+            if ([[strongSelf consentReviewDelegate] respondsToSelector:@selector(consentReviewStepViewController:didShowPhaseIndex:)]) {
+                [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:page];
+            }
             
             //register ScrollView to update hairline
             if ([viewController isKindOfClass:[ORKConsentReviewController class]]) {

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.h
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.h
@@ -36,6 +36,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ORKVisualConsentStepViewController;
+@class ORKConsentSection;
+
+/**
+ Implement this delegate in order to observe the user's interaction with a visual consent step.
+ */
+ORK_CLASS_AVAILABLE
+@protocol ORKVisualConsentStepViewControllerDelegate<NSObject>
+
+@optional
+
+/**
+ Tells the delegate when each section of the consent document is displayed, as the user navigates through them.
+ 
+ @param stepViewController The step view controller providing the callback.
+ @param section            The consent section displayed.
+ @param index              The index of the consent section.
+ */
+- (void)visualConsentStepViewController:(ORKVisualConsentStepViewController *)stepViewController didShowSection:(ORKConsentSection *)section sectionIndex:(NSInteger)index;
+
+@end
+
+
 /**
  The `ORKVisualConsentStepViewController` class is a view controller subclass
  used to manage a visual consent step (`ORKVisualConsentStep`).
@@ -46,6 +69,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 ORK_CLASS_AVAILABLE
 @interface ORKVisualConsentStepViewController : ORKStepViewController
+
+/**
+ The delegate for visual consent interactions. This delegate is optional.
+ */
+@property (nonatomic, weak, nullable) id<ORKVisualConsentStepViewControllerDelegate> visualConsentDelegate;
 
 /**
  The view in which animations are displayed.

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -325,6 +325,8 @@
         _animationView.accessibilityLabel = [NSString stringWithFormat:ORKLocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), currentSection.title];
         _animationView.accessibilityTraits |= UIAccessibilityTraitImage;
     }
+    
+    [[self visualConsentDelegate] visualConsentStepViewController:self didShowSection:currentSection sectionIndex:currentIndex];
 }
 
 - (void)setScrollEnabled:(BOOL)enabled {

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -326,7 +326,9 @@
         _animationView.accessibilityTraits |= UIAccessibilityTraitImage;
     }
     
-    [[self visualConsentDelegate] visualConsentStepViewController:self didShowSection:currentSection sectionIndex:currentIndex];
+    if ([[self visualConsentDelegate] respondsToSelector:@selector(visualConsentStepViewController:didShowSection:sectionIndex:)]) {
+        [[self visualConsentDelegate] visualConsentStepViewController:self didShowSection:currentSection sectionIndex:currentIndex];
+    }
 }
 
 - (void)setScrollEnabled:(BOOL)enabled {


### PR DESCRIPTION
This is supporting code for https://github.com/CareEvolution/RKStudio-Participant/pull/518

ORKVisualConsentViewController and ORKConsentReviewViewController can display, from the user's perspective, multiple steps in a consent survey. In order to track each of these "substeps" for analytics purposes, I created a new delegate protocol for each of these view controllers. In each view controller, I found only a single place where I needed to invoke the delegate callback.