### PR TITLE
Fix NSSecureCoding in ORKConsentDocument

### DIFF
--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.m
@@ -215,7 +215,7 @@
         ORK1_DECODE_OBJ_CLASS(aDecoder, signaturePageTitle, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, signaturePageContent, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, htmlReviewContent, NSString);
-        NSArray *signatures = (NSArray *)[aDecoder decodeObjectOfClass:[NSArray class] forKey:@"signatures"];
+        NSArray *signatures = (NSArray *)[aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [ORK1ConsentSignature class], nil] forKey:@"signatures"];
         _signatures = [signatures mutableCopy];
         ORK1_DECODE_OBJ_ARRAY(aDecoder, sections, ORK1ConsentSection);
     }

--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -233,7 +233,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, signaturePageTitle, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, signaturePageContent, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, htmlReviewContent, NSString);
-        NSArray *signatures = (NSArray *)[aDecoder decodeObjectOfClass:[NSArray class] forKey:@"signatures"];
+        NSArray *signatures = (NSArray *)[aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [ORKConsentSignature class], nil] forKey:@"signatures"];
         _signatures = [signatures mutableCopy];
         ORK_DECODE_OBJ_ARRAY(aDecoder, sections, ORKConsentSection);
     }


### PR DESCRIPTION
In order to support NSSecureCoding, all decoded classes need to be provided including NSArray's object type and NSDictionary's key and value types.