### PR TITLE
Revert JavaScript message handler name change with ORK1Kit work

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -95,7 +95,7 @@
     self = [super initWithStep:step];
     if (self) {
         _webView = [[ORK1WebViewPreloader shared] webViewForKey:step.identifier];
-        [_webView.configuration.userContentController addScriptMessageHandler:self name:@"ORK1Kit"];
+        [_webView.configuration.userContentController addScriptMessageHandler:self name:@"ResearchKit"];
         _webView.frame = self.view.bounds;
         _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _webView.navigationDelegate = self;


### PR DESCRIPTION
Regression bug with new ORK1 renaming. The message handler should be named "ResearchKit" in both RK1/RK2 and we don't want to break current surveys.