### PR TITLE
Fix MyDataHelps: Discrete scale text cut off screen on ioS

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ScaleSliderView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ScaleSliderView.m
@@ -112,10 +112,12 @@
             
             _leftRangeDescriptionLabel = [[ORK1ScaleRangeDescriptionLabel alloc] initWithFrame:CGRectZero];
             _leftRangeDescriptionLabel.numberOfLines = -1;
+            _leftRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:_leftRangeDescriptionLabel];
             
             _rightRangeLabel = [[ORK1ScaleRangeLabel alloc] initWithFrame:CGRectZero];
             _rightRangeLabel.textAlignment = NSTextAlignmentCenter;
+            _rightRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:_rightRangeLabel];
             
             _rightRangeDescriptionLabel = [[ORK1ScaleRangeDescriptionLabel alloc] initWithFrame:CGRectZero];
@@ -174,8 +176,6 @@
             _rightRangeView.translatesAutoresizingMaskIntoConstraints = NO;
             _leftRangeLabel.translatesAutoresizingMaskIntoConstraints = NO;
             _rightRangeLabel.translatesAutoresizingMaskIntoConstraints = NO;
-            _leftRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
-            _rightRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
         }
         
         self.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
Manually cherry-pick changes from https://github.com/ResearchKit/ResearchKit/commit/774e638ca779560f236cb471113f93760afc01c2 / https://github.com/ResearchKit/ResearchKit/issues/1043

FIxes https://github.com/CareEvolution/RKStudio-Participant/issues/623