### PR TITLE
Consent review: pass the correct phase info to the delegate

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.h
@@ -41,6 +41,18 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORKConsentReviewStepViewController;
 
 /**
+ Values that identify different phases of the consent review step. Which phases are shown to the user depend on the configuration of the associated ORKConsentSignature.
+ */
+typedef NS_ENUM(NSInteger, ORKConsentReviewPhase) {
+    /// The (optional) phase in which the user enters their name.
+    ORKConsentReviewPhaseName,
+    /// The phase in which the consent document is displayed for final review before agreeing.
+    ORKConsentReviewPhaseReviewDocument,
+    /// The (optional) phase in which the user enters a signature.
+    ORKConsentReviewPhaseSignature
+} ORK_ENUM_AVAILABLE;
+
+/**
  Implement this delegate in order to observe the user's interaction with a consent review step.
  */
 ORK_CLASS_AVAILABLE
@@ -52,9 +64,10 @@ ORK_CLASS_AVAILABLE
  Tells the delegate when various phases of consent review are displayed.
  
  @param stepViewController The step view controller providing the callback.
- @param index              A value indicating the phase of consent review. May not be contiguous (some phases may be skipped), depending on the signature requirements.
+ @param phase              The phase of consent review shown to the user.
+ @param pageIndex          Indicates the ordering of the phase shown to the user.
  */
-- (void)consentReviewStepViewController:(ORKConsentReviewStepViewController *)stepViewController didShowPhaseIndex:(NSInteger)index;
+- (void)consentReviewStepViewController:(ORKConsentReviewStepViewController *)stepViewController didShowPhase:(ORKConsentReviewPhase)phase pageIndex:(NSInteger)pageIndex;
 
 @end
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -377,8 +377,13 @@ static NSString *const _SignatureStepIdentifier = @"signatureStep";
         if (finished) {
             ORKStrongTypeOf(weakSelf) strongSelf = weakSelf;
             [strongSelf updateBackButton];
-            if ([[strongSelf consentReviewDelegate] respondsToSelector:@selector(consentReviewStepViewController:didShowPhaseIndex:)]) {
-                [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:page];
+            
+            NSUInteger currentPageIndex = strongSelf->_currentPageIndex;
+            NSArray *pageIndices = strongSelf->_pageIndices;
+            if (currentPageIndex < pageIndices.count
+                && [[strongSelf consentReviewDelegate] respondsToSelector:@selector(consentReviewStepViewController:didShowPhaseIndex:)]) {
+                NSInteger phaseIndex = ((NSNumber *)pageIndices[currentPageIndex]).integerValue;
+                [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:phaseIndex];
             }
             
             //register ScrollView to update hairline

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -50,12 +50,6 @@
 #import "UIBarButtonItem+ORKBarButtonItem.h"
 
 
-typedef NS_ENUM(NSInteger, ORKConsentReviewPhase) {
-    ORKConsentReviewPhaseName,
-    ORKConsentReviewPhaseReviewDocument,
-    ORKConsentReviewPhaseSignature
-};
-
 @interface ORKConsentReviewStepViewController () <UIPageViewControllerDelegate, ORKStepViewControllerDelegate, ORKConsentReviewControllerDelegate> {
     ORKConsentSignature *_currentSignature;
     UIPageViewController *_pageViewController;
@@ -381,9 +375,9 @@ static NSString *const _SignatureStepIdentifier = @"signatureStep";
             NSUInteger currentPageIndex = strongSelf->_currentPageIndex;
             NSArray *pageIndices = strongSelf->_pageIndices;
             if (currentPageIndex < pageIndices.count
-                && [[strongSelf consentReviewDelegate] respondsToSelector:@selector(consentReviewStepViewController:didShowPhaseIndex:)]) {
-                NSInteger phaseIndex = ((NSNumber *)pageIndices[currentPageIndex]).integerValue;
-                [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhaseIndex:phaseIndex];
+                && [[strongSelf consentReviewDelegate] respondsToSelector:@selector(consentReviewStepViewController:didShowPhase:pageIndex:)]) {
+                ORKConsentReviewPhase phase = ((NSNumber *)pageIndices[currentPageIndex]).integerValue;
+                [[strongSelf consentReviewDelegate] consentReviewStepViewController:strongSelf didShowPhase:phase pageIndex:currentPageIndex];
             }
             
             //register ScrollView to update hairline


### PR DESCRIPTION
Fixes a bug in the last pull request #21 

Some substeps or "phases" of consent review are optional; e.g. 
ORKConsentReviewStepViewController. The phases to display are stored in an array, which determines the screens shown to the user. In the original implementation of ORKConsentReviewStepViewControllerDelegate, I was passing the array index rather than the actual phase value. This pull request fixes that, and also passes the page index and phase enum values separately to the delegate, since both have meaning for the analytics tracking we are implementing.

@eschramm 
