### PR TITLE
Add support for preloading webview steps

### DIFF
--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -34,6 +34,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ORKWebViewPreloader: NSObject
++ (instancetype)shared;
+- (void)preload:(NSString *)htmlString forKey:(NSString *)key;
+- (WKWebView *)webViewForKey:(NSString *)key;
+@end
+
 /**
  The `ORKWebViewStepViewController` class is a step view controller subclass
  used to manage a web view step (`ORKWebViewStep`).

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -33,9 +33,77 @@
 #import <ResearchKit/ORKResult.h>
 @import SafariServices;
 
+@implementation ORKWebViewPreloader {
+    NSCache *_cache;
+}
+
++ (instancetype)shared {
+    static ORKWebViewPreloader *shared;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        shared = [[ORKWebViewPreloader alloc] init];
+    });
+    return shared;
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _cache = [[NSCache alloc] init];
+        _cache.countLimit = 1;
+    }
+    return self;
+}
+
+- (void)preload:(NSString *)htmlString forKey:(NSString *)key {
+    WKWebView *webView = [self newWebView:htmlString];
+    [_cache setObject:webView forKey:key];
+}
+
+- (WKWebView *)webViewForKey:(NSString *)key {
+    WKWebView *webView = [_cache objectForKey:key];
+    [_cache removeObjectForKey:key];
+    if (webView == nil) {
+        webView = [self newWebView:nil];
+    }
+    return webView;
+}
+
+- (WKWebView *)newWebView:(NSString *)htmlString {
+    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+    config.allowsInlineMediaPlayback = true;
+    if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
+        config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+    }
+    WKUserContentController *controller = [[WKUserContentController alloc] init];
+    config.userContentController = controller;
+    
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
+    if (htmlString) {
+        [webView loadHTMLString:htmlString baseURL:nil];
+    }
+    return webView;
+}
+
+@end
+
 @implementation ORKWebViewStepViewController {
     WKWebView *_webView;
     NSString *_result;
+}
+
+- (instancetype)initWithStep:(ORKStep *)step {
+    self = [super initWithStep:step];
+    if (self) {
+        _webView = [[ORKWebViewPreloader shared] webViewForKey:step.identifier];
+        [_webView.configuration.userContentController addScriptMessageHandler:self name:@"ResearchKit"];
+        _webView.frame = self.view.bounds;
+        _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _webView.navigationDelegate = self;
+        [_webView loadHTMLString:[self webViewStep].html baseURL:nil];
+        [self.view addSubview:_webView];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    }
+    return self;
 }
 
 - (ORKWebViewStep *)webViewStep {
@@ -44,33 +112,7 @@
 
 - (void)stepDidChange {
     _result = nil;
-    [_webView removeFromSuperview];
-    _webView = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
-    
-    if (self.step && [self isViewLoaded]) {
-        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-        config.allowsInlineMediaPlayback = true;
-        if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
-            config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-        }
-        WKUserContentController *controller = [[WKUserContentController alloc] init];
-        [controller addScriptMessageHandler:self name:@"ResearchKit"];
-        config.userContentController = controller;
-        
-        _webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
-        _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        _webView.navigationDelegate = self;
-        [self.view addSubview:_webView];
-        
-        [_webView loadHTMLString:[self webViewStep].html baseURL:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
-    }
-}
-
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self stepDidChange];
+    [_webView loadHTMLString:[self webViewStep].html baseURL:nil];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
Adds a ORKWebViewPreloader object that preloads webpages. When the step is ready to be displayed the ORKWebViewController will need to load the page again (because of the new step results), however the webview will be warmed up and display the page faster.