### PR TITLE
ORKResultPredicates for ORKWebViewStepResult

### DIFF
--- a/ResearchKit/Common/ORKResultPredicate.h
+++ b/ResearchKit/Common/ORKResultPredicate.h
@@ -373,6 +373,32 @@ ORK_CLASS_AVAILABLE
                                                   matchingPattern:(NSString *)pattern;
 
 /**
+ Returns a predicate matching a result of type `ORKWebViewStepResult` whose result is equal to the
+ specified string.
+ 
+ @param resultSelector      The result selector object which specifies the step result you are
+                                interested in.
+ @param expectedString      The expected result string.
+ 
+ @return A result predicate.
+ */
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                  expectedString:(NSString *)expectedString;
+
+/**
+ Returns a predicate matching a result of type `ORKWebViewStepResult` whose result matches the
+ specified regular expression pattern.
+ 
+ @param resultSelector      The result selector object which specifies the step result you are
+                                interested in.
+ @param pattern             An ICU-compliant regular expression pattern that matches the result string.
+ 
+ @return A result predicate.
+ */
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                 matchingPattern:(NSString *)pattern;
+
+/**
  Returns a predicate matching a result of type `ORKNumericQuestionResult` whose answer is the
  specified integer value.
  

--- a/ResearchKit/Common/ORKResultPredicate.m
+++ b/ResearchKit/Common/ORKResultPredicate.m
@@ -352,6 +352,22 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
                  subPredicateFormatArgumentArray:@[ pattern ]];
 }
 
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                  expectedString:(NSString *)expectedString {
+    ORKThrowInvalidArgumentExceptionIfNil(expectedString);
+    return [self predicateMatchingResultSelector:resultSelector
+                         subPredicateFormatArray:@[ @"result == %@" ]
+                 subPredicateFormatArgumentArray:@[ expectedString ]];
+}
+
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                 matchingPattern:(NSString *)pattern {
+    ORKThrowInvalidArgumentExceptionIfNil(pattern);
+    return [self predicateMatchingResultSelector:resultSelector
+                         subPredicateFormatArray:@[ @"result matches %@" ]
+                 subPredicateFormatArgumentArray:@[ pattern ]];
+}
+
 + (NSPredicate *)predicateForNumericQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector
                                                       expectedAnswer:(NSInteger)expectedAnswer {
     return [self predicateMatchingResultSelector:resultSelector

--- a/ResearchKitTests/ORKConsentDocumentTests.m
+++ b/ResearchKitTests/ORKConsentDocumentTests.m
@@ -133,7 +133,7 @@ body, p, h1, h2, h3 { font-family: Helvetica; }\n\
 - (void)testMakePDFWithCompletionHandler_withHTMLReviewContent_callsWriterWithCorrectHTML {
     self.document.htmlReviewContent = @"some content";
     [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {}];
-    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:@"some content"]);
+    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:@"some content" mobile:NO]);
 }
 
 - (void)testMakePDFWithCompletionHandler_withoutHTMLReviewContent_callsWriterWithCorrectHTML {
@@ -158,7 +158,7 @@ body, p, h1, h2, h3 { font-family: Helvetica; }\n\
                         @"html for signature";
 
     [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {}];
-    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:content]);
+    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:content mobile:NO]);
 }
 
 - (void)testMakePDFWithCompletionHandler_whenWriterReturnsData_callsCompletionBlockWithData {


### PR DESCRIPTION
For https://github.com/CareEvolution/CEVResearchKit/issues/128

Almost identical to the ORKTextQuestionResult predicates. I ran into a unit test compilation failure, the ORKConsentDocumentTests.m changes address that. I'll also make a separate branch off of master and contribute a PR to the main ResearchKit fork.