### PR TITLE
Fix warnings in documentation

### DIFF
--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -396,7 +396,6 @@ ORK_CLASS_AVAILABLE
 /**
  Returns a new step modifier.
  
- @param stepIdentifier    The step identifier for the step to modify
  @param resultPredicate   The result predicate to use to determine if the step should be modified
  @param keyValueMap       The mapping dictionary for this object
  @return                  A new step modifier

--- a/ResearchKit/ORKDeprecated.h
+++ b/ResearchKit/ORKDeprecated.h
@@ -95,7 +95,7 @@ __attribute__((deprecated("Use 'validationRegularExpression' instead.",
  @param identifier                  The string that identifies the step (see `ORKStep`).
  @param title                       The title of the form (see `ORKStep`).
  @param text                        The text shown immediately below the title (see `ORKStep`).
- @param passcodeValidationRegex     The regular expression pattern used to validate the passcode form item (see `ORKTextAnswerFormat`).
+ @param passcodeValidationRegularExpressionPattern     The regular expression pattern used to validate the passcode form item (see `ORKTextAnswerFormat`).
  @param passcodeInvalidMessage      The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
  @param options                     The options used for the step (see `ORKRegistrationStepOption`).
   


### PR DESCRIPTION
Just cleans up some warnings that pop up whenever you compile other projects that have a ResearchKit dependency exposed via an Objective-C bridging header:

<img width="263" alt="Screen Shot 2019-10-31 at 3 14 15 PM" src="https://user-images.githubusercontent.com/2637734/67978811-4a139c00-fbf1-11e9-82ea-e038c634188c.png">

