### PR TITLE
Fix skip nav rule bug - resignFirstResponder BEFORE nav to next step

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -836,6 +836,18 @@
     [super skipForward];
 }
 
+- (void)goForward {
+    /*
+    CEV HACK - Cell should resign any firstResponder text fields to prevent a race condition where
+    navigation writes result data to internal cache (_managedResults on ORK1TaskViewController)
+    first, then during tear down the firstResponder is resigned to a text field rewriting the
+    answer marking the original answer as isPreviousResult == YES which breaks skip navigation rules
+    in certain scenarios (answer on Q1 to skip Q3 doesn't skip Q3).
+    */
+    [_currentFirstResponderCell resignFirstResponder];
+    [super goForward];
+}
+
 - (void)goBackward {
     if (self.isBeingReviewed) {
         self.savedAnswers = [[NSMutableDictionary alloc] initWithDictionary:self.originalAnswers];

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
@@ -652,7 +652,7 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
     if (![self shouldContinue]) {
         return;
     }
-    
+    [[self answerCell] stepIsNavigatingForward];
     [self notifyDelegateOnResultChange];
     [super goForward];
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCell.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCell.h
@@ -90,6 +90,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)showValidityAlertWithTitle:(NSString *)title message:(NSString *)message;
 
+/*
+ CEV HACK - Cell should resign any firstResponder text fields to prevent a race condition where
+ navigation writes result data to internal cache (_managedResults on ORK1TaskViewController)
+ first, then during tear down the firstResponder is resigned to a text field rewriting the
+ answer marking the original answer as isPreviousResult == YES which breaks skip navigation rules
+ in certain scenarios (answer on Q1 to skip Q3 doesn't skip Q3).
+ */
+- (void)stepIsNavigatingForward;
+
 // Get full width layout for some subclass cells 
 + (NSLayoutConstraint *)fullWidthLayoutConstraint:(UIView *)view;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForNumber.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForNumber.m
@@ -180,6 +180,10 @@
     self.textField.text = displayValue;
 }
 
+- (void)stepIsNavigatingForward {
+    [_textFieldView.textField resignFirstResponder];
+}
+
 #pragma mark - UITextFieldDelegate
 
 - (void)valueFieldDidChange:(UITextField *)textField {

--- a/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
@@ -279,6 +279,10 @@
     [self ork_setAnswer:text.length ? text : ORK1NullAnswerValue()];
 }
 
+- (void)stepIsNavigatingForward {
+    [_textField resignFirstResponder];
+}
+
 #pragma mark - UITextFieldDelegate
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/205. In testing (in RK1 only) this situation could be consistently reproduced with survey in the linked issue which has a skip navigation rule from a step 2 steps before it AND the keyboard remains on screen when the Next button is tapped.

Did not observe the issue with backwards navigation.

In further testing, found that Form Steps also have the same problem and fixed that as well.