### PR TITLE
Validate date against min/max before setting ORKDateTimePicker

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -1417,7 +1417,7 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
 
 - (void)validateParameters {
     if (self.minimumDate && self.maximumDate && [self.minimumDate compare:self.maximumDate] == NSOrderedDescending) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumValue larger than minimumValue"] userInfo:nil];
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumDate later than minimumDate"] userInfo:nil];
     }
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -1415,6 +1415,12 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     return self.maximumDate;
 }
 
+- (void)validateParameters {
+    if (self.minimumDate && self.maximumDate && [self.minimumDate compare:self.maximumDate] == NSOrderedDescending) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumValue larger than minimumValue"] userInfo:nil];
+    }
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1DateTimePicker.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DateTimePicker.m
@@ -134,18 +134,28 @@
         [self setDate:[(ORK1TimeOfDayAnswerFormat *)answerFormat pickerDefaultDate]];
     } else {
         ORK1DateAnswerFormat *dateAnswerFormat = (ORK1DateAnswerFormat *)answerFormat;
-        [self setDate:[dateAnswerFormat pickerDefaultDate]];
         _pickerView.calendar = [dateAnswerFormat currentCalendar];
         _calendar = [dateAnswerFormat currentCalendar];
         
         [_pickerView setMinimumDate:[dateAnswerFormat pickerMinimumDate]];
         [_pickerView setMaximumDate:[dateAnswerFormat pickerMaximumDate]];
+        
+        [self setDate:[dateAnswerFormat pickerDefaultDate]];
     }
     
     _labelFormatter = nil;
 }
 
 - (void)setDate:(NSDate *)date {
+    if ([self.answerFormat isKindOfClass:[ORK1DateAnswerFormat class]]) {
+        ORK1DateAnswerFormat *format = (ORK1DateAnswerFormat *)self.answerFormat;
+        if (format.minimumDate && [date compare:format.minimumDate] == NSOrderedAscending) {
+            date = format.minimumDate;
+        }
+        if (format.maximumDate && [date compare:format.maximumDate] == NSOrderedDescending) {
+            date = format.maximumDate;
+        }
+    }
     _date = date;
     _pickerView.date = date;
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1420,7 +1420,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (void)validateParameters {
     if (self.minimumDate && self.maximumDate && [self.minimumDate compare:self.maximumDate] == NSOrderedDescending) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumValue larger than minimumValue"] userInfo:nil];
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumDate later than minimumDate"] userInfo:nil];
     }
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1418,6 +1418,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return self.maximumDate;
 }
 
+- (void)validateParameters {
+    if (self.minimumDate && self.maximumDate && [self.minimumDate compare:self.maximumDate] == NSOrderedDescending) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Expect maximumValue larger than minimumValue"] userInfo:nil];
+    }
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {

--- a/ResearchKit/Common/ORKDateTimePicker.m
+++ b/ResearchKit/Common/ORKDateTimePicker.m
@@ -134,8 +134,6 @@
         [self setDate:[(ORKTimeOfDayAnswerFormat *)answerFormat pickerDefaultDate]];
     } else {
         ORKDateAnswerFormat *dateAnswerFormat = (ORKDateAnswerFormat *)answerFormat;
-        [self setDate:[dateAnswerFormat pickerDefaultDate]];
-        
         _pickerView.calendar = [dateAnswerFormat currentCalendar];
         _pickerView.timeZone = _pickerView.calendar.timeZone;
         
@@ -143,12 +141,23 @@
         
         [_pickerView setMinimumDate:[dateAnswerFormat pickerMinimumDate]];
         [_pickerView setMaximumDate:[dateAnswerFormat pickerMaximumDate]];
+        
+        [self setDate:[dateAnswerFormat pickerDefaultDate]];
     }
     
     _labelFormatter = nil;
 }
 
 - (void)setDate:(NSDate *)date {
+    if ([self.answerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
+        ORKDateAnswerFormat *format = (ORKDateAnswerFormat *)self.answerFormat;
+        if (format.minimumDate && [date compare:format.minimumDate] == NSOrderedAscending) {
+            date = format.minimumDate;
+        }
+        if (format.maximumDate && [date compare:format.maximumDate] == NSOrderedDescending) {
+            date = format.maximumDate;
+        }
+    }
     _date = date;
     _pickerView.date = date;
 }


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/687. Note: validation of min/max for `ORKDateAnswerFormat` is different in that it uses the UIKit settings which prevent the UI from selecting a date out of min/max requirements. This guards the setting of the date with a value outside of those requirements.
