### PR TITLE
RK2 - Remove references to UIWebViewKit

### DIFF
--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -3019,6 +3019,7 @@
 				"en-AU",
 				nb,
 				"es-419",
+				es_419,
 			);
 			mainGroup = 3FFF18341829DB1D00167070;
 			productRefGroup = 3FFF183E1829DB1D00167070 /* Products */;

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -3588,6 +3588,7 @@
 				"en-AU",
 				nb,
 				"es-419",
+				es_419,
 			);
 			mainGroup = 3FFF18341829DB1D00167070;
 			productRefGroup = 3FFF183E1829DB1D00167070 /* Products */;

--- a/ResearchKit/Common/ORKHTMLPDFWriter.m
+++ b/ResearchKit/Common/ORKHTMLPDFWriter.m
@@ -31,6 +31,7 @@
 
 #import "ORKHTMLPDFWriter.h"
 #import "ORKHTMLPDFPageRenderer.h"
+#import <WebKit/WebKit.h>
 
 #import "ORKHelpers_Internal.h"
 
@@ -47,13 +48,13 @@ static const CGFloat LetterHeight = 11.0f;
 
 
 
-@interface ORKHTMLPDFWriter () <UIWebViewDelegate> {
+@interface ORKHTMLPDFWriter () <WKNavigationDelegate> {
     id _selfRetain;
 }
 
 @property (nonatomic) CGSize pageSize;
 @property (nonatomic) UIEdgeInsets pageMargins;
-@property (nonatomic, strong) UIWebView *webView;
+@property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, strong) NSData *data;
 @property (nonatomic, copy) NSError *error;
 @property (nonatomic, copy) void (^completionBlock)(NSData *data, NSError *error);
@@ -75,8 +76,10 @@ static const CGFloat PageEdge = 72.0 / 4;
     _data = nil;
     _error = nil;
     
-    self.webView = [[UIWebView alloc] init];
-    self.webView.delegate = self;
+    WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration new];
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration];
+    webView.navigationDelegate = self;
+    self.webView = webView;
     [self.webView loadHTMLString:html baseURL:ORKCreateRandomBaseURL()];
     
     _selfRetain = self;
@@ -141,22 +144,24 @@ static const CGFloat PageEdge = 72.0 / 4;
     return pageSize;
 }
 
-#pragma mark - UIWebViewDelegate
+#pragma mark - WKNavigationDelegate
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView {
-    NSString *readyState = [webView stringByEvaluatingJavaScriptFromString:@"document.readyState"];
-    BOOL complete = [readyState isEqualToString:@"complete"];
-    
-    [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeout) object:nil];
-    
-    if (complete) {
-        [self savePDF];
-    } else {
-        [self performSelector:@selector(timeout) withObject:nil afterDelay:1.0f];
-    }
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    [webView evaluateJavaScript:@"document.readyState" completionHandler:^(id _Nullable result, NSError * _Nullable error) {
+        NSString *readyState = [result isKindOfClass:NSString.class] ? result : [NSString new];
+        BOOL complete = [readyState isEqualToString:@"complete"];
+        
+        [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeout) object:nil];
+        
+        if (complete) {
+            [self savePDF];
+        } else {
+            [self performSelector:@selector(timeout) withObject:nil afterDelay:1.0f];
+        }
+    }];
 }
 
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
     [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeout) object:nil];
     
     _error = error;

--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -173,7 +173,7 @@
 + (NSString *)wrapHTMLBody:(NSString *)body mobile:(BOOL)mobile {
     NSMutableString *html = [NSMutableString string];
     
-    [html appendString:@"<html><head><style>"];
+    [html appendString:@"<html><head><meta name='viewport' content='width=device-width, initial-scale=1.0'><style>"];
     [html appendString:[[self class] cssStyleSheet:mobile]];
     [html appendString:@"</style></head><body>"];
     [html appendString:body];

--- a/ResearchKit/Consent/ORKConsentLearnMoreViewController.m
+++ b/ResearchKit/Consent/ORKConsentLearnMoreViewController.m
@@ -35,11 +35,12 @@
 
 #import "ORKHelpers_Internal.h"
 #import "ORKSkin.h"
+#import <WebKit/WebKit.h>
 
 
-@interface ORKConsentLearnMoreViewController () <UIWebViewDelegate>
+@interface ORKConsentLearnMoreViewController () <WKNavigationDelegate>
 
-@property (nonatomic, strong) UIWebView *webView;
+@property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, copy) NSString *content;
 @property (nonatomic, copy) NSURL *contentURL;
 
@@ -69,8 +70,9 @@
     [super viewDidLoad];
     
     self.view.backgroundColor = ORKColor(ORKBackgroundColorKey);
-    
-    _webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
+  
+    WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration new];
+    _webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:webViewConfiguration];
     
     const CGFloat horizMargin = ORKStandardLeftMarginForTableViewCell(self.view);
     _webView.backgroundColor = ORKColor(ORKBackgroundColorKey);
@@ -81,15 +83,15 @@
     _webView.scrollView.scrollIndicatorInsets = (UIEdgeInsets){.left = -horizMargin, .right = -horizMargin};
     _webView.opaque = NO; // If opaque is set to YES, _webView shows a black right margin during transition when modally presented. This is an artifact due to disabling clipsToBounds to be able to show the scroll indicator outside the view.
     
+    
+    _webView.navigationDelegate = self;
+    
     if (_contentURL) {
-        [_webView setScalesPageToFit:YES];
-        
         [_webView loadRequest:[NSURLRequest requestWithURL:_contentURL]];
     } else {
         [_webView loadHTMLString:self.content baseURL:ORKCreateRandomBaseURL()];
     }
     
-    _webView.delegate = self;
     [self.view addSubview:_webView];
     
     _webView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -119,12 +121,14 @@
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
-    if (navigationType != UIWebViewNavigationTypeOther) {
-        [[UIApplication sharedApplication] openURL:request.URL];
-        return NO;
+- (void)webView:(WKWebView *) __unused webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    if (navigationAction.navigationType != WKNavigationTypeOther) {
+        [[UIApplication sharedApplication] openURL:navigationAction.request.URL options:@{} completionHandler:^(BOOL __unused success) {
+            decisionHandler(WKNavigationActionPolicyCancel);
+        }];
+    } else {
+        decisionHandler(WKNavigationActionPolicyAllow);
     }
-    return YES;
 }
 
 @end

--- a/ResearchKit/Consent/ORKConsentReviewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewController.h
@@ -30,6 +30,7 @@
 
 
 @import UIKit;
+@import WebKit;
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -48,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom;
 
-@property (nonatomic, strong, nullable) UIWebView *webView;
+@property (nonatomic, strong, nullable) WKWebView *webView;
 
 @property (nonatomic, strong, nullable) UIBarButtonItem *cancelButtonItem;
 

--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -41,7 +41,7 @@
 
 
 static const CGFloat iPadStepTitleLabelFontSize = 50.0;
-@interface ORKConsentReviewController () <UIWebViewDelegate, UIScrollViewDelegate>
+@interface ORKConsentReviewController () <WKNavigationDelegate, UIScrollViewDelegate>
 
 @end
 
@@ -92,14 +92,15 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
         [self.navigationController.navigationBar setBarTintColor:self.view.backgroundColor];
     }
     
-    _webView = [UIWebView new];
+    WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration new];
+    _webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration];
     [_webView loadHTMLString:_htmlString baseURL:ORKCreateRandomBaseURL()];
     _webView.backgroundColor = ORKColor(ORKConsentBackgroundColorKey);
     _webView.scrollView.backgroundColor = ORKColor(ORKConsentBackgroundColorKey);
     if (!_agreeButton.isEnabled) {
         _webView.scrollView.delegate = self;
     }
-    _webView.delegate = self;
+    _webView.navigationDelegate = self;
     [_webView setClipsToBounds:YES];
     _webView.translatesAutoresizingMaskIntoConstraints = NO;
     _toolbar.translatesAutoresizingMaskIntoConstraints = NO;
@@ -218,15 +219,17 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
     [self presentViewController:alert animated:YES completion:nil];
 }
 
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
-    if (navigationType != UIWebViewNavigationTypeOther) {
-        [[UIApplication sharedApplication] openURL:request.URL];
-        return NO;
+- (void)webView:(WKWebView *) __unused webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    if (navigationAction.navigationType != WKNavigationTypeOther) {
+        [[UIApplication sharedApplication] openURL:navigationAction.request.URL options:@{} completionHandler:^(BOOL __unused success) {
+            decisionHandler(WKNavigationActionPolicyCancel);
+        }];
+    } else {
+        decisionHandler(WKNavigationActionPolicyAllow);
     }
-    return YES;
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView {
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *) __unused navigation {
     //need a delay here because of a race condition where the webview may not have fully rendered by the time this is called in which case scrolledToBottom returns YES because everything == 0
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!_agreeButton.isEnabled && [self scrolledToBottom:_webView.scrollView]) {

--- a/ResearchKitTests/ORKConsentDocumentTests.m
+++ b/ResearchKitTests/ORKConsentDocumentTests.m
@@ -110,7 +110,7 @@
 
 - (NSString *)htmlWithContent:(NSString *)content mobile:(BOOL)mobile {
     NSString *boilerplateHeader =
-@"<html><head><style>@media print { .pagebreak { page-break-before: always; } }\n\
+@"<html><head><meta name='viewport' content='width=device-width, initial-scale=1.0'><style>@media print { .pagebreak { page-break-before: always; } }\n\
 h1, h2 { text-align: center; }\n\
 h2, h3 { margin-top: 3em; }\n\
 body, p, h1, h2, h3 { font-family: Helvetica; }\n\

--- a/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
+++ b/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
@@ -298,6 +298,14 @@
 				"fr-CA",
 				"es-419",
 				pt,
+				zh_CN,
+				zh_TW,
+				es_419,
+				pt_PT,
+				en_GB,
+				en_AU,
+				zh_HK,
+				fr_CA,
 			);
 			mainGroup = 869230B51AAA890A00BFE11B;
 			productRefGroup = 869230BF1AAA890A00BFE11B /* Products */;


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/207. This should stop the warnings when uploading binaries to App Store Connect. Cherry picked the corresponding fixes from Apple's [master](https://github.com/ResearchKit/ResearchKit/tree/master) branch (since Apple's [stable](https://github.com/ResearchKit/ResearchKit/tree/stable) still doesn't have it 🤷‍♂️). Had to apply the same [fixes](https://github.com/CareEvolution/ResearchKit/pull/33) for `requiresScrollToBottom` that we applied back when we added this to our fork of RK1.

While no current surveys should be using RK2 for any of these classes, I checked UI tests in CEVResearchKit and they all pass with these changes.