### PR TITLE
Implement autoAgree to jump directly to signature

### DIFF
--- a/ResearchKit/Common/ORKVerticalContainerView.m
+++ b/ResearchKit/Common/ORKVerticalContainerView.m
@@ -58,6 +58,9 @@ static const CGFloat AssumedStatusBarHeight = 20;
     - continueSkipContainer
  */
 
+@interface ORKVerticalContainerView () <UIScrollViewDelegate>
+@end
+
 @implementation ORKVerticalContainerView {
     UIView *_scrollContainer;
     UIView *_container;

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -102,6 +102,11 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic) BOOL requiresScrollToBottom;
 
 /**
+ When set to YES, the consent document is not displayed and the user is sent straight to a signature.
+ */
+@property (nonatomic) BOOL autoAgree;
+
+/**
  A user-visible description of the reason for agreeing to consent in a localized string.
  
  The reason for consent is presented in the confirmation dialog that users see when giving their consent.

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -53,6 +53,7 @@
         _consentDocument = consentDocument;
         _signature = signature;
         _requiresScrollToBottom = NO;
+        _autoAgree = NO;
     }
     return self;
 }
@@ -63,6 +64,7 @@
     step->_signature = self.signature;
     step->_reasonForConsent = self.reasonForConsent;
     step->_requiresScrollToBottom = self.requiresScrollToBottom;
+    step->_autoAgree = self.autoAgree;
     return step;
 }
 
@@ -73,6 +75,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, signature, ORKConsentSignature);
         ORK_DECODE_OBJ_CLASS(aDecoder, reasonForConsent, NSString);
         ORK_DECODE_BOOL(aDecoder, requiresScrollToBottom);
+        ORK_DECODE_BOOL(aDecoder, autoAgree);
     }
     return self;
 }
@@ -83,6 +86,7 @@
     ORK_ENCODE_OBJ(aCoder, signature);
     ORK_ENCODE_OBJ(aCoder, reasonForConsent);
     ORK_ENCODE_BOOL(aCoder, requiresScrollToBottom);
+    ORK_ENCODE_BOOL(aCoder, autoAgree);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -97,11 +101,12 @@
             ORKEqualObjects(self.consentDocument, castObject.consentDocument) &&
             ORKEqualObjects(self.signature, castObject.signature) &&
             ORKEqualObjects(self.reasonForConsent, castObject.reasonForConsent)) &&
-            (self.requiresScrollToBottom == castObject.requiresScrollToBottom);
+            (self.requiresScrollToBottom == castObject.requiresScrollToBottom) &&
+            (self.autoAgree == castObject.autoAgree);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0);
+    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xf : 0x0);
 }
 
 - (BOOL)showsProgress {

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -106,7 +106,7 @@
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xf : 0x0);
+    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xe : 0x1);
 }
 
 - (BOOL)showsProgress {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -92,7 +92,7 @@
     _currentPageIndex = NSNotFound;
     ORKConsentReviewStep *step = [self consentReviewStep];
     NSMutableArray *indices = [NSMutableArray array];
-    if (step.consentDocument) {
+    if (step.consentDocument && !step.autoAgree) {
         [indices addObject:@(ORKConsentReviewPhaseReviewDocument)];
     }
     if (step.signature.requiresName) {


### PR DESCRIPTION
See [discussion](https://github.com/CareEvolution/Consumers/issues/7511) about adding a feature which allows the skipping of the review & agree step in the ConsentReviewStep flow.