### PR TITLE
Disable password autofill on secureTextEntry fields

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormItemCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormItemCell.m
@@ -592,6 +592,9 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
+    if (answerFormat.secureTextEntry) {
+        ORK1DisablePasswordAutofill(self.textField);
+    }
     
     [self answerDidChange];
 }
@@ -812,6 +815,9 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        if (textAnswerFormat.secureTextEntry) {
+            ORK1DisablePasswordAutofill(_textView);
+        }
     } else {
         _maxLength = 0;
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
@@ -553,3 +553,22 @@ NSNumberFormatter *ORK1DecimalNumberFormatter() {
     numberFormatter.usesGroupingSeparator = NO;
     return numberFormatter;
 }
+
+void ORK1DisablePasswordAutofill(id<UITextInputTraits> input) {
+    if (@available(iOS 12.0, *)) {
+        input.textContentType = UITextContentTypeOneTimeCode;
+    } else {
+        input.textContentType = @"";
+    }
+    
+    // iOS displays the keychain autofill interface for secureTextEntry fields and the one previous to it.
+    // Inject an invisble text field above the current one, so no other textfields inadvertantly show keychain autofill.
+    UIView *superview = [((UIView *)input) superview];
+    if (![superview viewWithTag:999]) {
+        UITextField *textField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+        textField.userInteractionEnabled = false;
+        textField.enabled = false;
+        textField.tag = 999;
+        [superview insertSubview:textField atIndex:0];
+    }
+}

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Internal.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Internal.h
@@ -365,6 +365,8 @@ ORK1_INLINE UIColor *ORK1OpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseC
     return color;
 }
 
+void ORK1DisablePasswordAutofill(id<UITextInputTraits> input);
+
 // Localization
 ORK1_EXTERN NSBundle *ORK1Bundle(void) ORK1_AVAILABLE_DECL;
 ORK1_EXTERN NSBundle *ORK1DefaultLocaleBundle(void);

--- a/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
@@ -63,6 +63,9 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        if (textAnswerFormat.secureTextEntry) {
+            ORK1DisablePasswordAutofill(self.textView);
+        }
     } else {
         _maxLength = 0;
     }
@@ -268,6 +271,9 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
+        if (textFormat.secureTextEntry) {
+            ORK1DisablePasswordAutofill(self.textField);
+        }
     }
     NSString *displayValue = (answer && answer != ORK1NullAnswerValue()) ? answer : nil;
     

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -698,6 +698,9 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
+    if (answerFormat.secureTextEntry) {
+        ORKDisablePasswordAutofill(self.textField);
+    }
     
     [self answerDidChange];
 }
@@ -948,6 +951,9 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        if (textAnswerFormat.secureTextEntry) {
+            ORKDisablePasswordAutofill(_textView);
+        }
     } else {
         _maxLength = 0;
     }

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -553,3 +553,22 @@ NSNumberFormatter *ORKDecimalNumberFormatter() {
     numberFormatter.usesGroupingSeparator = NO;
     return numberFormatter;
 }
+
+void ORKDisablePasswordAutofill(id<UITextInputTraits> input) {
+    if (@available(iOS 12.0, *)) {
+        input.textContentType = UITextContentTypeOneTimeCode;
+    } else {
+        input.textContentType = @"";
+    }
+    
+    // iOS displays the keychain autofill interface for secureTextEntry fields and the one previous to it.
+    // Inject an invisble text field above the current one, so no other textfields inadvertantly show keychain autofill.
+    UIView *superview = [((UIView *)input) superview];
+    if (![superview viewWithTag:999]) {
+        UITextField *textField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+        textField.userInteractionEnabled = false;
+        textField.enabled = false;
+        textField.tag = 999;
+        [superview insertSubview:textField atIndex:0];
+    }
+}

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -365,6 +365,8 @@ ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseCol
     return color;
 }
 
+void ORKDisablePasswordAutofill(id<UITextInputTraits> input);
+
 // Localization
 ORK_EXTERN NSBundle *ORKBundle(void) ORK_AVAILABLE_DECL;
 ORK_EXTERN NSBundle *ORKDefaultLocaleBundle(void);

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -65,6 +65,9 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        if (textAnswerFormat.secureTextEntry) {
+            ORKDisablePasswordAutofill(self.textView);
+        }
     } else {
         _maxLength = 0;
     }
@@ -284,6 +287,9 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
+        if (textFormat.secureTextEntry) {
+            ORKDisablePasswordAutofill(self.textField);
+        }
     }
     NSString *displayValue = (answer && answer != ORKNullAnswerValue()) ? answer : nil;
     


### PR DESCRIPTION
iOS displays the keychain autofill interface for both the secureTextEntry field and the one previous to it. Fix is to inject an invisble text field above the current one, so no other textfields inadvertantly show keychain autofill. Alternative would be to set `.textContentType = UITextContentTypeOneTimeCode;` on the previous text field, but that would disable keyboard autocomplete.

Fixes https://github.com/CareEvolution/CEVResearchKit/issues/212.