### PR TITLE
Add highlight state to ORKContinueButton

### DIFF
--- a/ResearchKit/Common/CEVRKTheme.m
+++ b/ResearchKit/Common/CEVRKTheme.m
@@ -166,7 +166,11 @@ NSString *const CEVRKThemeKey = @"cev_theme";
             
             CAGradientLayer *gradient = [[CAGradientLayer alloc] init];
             gradient.frame = continueButton.bounds;
-            gradient.colors = @[(id)ORKRGB(0xf38d7a).CGColor, (id)ORKRGB(0xf8c954).CGColor];
+            if (continueButton.highlighted || continueButton.selected) {
+                gradient.colors = @[(id)ORKRGB(0xcd6754).CGColor, (id)ORKRGB(0xd2a32e).CGColor];
+            } else {
+                gradient.colors = @[(id)ORKRGB(0xf38d7a).CGColor, (id)ORKRGB(0xf8c954).CGColor];
+            }
             gradient.startPoint = CGPointMake(0, 0);
             gradient.endPoint = CGPointMake(1, 0);
             gradient.cornerRadius = 5.0f;


### PR DESCRIPTION
Make the colors 15% darker on highlight.
<img width="508" alt="Screen Shot 2019-08-21 at 11 13 14 AM" src="https://user-images.githubusercontent.com/758035/63456900-c70de280-c404-11e9-9404-8b84a43eb672.png">
<img width="396" alt="Screen Shot 2019-08-21 at 11 13 22 AM" src="https://user-images.githubusercontent.com/758035/63456901-c7a67900-c404-11e9-88d8-658046ce1b64.png">

