### PR TITLE
Update font of text choice items to be bold, larger and regular-cased

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormSectionTitleLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormSectionTitleLabel.m
@@ -35,9 +35,9 @@
 @implementation ORK1FormSectionTitleLabel
 
 + (UIFont *)defaultFont {
-    // regular, 14
+    // bold, 17
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
-    return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - 3.0];
+    return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - 0.0 weight: UIFontWeightBold];
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -156,7 +156,7 @@
 }
 
 - (void)setTitle:(NSString *)title {
-    _title = [[title uppercaseStringWithLocale:[NSLocale currentLocale]] copy];
+    _title = title;
 }
 
 - (void)addFormItem:(ORK1FormItem *)item {

--- a/ORK1Kit/ORK1Kit/Common/ORK1SelectionTitleLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SelectionTitleLabel.m
@@ -37,10 +37,10 @@
 @implementation ORK1SelectionTitleLabel
 
 + (UIFont *)defaultFont {
-    // medium, 17. Increased by 1 due review feedback.
+    // regular, 17. Increased by 1 due review feedback.
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
     const CGFloat defaultSize = 17;
-    return ORK1MediumFontWithSize([[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] + 18 - defaultSize);
+    return [UIFont systemFontOfSize:([[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] + 18 - defaultSize)];
 }
 
 @end


### PR DESCRIPTION
Updated text choice header to bold 17point font. The other headers use a 17 point medium font (see Text and Numeric labels below). Using a medium font for the text choice header caused it to blend in with the choices themselves. Fixes https://github.com/CareEvolution/CEVResearchKit/issues/195

@chrisnowak 

![Screen Shot 2020-01-27 at 1 45 54 PM](https://user-images.githubusercontent.com/758035/73216726-5ed9d000-410b-11ea-86d5-12fd28a32983.png)
![Screen Shot 2020-01-27 at 1 32 02 PM](https://user-images.githubusercontent.com/758035/73216123-3dc4af80-410a-11ea-8391-aa914a1a6878.png)
