### PR TITLE
RK2: Adjust view for Normalized Reaction Time on smaller screen

### DIFF
--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
@@ -51,9 +51,9 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
     if (self) {
         self.translatesAutoresizingMaskIntoConstraints = NO;
         [self resizeConstraints];
+        [self addButton];
         [self addStimulusView];
         [self addBackgroundView];
-        [self addButton];
     }
     return self;
 }
@@ -98,17 +98,24 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
         [NSLayoutConstraint constraintWithItem:_button
                                      attribute:NSLayoutAttributeCenterX
                                      relatedBy:NSLayoutRelationEqual
-                                        toItem:self                                     attribute:NSLayoutAttributeCenterX
+                                        toItem:self
+                                     attribute:NSLayoutAttributeCenterX
                                     multiplier:1.0
                                       constant:0.0],
         [NSLayoutConstraint constraintWithItem:_button
-                                     attribute:NSLayoutAttributeTop
+                                     attribute:NSLayoutAttributeBottom
                                      relatedBy:NSLayoutRelationEqual
-                                        toItem:_backgroundView
+                                        toItem:self
                                      attribute:NSLayoutAttributeBottom
                                     multiplier:1.0
-                                      constant:1.0],
-
+                                      constant:20],
+        [NSLayoutConstraint constraintWithItem:self
+                                     attribute:NSLayoutAttributeHeight
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:nil
+                                     attribute:NSLayoutAttributeNotAnAttribute
+                                    multiplier:1
+                                      constant:NormalizeButtonSize * 3]
     ]];
 
 }
@@ -158,18 +165,13 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
                                                        multiplier:1.0
                                                          constant:0.0]];
     
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:_stimulusView
-                                                        attribute:NSLayoutAttributeCenterY
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:_button
+                                                        attribute:NSLayoutAttributeTop
                                                         relatedBy:NSLayoutRelationEqual
-                                                           toItem:self
-                                                        attribute:NSLayoutAttributeCenterY
+                                                           toItem:_stimulusView
+                                                        attribute:NSLayoutAttributeBottom
                                                        multiplier:1.0
-                                                         constant:0.0]];
-    
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_stimulusView]-(>=0)-|"
-                                                                             options:NSLayoutFormatAlignAllCenterX
-                                                                             metrics:nil
-                                                                               views:NSDictionaryOfVariableBindings(_stimulusView)]];
+                                                         constant:NormalizeButtonSize * 0.5 + 7.0]];
     
     [NSLayoutConstraint activateConstraints:constraints];
 }
@@ -185,12 +187,12 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
                                                                    multiplier:1.0
                                                                      constant:0.0],
                                        [NSLayoutConstraint constraintWithItem:_backgroundView
-                                                                    attribute:NSLayoutAttributeCenterY
+                                                                    attribute:NSLayoutAttributeBottom
                                                                     relatedBy:NSLayoutRelationEqual
-                                                                       toItem:_stimulusView
-                                                                    attribute:NSLayoutAttributeCenterY
+                                                                       toItem:_button
+                                                                    attribute:NSLayoutAttributeTop
                                                                    multiplier:1.0
-                                                                     constant:0.0],
+                                                                     constant:-2.0],
                                        [NSLayoutConstraint constraintWithItem:_backgroundView
                                                                     attribute:NSLayoutAttributeWidth
                                                                     relatedBy:NSLayoutRelationEqual


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/210.

The unintended consequence of allowing overrides on the instruction text does not allow for movement of the test view contents. Here we rearrange constraints to pin to the bottom of the view. Fits decently along device sizes with example instruction text.

Thanks @jbornemeier for reporting :)

|iPhone 11|iPhone 8|iPhone SE|iPad Pro 12.9"|
|---|---|---|---|
|![Simulator Screen Shot - iPhone 11 - 2020-03-20 at 15 25 22](https://user-images.githubusercontent.com/1008462/77203687-0695cd80-6abf-11ea-97cb-efed6a18b3b4.png)|![Simulator Screen Shot - iPhone 8 - 2020-03-20 at 14 27 48](https://user-images.githubusercontent.com/1008462/77203583-c20a3200-6abe-11ea-86ee-d42d644343e7.png)|![Simulator Screen Shot - iPhone SE - 2020-03-20 at 15 24 27](https://user-images.githubusercontent.com/1008462/77203650-ec5bef80-6abe-11ea-8768-be6d034689af.png)|![Simulator Screen Shot - iPad Pro (12 9-inch) (2nd generation) - 2020-03-20 at 15 13 38](https://user-images.githubusercontent.com/1008462/77203574-bc145100-6abe-11ea-897d-529b2c450453.png)|
