### PR TITLE
Implement InfoButton for ORKTextChoice

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
@@ -797,6 +797,11 @@ ORK1_CLASS_AVAILABLE
  */
 @property (copy, readonly) NSArray<ORK1TextChoice *> *textChoices;
 
+/**
+The description style of the question (that is, none, display always or display when expanded).
+*/
+@property ORK1ChoiceDescriptionStyle descriptionStyle;
+
 @end
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -1003,7 +1003,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
 
 + (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
     ORK1TextChoice *option = [[ORK1TextChoice alloc] initWithText:text detailText:detailText value:value exclusive:exclusive];
-    option.detailTextShouldDisplay = YES;
+    option.detailTextShouldDisplay = NO;
     return option;
 }
 
@@ -1018,7 +1018,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
         _detailText = [detailText copy];
         _value = value;
         _exclusive = exclusive;
-        _detailTextShouldDisplay = YES;
+        _detailTextShouldDisplay = NO;
     }
     return self;
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -1041,8 +1041,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     return (ORK1EqualObjects(self.text, castObject.text)
             && ORK1EqualObjects(self.detailText, castObject.detailText)
             && ORK1EqualObjects(self.value, castObject.value)
-            && self.exclusive == castObject.exclusive
-            && self.detailTextShouldDisplay == castObject.detailTextShouldDisplay);
+            && self.exclusive == castObject.exclusive);
 }
 
 - (NSUInteger)hash {
@@ -1057,7 +1056,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
         ORK1_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK1_DECODE_OBJ(aDecoder, value);
         ORK1_DECODE_BOOL(aDecoder, exclusive);
-        ORK1_DECODE_BOOL(aDecoder, detailTextShouldDisplay);
+        _detailTextShouldDisplay = NO;
     }
     return self;
 }
@@ -1067,7 +1066,6 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     ORK1_ENCODE_OBJ(aCoder, value);
     ORK1_ENCODE_OBJ(aCoder, detailText);
     ORK1_ENCODE_BOOL(aCoder, exclusive);
-    ORK1_ENCODE_BOOL(aCoder, detailTextShouldDisplay);
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -1003,6 +1003,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
 
 + (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
     ORK1TextChoice *option = [[ORK1TextChoice alloc] initWithText:text detailText:detailText value:value exclusive:exclusive];
+    option.detailTextShouldDisplay = YES;
     return option;
 }
 
@@ -1017,6 +1018,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
         _detailText = [detailText copy];
         _value = value;
         _exclusive = exclusive;
+        _detailTextShouldDisplay = YES;
     }
     return self;
 }
@@ -1039,7 +1041,8 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     return (ORK1EqualObjects(self.text, castObject.text)
             && ORK1EqualObjects(self.detailText, castObject.detailText)
             && ORK1EqualObjects(self.value, castObject.value)
-            && self.exclusive == castObject.exclusive);
+            && self.exclusive == castObject.exclusive
+            && self.detailTextShouldDisplay == castObject.detailTextShouldDisplay);
 }
 
 - (NSUInteger)hash {
@@ -1054,6 +1057,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
         ORK1_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK1_DECODE_OBJ(aDecoder, value);
         ORK1_DECODE_BOOL(aDecoder, exclusive);
+        ORK1_DECODE_BOOL(aDecoder, detailTextShouldDisplay);
     }
     return self;
 }
@@ -1063,6 +1067,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     ORK1_ENCODE_OBJ(aCoder, value);
     ORK1_ENCODE_OBJ(aCoder, detailText);
     ORK1_ENCODE_BOOL(aCoder, exclusive);
+    ORK1_ENCODE_BOOL(aCoder, detailTextShouldDisplay);
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat_Internal.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat_Internal.h
@@ -176,6 +176,12 @@ ORK1_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORK1WeightAnswerFormat)
 
 @interface ORK1TextChoice () <ORK1AnswerOption>
 
+/**
+ Used to store state when ORK1ChoiceDescriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded
+ */
+
+@property (nonatomic) BOOL detailTextShouldDisplay;
+
 @end
 
 @interface ORK1ValuePickerAnswerFormat ()

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
@@ -36,17 +36,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ORK1SelectionTitleLabel;
 @class ORK1SelectionSubTitleLabel;
+@class ORK1TextChoice;
+
+/// This is used when the size of the cell might change and forcing a reload will make the tableview appropriately resize the cell.
+extern NSNotificationName const ORK1UpdateChoiceCell;
+extern NSString const *ORK1UpdateChoiceCellKeyCell;
 
 @interface ORK1ChoiceViewCell : UITableViewCell
 
 @property (nonatomic, strong, readonly) ORK1SelectionTitleLabel *shortLabel;
 @property (nonatomic, strong, readonly) ORK1SelectionSubTitleLabel *longLabel;
+@property (nonatomic, weak) ORK1TextChoice *choice;
 
 + (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText LongText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
 
 @property (nonatomic, assign, getter=isImmediateNavigation) BOOL immediateNavigation;
 
 @property (nonatomic, assign, getter=isSelectedItem) BOOL selectedItem;
+
+@property (nonatomic, assign) BOOL showDetailTextIndicator;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
@@ -43,7 +43,8 @@ NSNotificationName const ORK1UpdateChoiceCell = @"ORK1UpdateChoiceCell";
 NSString const *ORK1UpdateChoiceCellKeyCell = @"ORK1UpdateChoiceCellKeyCell";
 
 static const CGFloat LabelRightMargin = 44.0;
-static const CGFloat DetailTextIndicatorWidth = 15.0;
+static const CGFloat DetailTextIndicatorTouchTargetWidth = 30.0;
+static const CGFloat DetailTextIndicatorImageWidth = 15.0;
 static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
 
@@ -75,7 +76,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
     CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORK1SelectionTitleLabel.defaultFont}].width;
-    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
     
     CGFloat cellHeight = self.bounds.size.height;
     
@@ -86,7 +87,12 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
         self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
-        self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel, self.shortLabel.frame.size.height / 2 - DetailTextIndicatorWidth / 2, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
+        self.detailTextIndicator.frame =
+        CGRectMake(
+                   cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel,
+                   self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2,
+                   DetailTextIndicatorTouchTargetWidth,
+                   DetailTextIndicatorTouchTargetWidth);
         self.longLabel.frame = CGRectZero;
     } else if (self.shortLabel.text.length == 0) {
         self.longLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
@@ -104,7 +110,12 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             
             rect.origin.y = firstBaselineOffsetFromTop - shortLabelFirstBaselineApproximateOffsetFromTop;
             self.shortLabel.frame = rect;
-            self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + 10, self.shortLabel.frame.size.height / 2 + 13, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
+            self.detailTextIndicator.frame =
+            CGRectMake(
+                       cellLeftMargin + shortLabelTextWidth + 10,
+                       self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2 + self.shortLabel.frame.origin.y,
+                       DetailTextIndicatorTouchTargetWidth,
+                       DetailTextIndicatorTouchTargetWidth);
         }
         
         {
@@ -149,6 +160,8 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 - (UIButton *)detailTextIndicator {
     if (_detailTextIndicator == nil) {
         _detailTextIndicator = [UIButton buttonWithType:UIButtonTypeInfoDark];
+        CGFloat inset = (DetailTextIndicatorTouchTargetWidth - DetailTextIndicatorImageWidth) / 2;
+        _detailTextIndicator.imageEdgeInsets = UIEdgeInsetsMake(inset, inset, inset, inset);
         [self.contentView addSubview:_detailTextIndicator];
         [_detailTextIndicator addTarget:self action:@selector(toggleDetailText) forControlEvents:UIControlEventTouchUpInside];
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
@@ -36,16 +36,22 @@
 
 #import "ORK1Accessibility.h"
 #import "ORK1Helpers_Internal.h"
+#import "ORK1AnswerFormat_Internal.h"
 #import "ORK1Skin.h"
 
+NSNotificationName const ORK1UpdateChoiceCell = @"ORK1UpdateChoiceCell";
+NSString const *ORK1UpdateChoiceCellKeyCell = @"ORK1UpdateChoiceCellKeyCell";
 
 static const CGFloat LabelRightMargin = 44.0;
+static const CGFloat DetailTextIndicatorWidth = 15.0;
+static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
 
 @implementation ORK1ChoiceViewCell {
     UIImageView *_checkView;
     ORK1SelectionTitleLabel *_shortLabel;
     ORK1SelectionSubTitleLabel *_longLabel;
+    UIButton *_detailTextIndicator;
 }
 
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
@@ -54,6 +60,7 @@ static const CGFloat LabelRightMargin = 44.0;
         self.clipsToBounds = YES;
         _checkView = [[UIImageView alloc] initWithImage:[[UIImage imageNamed:@"checkmark" inBundle:ORK1Bundle() compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
         self.accessoryView = _checkView;
+        self.showDetailTextIndicator = NO;
     }
     return self;
 }
@@ -67,13 +74,19 @@ static const CGFloat LabelRightMargin = 44.0;
     CGFloat cellLeftMargin = self.separatorInset.left;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
+    CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORK1SelectionTitleLabel.defaultFont}].width;
+    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    
     CGFloat cellHeight = self.bounds.size.height;
+    
+    [self detailTextIndicator].hidden = !self.showDetailTextIndicator;
     
     if (self.longLabel.text.length == 0 && self.shortLabel.text.length == 0) {
         self.shortLabel.frame = CGRectZero;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
         self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
+        self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel, self.shortLabel.frame.size.height / 2 - DetailTextIndicatorWidth / 2, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
         self.longLabel.frame = CGRectZero;
     } else if (self.shortLabel.text.length == 0) {
         self.longLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
@@ -91,6 +104,7 @@ static const CGFloat LabelRightMargin = 44.0;
             
             rect.origin.y = firstBaselineOffsetFromTop - shortLabelFirstBaselineApproximateOffsetFromTop;
             self.shortLabel.frame = rect;
+            self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + 10, self.shortLabel.frame.size.height / 2 + 13, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
         }
         
         {
@@ -130,6 +144,21 @@ static const CGFloat LabelRightMargin = 44.0;
         [self.contentView addSubview:_longLabel];
     }
     return _longLabel;
+}
+
+- (UIButton *)detailTextIndicator {
+    if (_detailTextIndicator == nil) {
+        _detailTextIndicator = [UIButton buttonWithType:UIButtonTypeInfoDark];
+        [self.contentView addSubview:_detailTextIndicator];
+        [_detailTextIndicator addTarget:self action:@selector(toggleDetailText) forControlEvents:UIControlEventTouchUpInside];
+    }
+    return _detailTextIndicator;
+}
+
+- (void)toggleDetailText {
+    self.choice.detailTextShouldDisplay = !self.choice.detailTextShouldDisplay;
+    NSNotification *notification = [NSNotification notificationWithName:ORK1UpdateChoiceCell object:nil userInfo:@{ORK1UpdateChoiceCellKeyCell : self}];
+    [[NSNotificationCenter defaultCenter] postNotification:notification];
 }
 
 - (void)tintColorDidChange {

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
@@ -65,6 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
     
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style;
 
+- (void)adjustBottomConstraintWithExpectedOffset:(CGFloat)offset;
+
+- (void)adjustBottomConstraintBasedOnLastContentSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1TextChoiceCellGroup.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TextChoiceCellGroup.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didSelectCellAtIndexPath:(NSIndexPath *)indexPath;
 
+- (void)updateLabelsForCell:(ORK1ChoiceViewCell *)cell atIndex:(NSUInteger)index;
+
 - (nullable id)answerForBoolean;
 
 - (NSUInteger)size;

--- a/ORK1Kit/ORK1Kit/Common/ORK1TextChoiceCellGroup.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TextChoiceCellGroup.m
@@ -45,6 +45,7 @@
     BOOL _singleChoice;
     BOOL _immediateNavigation;
     NSIndexPath *_beginningIndexPath;
+    ORK1ChoiceDescriptionStyle _descriptionStyle;
     
     NSMutableDictionary *_cells;
 }
@@ -60,6 +61,7 @@
         _singleChoice = answerFormat.style == ORK1ChoiceAnswerStyleSingleChoice;
         _immediateNavigation = immediateNavigation;
         _cells = [NSMutableDictionary new];
+        _descriptionStyle = answerFormat.descriptionStyle;
         [self setAnswer:answer];
     }
     return self;
@@ -89,16 +91,37 @@
     if (cell == nil) {
         cell = [[ORK1ChoiceViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
         cell.immediateNavigation = _immediateNavigation;
-        ORK1TextChoice *textChoice = [_helper textChoiceAtIndex:index];
-        cell.shortLabel.text = textChoice.text;
-        cell.longLabel.text = textChoice.detailText;
-        
         _cells[@(index)] = cell;
         
         [self setSelectedIndexes:[_helper selectedIndexesForAnswer:_answer]];
     }
     
+    [self updateLabelsForCell:cell atIndex:index];
+    
     return cell;
+}
+
+- (void)updateLabelsForCell:(ORK1ChoiceViewCell *)cell atIndex:(NSUInteger)index {
+    ORK1TextChoice *textChoice = [_helper textChoiceAtIndex:index];
+    cell.shortLabel.text = textChoice.text;
+    cell.choice = textChoice;
+    switch (_descriptionStyle) {
+        case ORK1ChoiceDescriptionStyleNone:
+            cell.longLabel.text = nil;
+            cell.showDetailTextIndicator = NO;
+            textChoice.detailTextShouldDisplay = NO;
+            break;
+        case ORK1ChoiceDescriptionStyleDisplayAlways:
+            cell.longLabel.text = textChoice.detailText;
+            cell.showDetailTextIndicator = NO;
+            textChoice.detailTextShouldDisplay = YES;
+            break;
+        case ORK1ChoiceDescriptionStyleDisplayWhenExpanded: {
+            cell.showDetailTextIndicator = textChoice.detailText.length > 0;
+            cell.longLabel.text = textChoice.detailTextShouldDisplay ? textChoice.detailText : nil;
+            break;
+        }
+    }
 }
 
 - (void)didSelectCellAtIndex:(NSUInteger)index {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Types.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Types.h
@@ -145,14 +145,14 @@ typedef NS_ENUM(NSInteger, ORK1ChoiceAnswerStyle) {
  */
 typedef NS_ENUM(NSInteger, ORK1ChoiceDescriptionStyle) {
     /**
-     No detailText/description appears
-     */
-    ORK1ChoiceDescriptionStyleNone,
-    
-    /**
      The detailText/description always appears under the answer choice
      */
     ORK1ChoiceDescriptionStyleDisplayAlways,
+    
+    /**
+     No detailText/description appears
+     */
+    ORK1ChoiceDescriptionStyleNone,
     
     /**
      The detailText/description only shows when it is expanded

--- a/ORK1Kit/ORK1Kit/Common/ORK1Types.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Types.h
@@ -140,6 +140,25 @@ typedef NS_ENUM(NSInteger, ORK1ChoiceAnswerStyle) {
     ORK1ChoiceAnswerStyleMultipleChoice
 } ORK1_ENUM_AVAILABLE;
 
+/**
+ An enumeration of how to display detailText/description
+ */
+typedef NS_ENUM(NSInteger, ORK1ChoiceDescriptionStyle) {
+    /**
+     No detailText/description appears
+     */
+    ORK1ChoiceDescriptionStyleNone,
+    
+    /**
+     The detailText/description always appears under the answer choice
+     */
+    ORK1ChoiceDescriptionStyleDisplayAlways,
+    
+    /**
+     The detailText/description only shows when it is expanded
+     */
+    ORK1ChoiceDescriptionStyleDisplayWhenExpanded
+} ORK1_ENUM_AVAILABLE;
 
 /**
  An enumeration of the format styles available for scale answers.

--- a/ResearchKit/ActiveTasks/ORKStroopStep.m
+++ b/ResearchKit/ActiveTasks/ORKStroopStep.m
@@ -41,10 +41,6 @@ NSString *const ORKStroopColorIdentifierBlack = @"BLACK";
 
 @implementation ORKStroopColor
 
-- (instancetype)init {
-    ORKThrowMethodUnavailableException();
-}
-
 - (instancetype __nullable)initWithIdentifier:(NSString *)identifier {
     if (self = [super init]) {
         if ([identifier isEqualToString:ORKStroopColorIdentifierRed]) {
@@ -102,6 +98,13 @@ NSString *const ORKStroopColorIdentifierBlack = @"BLACK";
     ORK_ENCODE_OBJ(aCoder, title);
 }
  
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    ORKStroopColor *stroopColor = [[[self class] allocWithZone:zone] init];
+    stroopColor.color = self.color;
+    stroopColor.title = self.title;
+    return stroopColor;
+}
+
 @end
             
 
@@ -141,6 +144,14 @@ NSString *const ORKStroopColorIdentifierBlack = @"BLACK";
     ORK_ENCODE_OBJ(aCoder, color);
     ORK_ENCODE_OBJ(aCoder, text);
     ORK_ENCODE_ENUM(aCoder, stroopStyle);
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    ORKStroopTest *test = [[[self class] allocWithZone:zone] init];
+    test.color = self.color;
+    test.text = self.text;
+    test.stroopStyle = self.stroopStyle;
+    return test;
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -824,6 +824,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (copy, readonly) NSArray<ORKTextChoice *> *textChoices;
 
+/**
+The description style of the question (that is, none, display always or display when expanded).
+*/
+@property ORKChoiceDescriptionStyle descriptionStyle;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1006,6 +1006,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 + (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
     ORKTextChoice *option = [[ORKTextChoice alloc] initWithText:text detailText:detailText value:value exclusive:exclusive];
+    option.detailTextShouldDisplay = YES;
     return option;
 }
 
@@ -1020,6 +1021,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _detailText = [detailText copy];
         _value = value;
         _exclusive = exclusive;
+        _detailTextShouldDisplay = YES;
     }
     return self;
 }
@@ -1042,7 +1044,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return (ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.detailText, castObject.detailText)
             && ORKEqualObjects(self.value, castObject.value)
-            && self.exclusive == castObject.exclusive);
+            && self.exclusive == castObject.exclusive
+            && self.detailTextShouldDisplay == castObject.detailTextShouldDisplay);
 }
 
 - (NSUInteger)hash {
@@ -1057,6 +1060,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK_DECODE_OBJ(aDecoder, value);
         ORK_DECODE_BOOL(aDecoder, exclusive);
+        ORK_DECODE_BOOL(aDecoder, detailTextShouldDisplay);
     }
     return self;
 }
@@ -1066,6 +1070,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, value);
     ORK_ENCODE_OBJ(aCoder, detailText);
     ORK_ENCODE_BOOL(aCoder, exclusive);
+    ORK_ENCODE_BOOL(aCoder, detailTextShouldDisplay);
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1044,8 +1044,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return (ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.detailText, castObject.detailText)
             && ORKEqualObjects(self.value, castObject.value)
-            && self.exclusive == castObject.exclusive
-            && self.detailTextShouldDisplay == castObject.detailTextShouldDisplay);
+            && self.exclusive == castObject.exclusive);
 }
 
 - (NSUInteger)hash {
@@ -1060,7 +1059,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK_DECODE_OBJ(aDecoder, value);
         ORK_DECODE_BOOL(aDecoder, exclusive);
-        ORK_DECODE_BOOL(aDecoder, detailTextShouldDisplay);
+        _detailTextShouldDisplay = NO;
     }
     return self;
 }
@@ -1070,7 +1069,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, value);
     ORK_ENCODE_OBJ(aCoder, detailText);
     ORK_ENCODE_BOOL(aCoder, exclusive);
-    ORK_ENCODE_BOOL(aCoder, detailTextShouldDisplay);
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1006,7 +1006,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 + (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
     ORKTextChoice *option = [[ORKTextChoice alloc] initWithText:text detailText:detailText value:value exclusive:exclusive];
-    option.detailTextShouldDisplay = YES;
+    option.detailTextShouldDisplay = NO;
     return option;
 }
 
@@ -1021,7 +1021,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _detailText = [detailText copy];
         _value = value;
         _exclusive = exclusive;
-        _detailTextShouldDisplay = YES;
+        _detailTextShouldDisplay = NO;
     }
     return self;
 }

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -176,6 +176,12 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKWeightAnswerFormat)
 
 @interface ORKTextChoice () <ORKAnswerOption>
 
+/**
+ Used to store state when ORKChoiceDescriptionStyle == ORKChoiceDescriptionStyleDisplayWhenExpanded
+ */
+
+@property BOOL detailTextShouldDisplay;
+
 @end
 
 @interface ORKValuePickerAnswerFormat ()

--- a/ResearchKit/Common/ORKChoiceViewCell.h
+++ b/ResearchKit/Common/ORKChoiceViewCell.h
@@ -36,11 +36,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ORKSelectionTitleLabel;
 @class ORKSelectionSubTitleLabel;
+@class ORKTextChoice;
+
+/// This is used when the size of the cell might change and forcing a reload will make the tableview appropriately resize the cell.
+extern NSNotificationName const ORKUpdateChoiceCell;
+extern NSString const *ORKUpdateChoiceCellKeyCell;
 
 @interface ORKChoiceViewCell : UITableViewCell
 
 @property (nonatomic, strong, readonly) ORKSelectionTitleLabel *shortLabel;
 @property (nonatomic, strong, readonly) ORKSelectionSubTitleLabel *longLabel;
+@property (nonatomic, weak) ORKTextChoice *choice;
 
 + (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText LongText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
 
@@ -53,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) bool isLastItem;
 
 @property (nonatomic) BOOL isFirstItemInSectionWithoutTitle;
+
+@property (nonatomic, assign) BOOL showDetailTextIndicator;
 
 @end
 

--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -44,7 +44,8 @@ NSString const *ORKUpdateChoiceCellKeyCell = @"ORKUpdateChoiceCellKeyCell";
 
 static const CGFloat LabelRightMargin = 44.0;
 static const CGFloat cardTopBottomMargin = 2.0;
-static const CGFloat DetailTextIndicatorWidth = 15.0;
+static const CGFloat DetailTextIndicatorTouchTargetWidth = 30.0;
+static const CGFloat DetailTextIndicatorImageWidth = 15.0;
 static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
 @interface ORKChoiceViewCell()
@@ -189,7 +190,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
     CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORKSelectionTitleLabel.defaultFont}].width;
-    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
     
     CGFloat cellHeight = self.bounds.size.height;
     
@@ -200,7 +201,12 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
         self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
-        self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel, self.shortLabel.frame.size.height / 2 - DetailTextIndicatorWidth / 2, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
+        self.detailTextIndicator.frame =
+        CGRectMake(
+                   cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel,
+                   self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2,
+                   DetailTextIndicatorTouchTargetWidth,
+                   DetailTextIndicatorTouchTargetWidth);
         self.longLabel.frame = CGRectZero;
     } else if (self.shortLabel.text.length == 0) {
         self.longLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
@@ -218,7 +224,12 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             
             rect.origin.y = firstBaselineOffsetFromTop - shortLabelFirstBaselineApproximateOffsetFromTop;
             self.shortLabel.frame = rect;
-            self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + 10, self.shortLabel.frame.size.height / 2 + 13, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
+            self.detailTextIndicator.frame =
+            CGRectMake(
+                       cellLeftMargin + shortLabelTextWidth + 10,
+                       self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2 + self.shortLabel.frame.origin.y,
+                       DetailTextIndicatorTouchTargetWidth,
+                       DetailTextIndicatorTouchTargetWidth);
         }
         
         {
@@ -274,6 +285,8 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 - (UIButton *)detailTextIndicator {
     if (_detailTextIndicator == nil) {
         _detailTextIndicator = [UIButton buttonWithType:UIButtonTypeInfoDark];
+        CGFloat inset = (DetailTextIndicatorTouchTargetWidth - DetailTextIndicatorImageWidth) / 2;
+        _detailTextIndicator.imageEdgeInsets = UIEdgeInsetsMake(inset, inset, inset, inset);
         [self.contentView addSubview:_detailTextIndicator];
         [_detailTextIndicator addTarget:self action:@selector(toggleDetailText) forControlEvents:UIControlEventTouchUpInside];
     }

--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -34,13 +34,18 @@
 #import "ORKSelectionTitleLabel.h"
 #import "ORKSelectionSubTitleLabel.h"
 
+#import "ORKAnswerFormat_Internal.h"
 #import "ORKAccessibility.h"
 #import "ORKHelpers_Internal.h"
 #import "ORKSkin.h"
 
+NSNotificationName const ORKUpdateChoiceCell = @"ORKUpdateChoiceCell";
+NSString const *ORKUpdateChoiceCellKeyCell = @"ORKUpdateChoiceCellKeyCell";
 
 static const CGFloat LabelRightMargin = 44.0;
 static const CGFloat cardTopBottomMargin = 2.0;
+static const CGFloat DetailTextIndicatorWidth = 15.0;
+static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
 
 @interface ORKChoiceViewCell()
 
@@ -57,6 +62,7 @@ static const CGFloat cardTopBottomMargin = 2.0;
     UIImageView *_checkView;
     ORKSelectionTitleLabel *_shortLabel;
     ORKSelectionSubTitleLabel *_longLabel;
+    UIButton *_detailTextIndicator;
     NSArray<NSLayoutConstraint *> *_containerConstraints;
 }
 
@@ -68,6 +74,7 @@ static const CGFloat cardTopBottomMargin = 2.0;
         _topBottomMargin = 0.0;
         _checkView = [[UIImageView alloc] initWithImage:[[UIImage imageNamed:@"checkmark" inBundle:ORKBundle() compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
         self.accessoryView = _checkView;
+        self.showDetailTextIndicator = NO;
         [self setupContainerView];
         [self setupConstraints];
     }
@@ -181,13 +188,19 @@ static const CGFloat cardTopBottomMargin = 2.0;
     CGFloat cellLeftMargin = self.separatorInset.left;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
+    CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORKSelectionTitleLabel.defaultFont}].width;
+    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    
     CGFloat cellHeight = self.bounds.size.height;
+    
+    [self detailTextIndicator].hidden = !self.showDetailTextIndicator;
     
     if (self.longLabel.text.length == 0 && self.shortLabel.text.length == 0) {
         self.shortLabel.frame = CGRectZero;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
         self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
+        self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel, self.shortLabel.frame.size.height / 2 - DetailTextIndicatorWidth / 2, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
         self.longLabel.frame = CGRectZero;
     } else if (self.shortLabel.text.length == 0) {
         self.longLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
@@ -205,6 +218,7 @@ static const CGFloat cardTopBottomMargin = 2.0;
             
             rect.origin.y = firstBaselineOffsetFromTop - shortLabelFirstBaselineApproximateOffsetFromTop;
             self.shortLabel.frame = rect;
+            self.detailTextIndicator.frame = CGRectMake(cellLeftMargin + shortLabelTextWidth + 10, self.shortLabel.frame.size.height / 2 + 13, DetailTextIndicatorWidth, DetailTextIndicatorWidth);
         }
         
         {
@@ -255,6 +269,21 @@ static const CGFloat cardTopBottomMargin = 2.0;
         [self.containerView addSubview:_longLabel];
     }
     return _longLabel;
+}
+
+- (UIButton *)detailTextIndicator {
+    if (_detailTextIndicator == nil) {
+        _detailTextIndicator = [UIButton buttonWithType:UIButtonTypeInfoDark];
+        [self.contentView addSubview:_detailTextIndicator];
+        [_detailTextIndicator addTarget:self action:@selector(toggleDetailText) forControlEvents:UIControlEventTouchUpInside];
+    }
+    return _detailTextIndicator;
+}
+
+- (void)toggleDetailText {
+    self.choice.detailTextShouldDisplay = !self.choice.detailTextShouldDisplay;
+    NSNotification *notification = [NSNotification notificationWithName:ORKUpdateChoiceCell object:nil userInfo:@{ORKUpdateChoiceCellKeyCell : self}];
+    [[NSNotificationCenter defaultCenter] postNotification:notification];
 }
 
 - (void)tintColorDidChange {

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -452,6 +452,14 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
         [cell loadPicker];
     }
     
+    [[NSNotificationCenter defaultCenter] addObserverForName:ORKUpdateChoiceCell object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
+        UITableViewCell *cell = (UITableViewCell *)note.userInfo[ORKUpdateChoiceCellKeyCell];
+        if ([cell isKindOfClass:[UITableViewCell class]]) {
+            NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
+            [self adjustUIforChangesToDetailTextAtIndexPath:indexPath];
+        }
+    }];
+    
     _visible = YES;
     
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
@@ -462,6 +470,18 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     
     _visible = NO;
 }
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:ORKUpdateChoiceCell object:nil];
+}
+
+- (void)adjustUIforChangesToDetailTextAtIndexPath:(NSIndexPath *)indexPath {
+    [self.tableView beginUpdates];
+    [_choiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:indexPath] atIndex:indexPath.row];
+    [self.tableView endUpdates];
+}
+
 
 - (void)setCustomQuestionView:(ORKQuestionStepCustomView *)customQuestionView {
     [_customQuestionView removeFromSuperview];
@@ -877,8 +897,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (CGFloat)heightForChoiceItemOptionAtIndex:(NSInteger)index {
     ORKTextChoice *option = [(ORKTextChoiceAnswerFormat *)_answerFormat textChoices][index];
-    CGFloat height = [ORKChoiceViewCell suggestedCellHeightForShortText:option.text LongText:option.detailText inTableView:_tableView];
-    return height;
+    return [ORKChoiceViewCell suggestedCellHeightForShortText:option.text
+                                                     LongText:(option.detailTextShouldDisplay) ? option.detailText : nil
+                                                  inTableView:_tableView];
 }
 
 #pragma mark - ORKSurveyAnswerCellDelegate

--- a/ResearchKit/Common/ORKTextChoiceCellGroup.h
+++ b/ResearchKit/Common/ORKTextChoiceCellGroup.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didSelectCellAtIndexPath:(NSIndexPath *)indexPath;
 
+- (void)updateLabelsForCell:(ORKChoiceViewCell *)cell atIndex:(NSUInteger)index;
+
 - (nullable id)answerForBoolean;
 
 - (NSUInteger)size;

--- a/ResearchKit/Common/ORKTextChoiceCellGroup.m
+++ b/ResearchKit/Common/ORKTextChoiceCellGroup.m
@@ -45,6 +45,7 @@
     BOOL _singleChoice;
     BOOL _immediateNavigation;
     NSIndexPath *_beginningIndexPath;
+    ORKChoiceDescriptionStyle _descriptionStyle;
     
     NSMutableDictionary *_cells;
 }
@@ -60,6 +61,7 @@
         _singleChoice = answerFormat.style == ORKChoiceAnswerStyleSingleChoice;
         _immediateNavigation = immediateNavigation;
         _cells = [NSMutableDictionary new];
+        _descriptionStyle = answerFormat.descriptionStyle;
         [self setAnswer:answer];
     }
     return self;
@@ -89,16 +91,38 @@
     if (cell == nil) {
         cell = [[ORKChoiceViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
         cell.immediateNavigation = _immediateNavigation;
-        ORKTextChoice *textChoice = [_helper textChoiceAtIndex:index];
-        cell.shortLabel.text = textChoice.text;
-        cell.longLabel.text = textChoice.detailText;
         
         _cells[@(index)] = cell;
         
         [self setSelectedIndexes:[_helper selectedIndexesForAnswer:_answer]];
     }
     
+    [self updateLabelsForCell:cell atIndex:index];
+    
     return cell;
+}
+
+- (void)updateLabelsForCell:(ORKChoiceViewCell *)cell atIndex:(NSUInteger)index {
+    ORKTextChoice *textChoice = [_helper textChoiceAtIndex:index];
+    cell.shortLabel.text = textChoice.text;
+    cell.choice = textChoice;
+    switch (_descriptionStyle) {
+        case ORKChoiceDescriptionStyleNone:
+            cell.longLabel.text = nil;
+            cell.showDetailTextIndicator = NO;
+            textChoice.detailTextShouldDisplay = NO;
+            break;
+        case ORKChoiceDescriptionStyleDisplayAlways:
+            cell.longLabel.text = textChoice.detailText;
+            cell.showDetailTextIndicator = NO;
+            textChoice.detailTextShouldDisplay = YES;
+            break;
+        case ORKChoiceDescriptionStyleDisplayWhenExpanded: {
+            cell.showDetailTextIndicator = textChoice.detailText.length > 0;
+            cell.longLabel.text = textChoice.detailTextShouldDisplay ? textChoice.detailText : nil;
+            break;
+        }
+    }
 }
 
 - (void)didSelectCellAtIndex:(NSUInteger)index {

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -140,6 +140,25 @@ typedef NS_ENUM(NSInteger, ORKChoiceAnswerStyle) {
     ORKChoiceAnswerStyleMultipleChoice
 } ORK_ENUM_AVAILABLE;
 
+/**
+ An enumeration of how to display detailText/description
+ */
+typedef NS_ENUM(NSInteger, ORKChoiceDescriptionStyle) {
+    /**
+     No detailText/description appears
+     */
+    ORKChoiceDescriptionStyleNone,
+    
+    /**
+     The detailText/description always appears under the answer choice
+     */
+    ORKChoiceDescriptionStyleDisplayAlways,
+    
+    /**
+     The detailText/description only shows when it is expanded
+     */
+    ORKChoiceDescriptionStyleDisplayWhenExpanded
+} ORK_ENUM_AVAILABLE;
 
 /**
  An enumeration of the format styles available for scale answers.

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -145,14 +145,14 @@ typedef NS_ENUM(NSInteger, ORKChoiceAnswerStyle) {
  */
 typedef NS_ENUM(NSInteger, ORKChoiceDescriptionStyle) {
     /**
-     No detailText/description appears
-     */
-    ORKChoiceDescriptionStyleNone,
-    
-    /**
      The detailText/description always appears under the answer choice
      */
     ORKChoiceDescriptionStyleDisplayAlways,
+    
+    /**
+     No detailText/description appears
+     */
+    ORKChoiceDescriptionStyleNone,
     
     /**
      The detailText/description only shows when it is expanded


### PR DESCRIPTION
Closes https://github.com/CareEvolution/RKStudio-Participant/issues/668. Implemented for both ORK1Kit and ResearchKit (RK2).

Note that there already is a `detailText` available on `ORKTextChoice`. Using the three options for `ORKChoiceDescriptionStyle`, the following behavior is observed.
- ORKChoiceDescriptionStyleNone - no `detailText` will show
- ORKChoiceDescriptionStyleDisplayAlways - if `detailText` exists, it will show
- ORKChoiceDescriptionStyleDisplayWhenExpanded - if 'detailText` exists, initially an info button will appear on the trailing side of the text with no `detailText` showing. When tapped, it will animate the expansion of the `detailText` into the cell.

In RK1, the Done/Next button is manually drawn in the `ORK1TableContainerView` and when the cell grows to show the `detailText`, the Done/Next button can inconveniently be pushed below the visible content in the scrollView. This also happens today with the hidePredicate in `ORKFormItemViewController. A solution is implemented here which sends the expected change in size to the TableContainerView which can adjust the constraint anchoring the button. Because this animation is independent of the TableView animation, it initially created a jumping with the tableView animation and then sliding back to expected position. Here we hide it at resize and then animate into view after the TableView resize to minimize the jumping.

Behavior was implemented for both the `ORK(1)QuestionViewController` and the `ORK(1)FormViewController` and tested with hidePredicate interaction as well. Tests added for basic behavior in CEVResearchKit.

![standardRK1](https://user-images.githubusercontent.com/1008462/77268501-291d1780-6c74-11ea-9197-1282525d90a7.gif)

In RK2, the animation of the TableView looks particularly bad if collapsing a large amount of detailText. I started to attempt to convert to auto-layout, thinking it might help and not only was it rather difficult to duplicate the style, it would be even more difficult to animate more cleanly due to being centered vertically when `detailText` is hidden, but top-justified when showing. I gave up for now and if we would rather have in NOT animate, we can simply reload the tableViewCell instead of adjusting it.

![rk2](https://user-images.githubusercontent.com/1008462/77268376-ac8a3900-6c73-11ea-89de-b92482b743d0.gif)

Also, in reviewing warnings, I noticed the recent [Stroop update](#55) did not completely implement NSCopying, omitting `copyWithZone:` so I added that here.