### PR TITLE
Ordering fix for ORK1ScaleSlider

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ScaleSliderView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ScaleSliderView.m
@@ -117,11 +117,11 @@
             
             _rightRangeLabel = [[ORK1ScaleRangeLabel alloc] initWithFrame:CGRectZero];
             _rightRangeLabel.textAlignment = NSTextAlignmentCenter;
-            _rightRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:_rightRangeLabel];
             
             _rightRangeDescriptionLabel = [[ORK1ScaleRangeDescriptionLabel alloc] initWithFrame:CGRectZero];
             _rightRangeDescriptionLabel.numberOfLines = -1;
+            _rightRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:_rightRangeDescriptionLabel];
             
             if (textChoices) {


### PR DESCRIPTION
Caught this in running UITests in CEVResearchKit on latest `CEVRelease-2.x`. In #46, the cherry pick merge put this line before the initialization so this was setting on nil.