### PR TITLE
Allow CEVRKTheme to be pushed to UI elements via notification to ensure visible on first appearance

### DIFF
--- a/ResearchKit/Common/CEVRKTheme.h
+++ b/ResearchKit/Common/CEVRKTheme.h
@@ -8,6 +8,9 @@
 
 @import UIKit;
 
+extern NSNotificationName _Nonnull const CEVORKStepViewControllerViewWillAppearNotification;
+extern NSString * _Nonnull const CEVRKThemeKey;
+
 typedef NS_ENUM(NSInteger, CEVRKThemeType) {
     CEVRKThemeTypeDefault,
     CEVRKThemeTypeAllOfUs

--- a/ResearchKit/Common/CEVRKTheme.m
+++ b/ResearchKit/Common/CEVRKTheme.m
@@ -53,6 +53,22 @@
     }
 }
 
++ (NSString *)themeTitleForType:(CEVRKThemeType)type {
+    switch (type) {
+        case CEVRKThemeTypeDefault:
+            return @"Default Theme";
+            break;
+        case CEVRKThemeTypeAllOfUs:
+            return @"All of Us Theme";
+            break;
+        default:
+            return @"No theme - undefined";
+    }
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<CEVRKTheme: %p : %@>", self, [CEVRKTheme themeTitleForType:_themeType]];
+}
 - (UIFont *)headlineLabelFontWithSize:(CGFloat)fontSize {
     switch (self.themeType) {
         case CEVRKThemeTypeAllOfUs:

--- a/ResearchKit/Common/CEVRKTheme.m
+++ b/ResearchKit/Common/CEVRKTheme.m
@@ -14,6 +14,9 @@
 #import "ORKTaskViewController.h"
 #import "ORKTask.h"
 
+NSNotificationName const CEVORKStepViewControllerViewWillAppearNotification = @"CEVORKStepViewControllerViewWillAppearNotification";
+NSString *const CEVRKThemeKey = @"cev_theme";
+
 @interface CEVRKTheme()
 @property (nonatomic, assign) CEVRKThemeType themeType;
 @end
@@ -40,7 +43,15 @@
     if ([element respondsToSelector:@selector(cev_theme)]) {             // has theme
         id <CEVRKThemedUIElement> themedElement = element;
         CEVRKTheme *theme = [themedElement cev_theme];
-        return theme ?: [CEVRKTheme defaultTheme];
+        if (theme) {                                                     // if theme is null, keep searching
+            return theme;
+        } else if ([element respondsToSelector:@selector(nextResponder)]) {
+            UIResponder *currentResponder = (UIResponder *)element;
+            id nextResponder = [currentResponder nextResponder];
+            return [CEVRKTheme themeForElement:nextResponder];
+        } else {
+            return [CEVRKTheme defaultTheme];
+        }
     } else if ([element isKindOfClass:[ORKStepViewController class]]) {  // is stepViewController, jump to task for theme
         id <ORKTask> task = [(ORKStepViewController *)element taskViewController].task;
         return [CEVRKTheme themeForElement:task];
@@ -69,6 +80,7 @@
 - (NSString *)description {
     return [NSString stringWithFormat:@"<CEVRKTheme: %p : %@>", self, [CEVRKTheme themeTitleForType:_themeType]];
 }
+
 - (UIFont *)headlineLabelFontWithSize:(CGFloat)fontSize {
     switch (self.themeType) {
         case CEVRKThemeTypeAllOfUs:

--- a/ResearchKit/Common/ORKHeadlineLabel.h
+++ b/ResearchKit/Common/ORKHeadlineLabel.h
@@ -32,7 +32,6 @@
 @import UIKit;
 #import "ORKLabel.h"
 
-@class CEVRKTheme;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,8 +42,6 @@ ORK_CLASS_AVAILABLE
 @interface ORKHeadlineLabel : ORKLabel
 
 @property (nonatomic, assign) BOOL useSurveyMode;
-
-@property (nonatomic, strong, nullable) CEVRKTheme *cev_theme;
 
 @end
 

--- a/ResearchKit/Common/ORKHeadlineLabel.h
+++ b/ResearchKit/Common/ORKHeadlineLabel.h
@@ -32,6 +32,7 @@
 @import UIKit;
 #import "ORKLabel.h"
 
+@class CEVRKTheme;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,6 +43,8 @@ ORK_CLASS_AVAILABLE
 @interface ORKHeadlineLabel : ORKLabel
 
 @property (nonatomic, assign) BOOL useSurveyMode;
+
+@property (nonatomic, strong, nullable) CEVRKTheme *cev_theme;
 
 @end
 

--- a/ResearchKit/Common/ORKHeadlineLabel.m
+++ b/ResearchKit/Common/ORKHeadlineLabel.m
@@ -36,6 +36,11 @@
 
 #import "CEVRKTheme.h"
 
+@interface ORKHeadlineLabel()
+
+@property (nonatomic, strong, nullable) CEVRKTheme *cev_theme;
+
+@end
 
 @implementation ORKHeadlineLabel
 
@@ -56,14 +61,18 @@
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
-    [NSNotificationCenter.defaultCenter addObserverForName:CEVORKStepViewControllerViewWillAppearNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
-        CEVRKTheme *theme = note.userInfo[CEVRKThemeKey];
-        if ([theme isKindOfClass:[CEVRKTheme class]]) {
-            self.cev_theme = theme;
-            [self updateAppearance];
-        }
-    }];
-    return [super initWithFrame:frame];
+    self = [super initWithFrame:frame];
+    if (self) {
+        __weak __typeof__(self) weakSelf = self;
+        [NSNotificationCenter.defaultCenter addObserverForName:CEVORKStepViewControllerViewWillAppearNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
+            CEVRKTheme *theme = note.userInfo[CEVRKThemeKey];
+            if ([theme isKindOfClass:[CEVRKTheme class]]) {
+                weakSelf.cev_theme = theme;
+                [weakSelf updateAppearance];
+            }
+        }];
+    }
+    return self;
 }
 
 - (UIFont *)defaultFont {

--- a/ResearchKit/Common/ORKHeadlineLabel.m
+++ b/ResearchKit/Common/ORKHeadlineLabel.m
@@ -39,6 +39,8 @@
 
 @implementation ORKHeadlineLabel
 
+@synthesize cev_theme = _cev_theme;
+
 + (UIFont *)defaultFontInSurveyMode:(BOOL)surveyMode {
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
     const CGFloat defaultHeadlineSize = 17;
@@ -51,6 +53,17 @@
 
 + (UIFont *)defaultFont {
     return [self defaultFontInSurveyMode:NO];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    [NSNotificationCenter.defaultCenter addObserverForName:CEVORKStepViewControllerViewWillAppearNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
+        CEVRKTheme *theme = note.userInfo[CEVRKThemeKey];
+        if ([theme isKindOfClass:[CEVRKTheme class]]) {
+            self.cev_theme = theme;
+            [self updateAppearance];
+        }
+    }];
+    return [super initWithFrame:frame];
 }
 
 - (UIFont *)defaultFont {

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -178,11 +178,6 @@
     [NSNotificationCenter.defaultCenter postNotification:notification];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    
-    [super viewDidAppear:animated];
-}
-
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     _dismissing = YES;

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -42,6 +42,7 @@
 #import "ORKHelpers_Internal.h"
 #import "ORKSkin.h"
 
+#import "CEVRKTheme.h"
 
 @interface ORKStepViewController () {
     BOOL _hasBeenPresented;
@@ -167,6 +168,19 @@
     
     // clear dismissedDate
     self.dismissedDate = nil;
+    
+    // Certain nested UI Elements (e.g., ORKHeadlineLabel) are attached to view hierarchy late in the lifecycle. This can cause a noticable,
+    // unintended animation of state change as the view animates into view. Posting this notification and handling theme application upon
+    // receipt can ensure a redraw cycle of the receiving element can "see" the theme prior to being inside the responder chain so the first
+    // displayed draw is the expected theme.
+    NSDictionary *userInfo = @{CEVRKThemeKey : [CEVRKTheme themeForElement:self]};
+    NSNotification *notification = [NSNotification notificationWithName:CEVORKStepViewControllerViewWillAppearNotification object:nil userInfo:userInfo];
+    [NSNotificationCenter.defaultCenter postNotification:notification];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    
+    [super viewDidAppear:animated];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/164. An ideal fix would allow for the theme to be visible/applied by the time the last draw completes before the view appears to the user. The difficulty with the `ORKHeadlineLabel` is that it is nested several layers deep in the view hierarchy and when it is init'd, it has no superview and its superview is still not in the view hierarchy. This prevents a dependency injection approach where we could pass the theme down to descendants.

Per previous discussion, I really wanted to avoid a global theme which could have be a source of future technical debt.

This approach, while not perfect, allows the `viewWillAppear` of the `ORKStepViewController` to trigger a notification with it's theme which could be received by UI elements like `ORKHeadlineLabel` where the responder chain isn't fully linked to the theme by the last draw before display. This is less likely to have regression bugs versus attempting to force an additional redraw between the last redraw and the view appearance. And while it does have global ramifications as theoretically there could be multiple step view controllers in memory which could receive the notification, at this point I can't conceive of a situation where we'd ever want multiple step view controllers appearing simultaneously with different themes.