### PR TITLE
Disable scrolling for contentHeight ~ scrollViewHeight

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -756,6 +756,20 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     _dismissedDate = nil;
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    /*
+       CEV HACK: due to a strange constraint hack in ORKVerticalContainerView, the _registeredScrollView content size will
+       always be 0.3 points larger than its size if ORKVerticalContainerView.scrollContainerShouldCollapseNavbar is NO. This
+       then enables the scrollView "bouncing" which can be disruptive if it's not needed.
+    */
+    if ((_registeredScrollView.contentSize.height - _registeredScrollView.frame.size.height) < 1) {
+        _registeredScrollView.scrollEnabled = NO;
+    } else {
+        _registeredScrollView.scrollEnabled = YES;
+    }
+}
+
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
     

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -758,16 +758,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    /*
-       CEV HACK: due to a strange constraint hack in ORKVerticalContainerView, the _registeredScrollView content size will
-       always be 0.3 points larger than its size if ORKVerticalContainerView.scrollContainerShouldCollapseNavbar is NO. This
-       then enables the scrollView "bouncing" which can be disruptive if it's not needed.
-    */
-    if ((_registeredScrollView.contentSize.height - _registeredScrollView.frame.size.height) < 1) {
-        _registeredScrollView.scrollEnabled = NO;
-    } else {
-        _registeredScrollView.scrollEnabled = YES;
-    }
+    [self fixScrollable];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -777,6 +768,19 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     // because nextResponder is not nil when current TaskVC is covered by another modal view
     if (self.nextResponder == nil) {
         _dismissedDate = [NSDate date];
+    }
+}
+
+- (void)fixScrollable {
+    /*
+       CEV HACK: due to a strange constraint hack in ORKVerticalContainerView, the _registeredScrollView content size will
+       always be 0.3 points larger than its size if ORKVerticalContainerView.scrollContainerShouldCollapseNavbar is NO. This
+       then enables the scrollView "bouncing" which can be disruptive if it's not needed.
+    */
+    if ((_registeredScrollView.contentSize.height - _registeredScrollView.frame.size.height) < 1) {
+        _registeredScrollView.scrollEnabled = NO;
+    } else {
+        _registeredScrollView.scrollEnabled = YES;
     }
 }
 
@@ -1086,6 +1090,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         
         // Collect toolbarItems
         [strongSelf collectToolbarItemsFromViewController:viewController];
+        
+        [strongSelf fixScrollable];
     }];
 }
 
@@ -1447,7 +1453,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         [self setManagedResult:[stepViewController result] forKey:stepViewController.step.identifier];
     }
     
-    // Alert the delegate that the step is finished 
+    // Alert the delegate that the step is finished
     ORKStrongTypeOf(self.delegate) strongDelegate = self.delegate;
     if ([strongDelegate respondsToSelector:@selector(taskViewController:stepViewControllerWillDisappear:navigationDirection:)]) {
         [strongDelegate taskViewController:self stepViewControllerWillDisappear:stepViewController navigationDirection:direction];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -775,9 +775,10 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     /*
        CEV HACK: due to a strange constraint hack in ORKVerticalContainerView, the _registeredScrollView content size will
        always be 0.3 points larger than its size if ORKVerticalContainerView.scrollContainerShouldCollapseNavbar is NO. This
-       then enables the scrollView "bouncing" which can be disruptive if it's not needed.
+       then enables the scrollView "bouncing" which can be disruptive if it's not needed. But let's not do this for Form
+       Steps since those should behave like a normal UITableView
     */
-    if ((_registeredScrollView.contentSize.height - _registeredScrollView.frame.size.height) < 1) {
+    if ((_registeredScrollView.contentSize.height - _registeredScrollView.frame.size.height) < 1 && ![_registeredScrollView isKindOfClass:[UITableView class]]) {
         _registeredScrollView.scrollEnabled = NO;
     } else {
         _registeredScrollView.scrollEnabled = YES;


### PR DESCRIPTION
This fixes a strange phenomenon seen in RK2 where scrollViews inside the `ORKTaskViewController` bounce even if there really isn't scrollable content. 

|BEFORE|AFTER|
|----|----|
|![scrolling](https://user-images.githubusercontent.com/1008462/73493558-9ac59d00-4378-11ea-8864-243dcce23e9a.gif)|![fixed](https://user-images.githubusercontent.com/1008462/73493576-a0bb7e00-4378-11ea-99e6-80f8487b72d8.gif)|

