### PR TITLE
Configurable survey styles

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -7,6 +7,7 @@
 //
 
 @import UIKit;
+@class ORK1TaskViewController;
 
 #import "ORK1Defines.h"
 
@@ -42,8 +43,8 @@ ORK1_CLASS_AVAILABLE
 @interface CEVRK1Theme : NSObject
 + (nonnull CEVRK1Theme *)themeByOverridingTheme:(nullable CEVRK1Theme *)theme1 withTheme:(nullable CEVRK1Theme *)theme2; // properties from theme2 take priority over theme1
 + (nonnull instancetype)themeForElement:(nonnull id)element;
-+ (nonnull CEVRK1Theme *)fallbackTheme;
-+ (void)setFallbackTheme:(nonnull CEVRK1Theme *)theme;
++ (nullable ORK1TaskViewController *)fallbackTaskViewController;
++ (void)setFallbackTaskViewController:(nullable ORK1TaskViewController *)taskViewController;
 - (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
 
 @property (nonatomic, strong) UIColor * _Nullable tintColor;

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -12,34 +12,71 @@
 
 extern NSNotificationName _Nonnull const CEVORK1StepViewControllerViewWillAppearNotification;
 extern NSString * _Nonnull const CEVRK1ThemeKey;
+extern NSString * _Nonnull const CEVThemeAttributeName;
 
 typedef NS_ENUM(NSInteger, CEVRK1ThemeType) {
     CEVRK1ThemeTypeDefault,
     CEVRK1ThemeTypeAllOfUs
 } ORK1_ENUM_AVAILABLE;
 
+typedef NS_ENUM(NSInteger, CEVRK1TextTransform) {
+    CEVRK1TextTransformUppercase,
+    CEVRK1TextTransformLowercase
+} ORK1_ENUM_AVAILABLE;
+
+typedef NS_ENUM(NSInteger, CEVRK1GradientDirection) {
+    CEVRK1GradientDirectionLeftToRight,
+    CEVRK1GradientDirectionTopToBottom
+} ORK1_ENUM_AVAILABLE;
 
 @class ORK1BorderedButton;
 @class ORK1ContinueButton;
 
 ORK1_CLASS_AVAILABLE
+@interface CEVRK1Gradient : NSObject
+@property (nonatomic, assign) CEVRK1GradientDirection direction;
+@property (nonatomic, strong) UIColor * _Nonnull startColor;
+@property (nonatomic, strong) UIColor * _Nonnull endColor;
+@end
+
+ORK1_CLASS_AVAILABLE
 @interface CEVRK1Theme : NSObject
-
-- (nonnull instancetype)init NS_UNAVAILABLE;
-- (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
-+ (nonnull instancetype)defaultTheme;
 + (nonnull instancetype)themeForElement:(nonnull id)element;
+- (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
 
-- (nullable UIFont *)headlineLabelFontWithSize:(CGFloat)fontSize;
-- (nullable UIColor *)headlineLabelFontColor;
+@property (nonatomic, assign) CEVRK1ThemeType themeType;
+@property (nonatomic, strong) UIColor * _Nullable tintColor;
+
+@property (nonatomic, strong) NSNumber * _Nullable titleFontSize;
+@property (nonatomic, strong) NSNumber * _Nullable titleFontWeight; // UIFontWeight
+@property (nonatomic, strong) UIColor * _Nullable titleColor;
+@property (nonatomic, strong) NSNumber * _Nullable titleAlignment; // NSTextAlignment
+
+@property (nonatomic, strong) NSNumber * _Nullable textFontSize;
+@property (nonatomic, strong) NSNumber * _Nullable textFontWeight; // UIFontWeight
+@property (nonatomic, strong) UIColor * _Nullable textColor;
+@property (nonatomic, strong) NSNumber * _Nullable textAlignment; // NSTextAlignment
+
+@property (nonatomic, strong) NSNumber * _Nullable detailTextFontSize;
+@property (nonatomic, strong) NSNumber * _Nullable detailTextFontWeight; // UIFontWeight
+@property (nonatomic, strong) UIColor * _Nullable detailTextColor;
+@property (nonatomic, strong) NSNumber * _Nullable detailTextAlignment; // NSTextAlignment
+
+@property (nonatomic, strong) UIColor * _Nullable nextButtonBackgroundColor;
+@property (nonatomic, strong) CEVRK1Gradient * _Nullable nextButtonBackgroundGradient;
+@property (nonatomic, strong) NSNumber * _Nullable nextButtonFontWeight; // UIFontWeight
+@property (nonatomic, strong) NSNumber * _Nullable nextButtonTextTransform; // CEVRK1TextTransform
+@property (nonatomic, strong) NSNumber * _Nullable nextButtonLetterSpacing; // in points
+@property (nonatomic, strong) UIColor * _Nullable nextButtonTextColor;
+
+- (void)updateAppearanceForTitleLabel:(nonnull UILabel *)label;
+- (void)updateAppearanceForTextLabel:(nonnull UILabel *)label;
+- (void)updateAttributesForText:(nonnull NSMutableDictionary *)attributes;
+- (void)updateAttributesForDetailText:(nonnull NSMutableDictionary *)attributes;
+- (void)updateAppearanceForContinueButton:(nonnull ORK1ContinueButton *)continueButton;
+
 - (nullable UIColor *)taskViewControllerTintColor;
 - (nullable NSNumber *)navigationContrainerViewButtonConstraintFromContinueButton;
-- (nullable NSNumber *)continueButtonHeightForTextSize:(CGSize)textSize;
-- (nullable NSNumber *)continueButtonWidthForWindowWidth:(CGFloat)windowWidth;
-- (nullable UIColor *)disabledTintColor;
-- (void)updateAppearanceForContinueButton:(nonnull ORK1ContinueButton *)continueButton;
-- (void)updateTextForContinueButton:(nonnull ORK1ContinueButton *)continueButton;
-
 @end
 
 

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -10,7 +10,6 @@
 
 #import "ORK1Defines.h"
 
-extern NSNotificationName _Nonnull const CEVORK1StepViewControllerViewWillAppearNotification;
 extern NSString * _Nonnull const CEVRK1ThemeKey;
 extern NSString * _Nonnull const CEVThemeAttributeName;
 
@@ -40,9 +39,11 @@ ORK1_CLASS_AVAILABLE
 @end
 
 ORK1_CLASS_AVAILABLE
-@interface CEVRK1Theme : NSObject <NSCopying>
-+ (nonnull CEVRK1Theme *)themeByMergingTheme:(nullable CEVRK1Theme *)theme1 withTheme:(nullable CEVRK1Theme *)theme2; // properties from theme take priority over theme2
+@interface CEVRK1Theme : NSObject
++ (nonnull CEVRK1Theme *)themeByOverridingTheme:(nullable CEVRK1Theme *)theme1 withTheme:(nullable CEVRK1Theme *)theme2; // properties from theme2 take priority over theme1
 + (nonnull instancetype)themeForElement:(nonnull id)element;
++ (nonnull CEVRK1Theme *)fallbackTheme;
++ (void)setFallbackTheme:(nonnull CEVRK1Theme *)theme;
 - (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
 
 @property (nonatomic, strong) UIColor * _Nullable tintColor;

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -40,11 +40,11 @@ ORK1_CLASS_AVAILABLE
 @end
 
 ORK1_CLASS_AVAILABLE
-@interface CEVRK1Theme : NSObject
+@interface CEVRK1Theme : NSObject <NSCopying>
++ (nonnull CEVRK1Theme *)themeByMergingTheme:(nullable CEVRK1Theme *)theme1 withTheme:(nullable CEVRK1Theme *)theme2; // properties from theme take priority over theme2
 + (nonnull instancetype)themeForElement:(nonnull id)element;
 - (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
 
-@property (nonatomic, assign) CEVRK1ThemeType themeType;
 @property (nonatomic, strong) UIColor * _Nullable tintColor;
 
 @property (nonatomic, strong) NSNumber * _Nullable titleFontSize;

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -41,7 +41,6 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
 
 + (CEVRK1Theme *)themeByMergingTheme:(nullable CEVRK1Theme *)theme withTheme:(nullable CEVRK1Theme *)theme2 {
     CEVRK1Theme *merged = [[CEVRK1Theme alloc] init];
-    merged.themeType = theme.themeType ?: theme2.themeType;
     merged.tintColor = theme.tintColor ?: theme2.tintColor;
 
     merged.titleFontSize = theme.titleFontSize ?: theme2.titleFontSize;
@@ -101,8 +100,6 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
 
 - (instancetype)initWithType:(CEVRK1ThemeType)type {
     if (self = [super init]) {
-        self.themeType = type;
-        
         if (type == CEVRK1ThemeTypeAllOfUs) {
             self.tintColor = ORK1RGB(0x216fb4);
             self.titleColor = ORK1RGB(0x262262);

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -20,7 +20,6 @@
 - (UIColor *)darkerColor;
 @end
 
-NSNotificationName const CEVORK1StepViewControllerViewWillAppearNotification = @"CEVORK1StepViewControllerViewWillAppearNotification";
 NSString *const CEVThemeAttributeName = @"CEVThemeAttributeName";
 NSString *const CEVRK1ThemeKey = @"cev_theme";
 
@@ -39,31 +38,31 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
 
 @implementation CEVRK1Theme
 
-+ (CEVRK1Theme *)themeByMergingTheme:(nullable CEVRK1Theme *)theme withTheme:(nullable CEVRK1Theme *)theme2 {
++ (CEVRK1Theme *)themeByOverridingTheme:(nullable CEVRK1Theme *)theme withTheme:(nullable CEVRK1Theme *)theme2 {
     CEVRK1Theme *merged = [[CEVRK1Theme alloc] init];
-    merged.tintColor = theme.tintColor ?: theme2.tintColor;
+    merged.tintColor = theme2.tintColor ?: theme.tintColor;
 
-    merged.titleFontSize = theme.titleFontSize ?: theme2.titleFontSize;
-    merged.titleFontWeight = theme.titleFontWeight ?: theme2.titleFontWeight;
-    merged.titleColor = theme.titleColor ?: theme2.titleColor;
-    merged.titleAlignment = theme.titleAlignment ?: theme2.titleAlignment;
+    merged.titleFontSize = theme2.titleFontSize ?: theme.titleFontSize;
+    merged.titleFontWeight = theme2.titleFontWeight ?: theme.titleFontWeight;
+    merged.titleColor = theme2.titleColor ?: theme.titleColor;
+    merged.titleAlignment = theme2.titleAlignment ?: theme.titleAlignment;
 
-    merged.textFontSize = theme.textFontSize ?: theme2.textFontSize;
-    merged.textFontWeight = theme.textFontWeight ?: theme2.textFontWeight;
-    merged.textColor = theme.textColor ?: theme2.textColor;
-    merged.textAlignment = theme.textAlignment ?: theme2.textAlignment;
+    merged.textFontSize = theme2.textFontSize ?: theme.textFontSize;
+    merged.textFontWeight = theme2.textFontWeight ?: theme.textFontWeight;
+    merged.textColor = theme2.textColor ?: theme.textColor;
+    merged.textAlignment = theme2.textAlignment ?: theme.textAlignment;
 
-    merged.detailTextFontSize = theme.detailTextFontSize ?: theme2.detailTextFontSize;
-    merged.detailTextFontWeight = theme.detailTextFontWeight ?: theme2.detailTextFontWeight;
-    merged.detailTextColor = theme.detailTextColor ?: theme2.detailTextColor;
-    merged.detailTextAlignment = theme.detailTextAlignment ?: theme2.detailTextAlignment;
+    merged.detailTextFontSize = theme2.detailTextFontSize ?: theme.detailTextFontSize;
+    merged.detailTextFontWeight = theme2.detailTextFontWeight ?: theme.detailTextFontWeight;
+    merged.detailTextColor = theme2.detailTextColor ?: theme.detailTextColor;
+    merged.detailTextAlignment = theme2.detailTextAlignment ?: theme.detailTextAlignment;
 
-    merged.nextButtonBackgroundColor = theme.nextButtonBackgroundColor ?: theme2.nextButtonBackgroundColor;
-    merged.nextButtonBackgroundGradient = theme.nextButtonBackgroundGradient ?: theme2.nextButtonBackgroundGradient;
-    merged.nextButtonFontWeight = theme.nextButtonFontWeight ?: theme2.nextButtonFontWeight;
-    merged.nextButtonTextTransform = theme.nextButtonTextTransform ?: theme2.nextButtonTextTransform;
-    merged.nextButtonLetterSpacing = theme.nextButtonLetterSpacing ?: theme2.nextButtonLetterSpacing;
-    merged.nextButtonTextColor = theme.nextButtonTextColor ?: theme2.nextButtonTextColor;
+    merged.nextButtonBackgroundColor = theme2.nextButtonBackgroundColor ?: theme.nextButtonBackgroundColor;
+    merged.nextButtonBackgroundGradient = theme2.nextButtonBackgroundGradient ?: theme.nextButtonBackgroundGradient;
+    merged.nextButtonFontWeight = theme2.nextButtonFontWeight ?: theme.nextButtonFontWeight;
+    merged.nextButtonTextTransform = theme2.nextButtonTextTransform ?: theme.nextButtonTextTransform;
+    merged.nextButtonLetterSpacing = theme2.nextButtonLetterSpacing ?: theme.nextButtonLetterSpacing;
+    merged.nextButtonTextColor = theme2.nextButtonTextColor ?: theme.nextButtonTextColor;
     return merged;
 }
 
@@ -79,7 +78,7 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
         id <ORK1Task> task = [(ORK1StepViewController *)element taskViewController].task;
         CEVRK1Theme *taskTheme = task.cev_theme;
         CEVRK1Theme *stepTheme = ((ORK1StepViewController *)element).step.cev_theme;
-        return [CEVRK1Theme themeByMergingTheme:stepTheme withTheme:taskTheme];
+        return [CEVRK1Theme themeByOverridingTheme:taskTheme withTheme:stepTheme];
     } else if ([element respondsToSelector:@selector(nextResponder)] && [element nextResponder]) {                // continue up responder chain
         id nextResponder = [element nextResponder];
         return [CEVRK1Theme themeForElement:nextResponder];
@@ -87,15 +86,21 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
         UIViewController *parentViewController = [element parentViewController];
         return [CEVRK1Theme themeForElement:parentViewController];
     } else {                                                                                                      // has reached end of chain or not in chain
-        UIViewController *viewController = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] presentedViewController];
-        if ([viewController isKindOfClass:[ORK1TaskViewController class]]) {
-            ORK1TaskViewController *taskViewController = (ORK1TaskViewController *)viewController;
-            CEVRK1Theme *taskTheme = taskViewController.task.cev_theme;
-            CEVRK1Theme *stepTheme = taskViewController.currentStepViewController.step.cev_theme;
-            return [CEVRK1Theme themeByMergingTheme:stepTheme withTheme:taskTheme];
-        }
-        return [[CEVRK1Theme alloc] initWithType:CEVRK1ThemeTypeDefault];
+        return [CEVRK1Theme fallbackTheme];
     }
+}
+
+static CEVRK1Theme *sFallbackTheme = nil;
+
++ (nonnull CEVRK1Theme *)fallbackTheme {
+    if (sFallbackTheme != nil) {
+        return sFallbackTheme;
+    }
+    return [[CEVRK1Theme alloc] initWithType:CEVRK1ThemeTypeDefault];
+}
+
++ (void)setFallbackTheme:(nonnull CEVRK1Theme *)theme {
+    sFallbackTheme = theme;
 }
 
 - (instancetype)initWithType:(CEVRK1ThemeType)type {

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -273,7 +273,7 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
         attributes[NSKernAttributeName] = self.nextButtonLetterSpacing;
     }
     
-    NSString *text = continueButton.titleLabel.text;
+    NSString *text = [continueButton titleForState:UIControlStateNormal];
     if (self.nextButtonTextTransform != nil) {
         switch ((CEVRK1TextTransform)self.nextButtonTextTransform.integerValue) {
         case CEVRK1TextTransformUppercase:

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -15,9 +15,13 @@
 #import "ORK1Task.h"
 #import "ORK1Step.h"
 
+@interface UIFont (Scalable)
++ (NSDictionary *)cevrk1_textStyleToPointSize;
++ (UIFont *)cevrk1_preferredFontOfSize:(CGFloat)size weight:(UIFontWeight)weight;
+@end
+
 @interface UIColor (LightAndDark)
-- (UIColor *)lighterColor;
-- (UIColor *)darkerColor;
+- (UIColor *)cevrk1_darkerColor;
 @end
 
 NSString *const CEVThemeAttributeName = @"CEVThemeAttributeName";
@@ -136,10 +140,10 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         label.textAlignment = self.titleAlignment.intValue;
     }
     if (self.titleFontSize != nil) {
-        label.font = [UIFont systemFontOfSize:self.titleFontSize.floatValue weight:UIFontWeightRegular];
+        label.font = [UIFont cevrk1_preferredFontOfSize:self.titleFontSize.floatValue weight:UIFontWeightRegular];
     }
     if (self.titleFontWeight != nil) {
-        label.font = [UIFont systemFontOfSize:label.font.pointSize weight:self.titleFontWeight.floatValue];
+        label.font = [UIFont cevrk1_preferredFontOfSize:label.font.pointSize weight:self.titleFontWeight.floatValue];
     }
 }
 
@@ -155,10 +159,10 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         label.textAlignment = self.textAlignment.intValue;
     }
     if (self.textFontSize != nil) {
-        label.font = [UIFont systemFontOfSize:self.textFontSize.floatValue weight:UIFontWeightRegular];
+        label.font = [UIFont cevrk1_preferredFontOfSize:self.textFontSize.floatValue weight:UIFontWeightRegular];
     }
     if (self.textFontWeight != nil) {
-        label.font = [UIFont systemFontOfSize:label.font.pointSize weight:self.textFontWeight.floatValue];
+        label.font = [UIFont cevrk1_preferredFontOfSize:label.font.pointSize weight:self.textFontWeight.floatValue];
     }
 }
 
@@ -175,11 +179,11 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }
     if (self.textFontSize != nil && self.textFontWeight != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:self.textFontSize.floatValue weight: self.textFontWeight.floatValue];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:self.textFontSize.floatValue weight: self.textFontWeight.floatValue];
     } else if (self.textFontSize != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:self.textFontSize.floatValue weight:UIFontWeightRegular];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:self.textFontSize.floatValue weight:UIFontWeightRegular];
     } else if (self.textFontWeight != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:15 weight:self.textFontWeight.floatValue];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:15 weight:self.textFontWeight.floatValue];
     }
     attributes[CEVThemeAttributeName] = @0; // Flag that we have styled this string.
 }
@@ -197,11 +201,11 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }
     if (self.detailTextFontSize != nil && self.detailTextFontWeight != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:self.detailTextFontSize.floatValue weight: self.detailTextFontWeight.floatValue];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:self.detailTextFontSize.floatValue weight: self.detailTextFontWeight.floatValue];
     } else if (self.detailTextFontSize != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:self.detailTextFontSize.floatValue weight:UIFontWeightRegular];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:self.detailTextFontSize.floatValue weight:UIFontWeightRegular];
     } else if (self.detailTextFontWeight != nil) {
-        attributes[NSFontAttributeName] = [UIFont systemFontOfSize:15 weight:self.detailTextFontWeight.floatValue];
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:15 weight:self.detailTextFontWeight.floatValue];
     }
     attributes[CEVThemeAttributeName] = @0; // Flag that we have styled this string.
 }
@@ -239,7 +243,7 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         borderWidth = 1;
         borderColor = [UIColor colorWithWhite:0.7 alpha:1.0];
     } else if (continueButton.highlighted || continueButton.selected) {
-        gradient.colors = @[(id)startColor.darkerColor.CGColor, (id)endColor.darkerColor.CGColor];
+        gradient.colors = @[(id)startColor.cevrk1_darkerColor.CGColor, (id)endColor.cevrk1_darkerColor.CGColor];
     } else {
         gradient.colors = @[(id)startColor.CGColor, (id)endColor.CGColor];
     }
@@ -260,9 +264,10 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
     
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
-    UIFont *font = [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] weight:UIFontWeightSemibold];
+    CGFloat fontSize = [[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue];
+    UIFont *font = [UIFont cevrk1_preferredFontOfSize:fontSize weight:UIFontWeightSemibold];
     if (self.nextButtonFontWeight != nil) {
-        font = [UIFont systemFontOfSize:font.pointSize weight:self.nextButtonFontWeight.floatValue];
+        font = [UIFont cevrk1_preferredFontOfSize:fontSize weight:self.nextButtonFontWeight.floatValue];
     }
     attributes[NSFontAttributeName] = font;
     
@@ -314,18 +319,7 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
 // https://stackoverflow.com/a/11598127
 @implementation UIColor (LightAndDark)
 
-- (UIColor *)lighterColor
-{
-    CGFloat h, s, b, a;
-    if ([self getHue:&h saturation:&s brightness:&b alpha:&a])
-        return [UIColor colorWithHue:h
-                          saturation:s
-                          brightness:MIN(b * 1.3, 1.0)
-                               alpha:a];
-    return nil;
-}
-
-- (UIColor *)darkerColor
+- (UIColor *)cevrk1_darkerColor
 {
     CGFloat h, s, b, a;
     if ([self getHue:&h saturation:&s brightness:&b alpha:&a])
@@ -335,4 +329,49 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
                                alpha:a];
     return nil;
 }
+@end
+
+@implementation UIFont (Scalable)
+
++ (NSDictionary *)cevrk1_textStyleToPointSize {
+    NSMutableDictionary *dict = [@{
+        UIFontTextStyleTitle1: @28,
+        UIFontTextStyleTitle2: @22,
+        UIFontTextStyleTitle3: @20,
+        UIFontTextStyleHeadline: @17,
+        UIFontTextStyleBody: @17,
+        UIFontTextStyleCallout: @16,
+        UIFontTextStyleSubheadline: @15,
+        UIFontTextStyleFootnote: @13,
+        UIFontTextStyleCaption1: @12,
+        UIFontTextStyleCaption2: @11,
+    } mutableCopy];
+    if (@available(iOS 11.0, *)) {
+        dict[UIFontTextStyleLargeTitle] = @34;
+    }
+    return dict;
+}
+
++ (UIFont *)cevrk1_preferredFontOfSize:(CGFloat)size weight:(UIFontWeight)weight {
+    if (@available(iOS 11.0, *)) {
+        // Find closest style to the given size
+        NSString *style = UIFontTextStyleBody;
+        CGFloat diff = fabs(size - 17);
+        for (NSString *i in [UIFont cevrk1_textStyleToPointSize].allKeys) {
+            NSString *currStyle = i;
+            CGFloat currSize = ((NSNumber *)[UIFont cevrk1_textStyleToPointSize][i]).floatValue;
+            CGFloat currDiff = fabs(currSize - size);
+            if (currDiff < diff) {
+                diff = currDiff;
+                style = currStyle;
+            }
+        }
+
+        UIFont *font = [UIFont systemFontOfSize:size weight:weight];
+        return [[UIFontMetrics metricsForTextStyle:style] scaledFontForFont:font];
+    } else {
+        return [UIFont systemFontOfSize:size weight:weight];
+    }
+}
+
 @end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -85,22 +85,23 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
     } else if ([element respondsToSelector:@selector(parentViewController)] && [element parentViewController]) {  // if has parentViewController, try that route
         UIViewController *parentViewController = [element parentViewController];
         return [CEVRK1Theme themeForElement:parentViewController];
+    } else if (sFallbackTaskViewController != nil) {                                                              // if has fallback, try fallback
+        CEVRK1Theme *taskTheme = sFallbackTaskViewController.task.cev_theme;
+        CEVRK1Theme *stepTheme = sFallbackTaskViewController.currentStepViewController.step.cev_theme;
+        return [CEVRK1Theme themeByOverridingTheme:taskTheme withTheme:stepTheme];
     } else {                                                                                                      // has reached end of chain or not in chain
-        return [CEVRK1Theme fallbackTheme];
+        return [[CEVRK1Theme alloc] init];
     }
 }
 
-static CEVRK1Theme *sFallbackTheme = nil;
+__weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
 
-+ (nonnull CEVRK1Theme *)fallbackTheme {
-    if (sFallbackTheme != nil) {
-        return sFallbackTheme;
-    }
-    return [[CEVRK1Theme alloc] initWithType:CEVRK1ThemeTypeDefault];
++ (nullable ORK1TaskViewController *)fallbackTaskViewController {
+    return sFallbackTaskViewController;
 }
 
-+ (void)setFallbackTheme:(nonnull CEVRK1Theme *)theme {
-    sFallbackTheme = theme;
++ (void)setFallbackTaskViewController:(nullable ORK1TaskViewController *)taskViewController {
+    sFallbackTaskViewController = taskViewController;
 }
 
 - (instancetype)initWithType:(CEVRK1ThemeType)type {

--- a/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.h
@@ -39,9 +39,9 @@ ORK1_CLASS_AVAILABLE
 @interface ORK1ContinueButton : ORK1BorderedButton
 
 - (instancetype)initWithTitle:(NSString *)title isDoneButton:(BOOL)isDoneButton;
-+ (UIFont *)defaultFont;
-- (CGFloat)buttonWidthForWindow:(UIWindow *)window;
-- (CGFloat)buttonHeightForWindow:(UIWindow *)window;
+
+@property (nonatomic, readonly) NSLayoutConstraint *widthConstraint;
+@property (nonatomic, readonly) NSLayoutConstraint *heightConstraint;
 
 @property (nonatomic) BOOL isDoneButton;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.m
@@ -65,34 +65,17 @@ static const CGFloat ContinueButtonTouchMargin = 10;
     if (self.traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass) {
         [self updateConstraintConstantsForWindow:self.window];
     }
-    
-    if (self.traitCollection.preferredContentSizeCategory != previousTraitCollection.preferredContentSizeCategory) {
-        [[CEVRK1Theme themeForElement:self] updateTextForContinueButton:self];
-    }
 }
 
 - (void)updateConstraintConstantsForWindow:(UIWindow *)window {
-    _heightConstraint.constant = [self buttonHeightForWindow:window];
-    _widthConstraint.constant = [self buttonWidthForWindow:window];
-}
-
-- (CGFloat)buttonWidthForWindow:(UIWindow *)window {
-    NSNumber *overrideWidth = [[CEVRK1Theme themeForElement:self] continueButtonWidthForWindowWidth:window.frame.size.width];
-    
-    if (overrideWidth) {
-        return overrideWidth.floatValue;
-    } else {
-        return ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonWidth, self.window);
-    }
-}
-
-- (CGFloat)buttonHeightForWindow:(UIWindow *)window {
     CGFloat height = (self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact) ?
-    ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonHeightCompact, window) :
-    ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonHeightRegular, window);
+        ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonHeightCompact, window) :
+        ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonHeightRegular, window);
+    _heightConstraint.constant = height;
     
-    CGSize textSize = [self.titleLabel.text sizeWithAttributes:@{NSFontAttributeName : [ORK1ContinueButton defaultFont]}];
-    return ([[CEVRK1Theme themeForElement:self] continueButtonHeightForTextSize:textSize] ?: @(height)).floatValue;
+    _widthConstraint.constant = ORK1GetMetricForWindow(ORK1ScreenMetricContinueButtonWidth, self.window);
+    
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForContinueButton:self];
 }
     
 - (void)setUpConstraints {
@@ -119,11 +102,6 @@ static const CGFloat ContinueButtonTouchMargin = 10;
 - (void)updateConstraints {
     [self updateConstraintConstantsForWindow:self.window];
     [super updateConstraints];
-}
-
-+ (UIFont *)defaultFont {
-    UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
-    return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue]];
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {

--- a/ORK1Kit/ORK1Kit/Common/ORK1HeadlineLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1HeadlineLabel.m
@@ -36,15 +36,7 @@
 
 #import "CEVRK1Theme.h"
 
-@interface ORK1HeadlineLabel()
-
-@property (nonatomic, strong, nullable) CEVRK1Theme *cev_theme;
-
-@end
-
 @implementation ORK1HeadlineLabel
-
-@synthesize cev_theme = _cev_theme;
 
 + (UIFont *)defaultFontInSurveyMode:(BOOL)surveyMode {
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
@@ -60,24 +52,8 @@
     return [self defaultFontInSurveyMode:NO];
 }
 
-- (instancetype)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
-    if (self) {
-        __weak __typeof__(self) weakSelf = self;
-        [NSNotificationCenter.defaultCenter addObserverForName:CEVORK1StepViewControllerViewWillAppearNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
-            CEVRK1Theme *theme = note.userInfo[CEVRK1ThemeKey];
-            if ([theme isKindOfClass:[CEVRK1Theme class]]) {
-                weakSelf.cev_theme = theme;
-                [weakSelf updateAppearance];
-            }
-        }];
-    }
-    return self;
-}
-
 - (UIFont *)defaultFont {
-    UIFont *defaultFontForSurveyMode = [[self class] defaultFontInSurveyMode:_useSurveyMode];
-    return [[CEVRK1Theme themeForElement:self] headlineLabelFontWithSize:defaultFontForSurveyMode.pointSize] ?: defaultFontForSurveyMode;
+    return [[self class] defaultFontInSurveyMode:_useSurveyMode];
 }
 
 - (void)setUseSurveyMode:(BOOL)useSurveyMode {
@@ -87,12 +63,8 @@
 
 // Nasty override (hack)
 - (void)updateAppearance {
-    UIColor *overrideColor = [[CEVRK1Theme themeForElement:self] headlineLabelFontColor];
-    if (overrideColor) {
-        self.textColor = overrideColor;
-    }
-    
     self.font = [self defaultFont];
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForTitleLabel:self];
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
@@ -43,6 +43,7 @@
 
 #import "ORK1Helpers_Internal.h"
 #import "ORK1Skin.h"
+#import "CEVRK1Theme.h"
 
 
 @implementation ORK1InstructionStepView {
@@ -151,14 +152,18 @@
     text = text.length ? text : nil;
     
     if (detail && text) {
-        [attributedInstruction appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n", text] attributes:nil]];
+        NSMutableDictionary *textAttributes = [NSMutableDictionary dictionary];
+        [[CEVRK1Theme themeForElement:self] updateAttributesForText:textAttributes];
+        [attributedInstruction appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n", text] attributes:textAttributes]];
 
         NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
         [style setParagraphSpacingBefore:self.headerView.instructionLabel.font.lineHeight * 0.5];
         [style setAlignment:NSTextAlignmentCenter];
         
+        NSMutableDictionary *detailAttributes = [@{NSParagraphStyleAttributeName: style} mutableCopy];
+        [[CEVRK1Theme themeForElement:self] updateAttributesForDetailText:detailAttributes];
         NSAttributedString *attString = [[NSMutableAttributedString alloc] initWithString:detail
-                                                                               attributes:@{NSParagraphStyleAttributeName: style}];
+                                                                               attributes:detailAttributes];
         [attributedInstruction appendAttributedString:attString];
         
     } else if (detail || text) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Label.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Label.m
@@ -32,6 +32,7 @@
 #import "ORK1Label.h"
 
 #import "ORK1Helpers_Internal.h"
+#import "CEVRK1Theme.h"
 
 
 @implementation ORK1Label
@@ -66,7 +67,10 @@
 }
 
 - (void)updateAppearance {
-    self.font = [[self class] defaultFont];
+    // If we have styled this, don't override
+    if (self.attributedText.length > 0 && [self.attributedText attribute:CEVThemeAttributeName atIndex:0 effectiveRange:nil] == nil) {
+        self.font = [[self class] defaultFont];
+    }
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -32,6 +32,7 @@
 @import Foundation;
 @import HealthKit;
 #import <ORK1Kit/ORK1Types.h>
+#import "CEVRK1Theme.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -62,7 +63,7 @@ ORK1_EXTERN NSString *const ORK1NullStepIdentifier ORK1_AVAILABLE_DECL;
  instead.
  */
 ORK1_CLASS_AVAILABLE
-@interface ORK1Step : NSObject <NSSecureCoding, NSCopying>
+@interface ORK1Step : NSObject <NSSecureCoding, NSCopying, CEVRK1ThemedUIElement>
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
@@ -217,6 +218,13 @@ ORK1_CLASS_AVAILABLE
  @return A newly initialized step view controller.
  */
 - (ORK1StepViewController *)instantiateStepViewControllerWithResult:(ORK1Result *)result;
+
+/**
+ The theme for the step.
+ 
+ Various UI elements may check the theme and use it to apply modifications.
+ */
+@property (nonatomic, retain, nullable) CEVRK1Theme *cev_theme;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
@@ -168,11 +168,6 @@
     
     // clear dismissedDate
     self.dismissedDate = nil;
-    
-    // Certain nested UI Elements (e.g., ORK1HeadlineLabel) are attached to view hierarchy late in the lifecycle. This can cause a noticable,
-    // unintended animation of state change as the view animates into view. Setting the fallback theme can ensure a redraw cycle of the 
-    // receiving element can "see" the theme prior to being inside the responder chain so the first displayed draw is the expected theme.
-    [CEVRK1Theme setFallbackTheme:[CEVRK1Theme themeForElement:self]];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
@@ -170,12 +170,9 @@
     self.dismissedDate = nil;
     
     // Certain nested UI Elements (e.g., ORK1HeadlineLabel) are attached to view hierarchy late in the lifecycle. This can cause a noticable,
-    // unintended animation of state change as the view animates into view. Posting this notification and handling theme application upon
-    // receipt can ensure a redraw cycle of the receiving element can "see" the theme prior to being inside the responder chain so the first
-    // displayed draw is the expected theme.
-    NSDictionary *userInfo = @{CEVRK1ThemeKey : [CEVRK1Theme themeForElement:self]};
-    NSNotification *notification = [NSNotification notificationWithName:CEVORK1StepViewControllerViewWillAppearNotification object:nil userInfo:userInfo];
-    [NSNotificationCenter.defaultCenter postNotification:notification];
+    // unintended animation of state change as the view animates into view. Setting the fallback theme can ensure a redraw cycle of the 
+    // receiving element can "see" the theme prior to being inside the responder chain so the first displayed draw is the expected theme.
+    [CEVRK1Theme setFallbackTheme:[CEVRK1Theme themeForElement:self]];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ORK1Kit/ORK1Kit/Common/ORK1SubheadlineLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SubheadlineLabel.m
@@ -32,6 +32,7 @@
 #import "ORK1SubheadlineLabel.h"
 
 #import "ORK1Skin.h"
+#import "CEVRK1Theme.h"
 
 
 @implementation ORK1SubheadlineLabel
@@ -40,6 +41,11 @@
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleSubheadline];
     const CGFloat defaultSize = 15;
     return [UIFont systemFontOfSize:[[descriptor objectForKey:UIFontDescriptorSizeAttribute] doubleValue] - defaultSize + ORK1GetMetricForWindow(ORK1ScreenMetricFontSizeSubheadline, nil)];
+}
+
+- (void)updateAppearance {
+    [super updateAppearance];
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForTextLabel:self];
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -636,6 +636,11 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
+    // Certain nested UI Elements (e.g., ORK1HeadlineLabel) are attached to view hierarchy late in the lifecycle. This can cause a noticable,
+    // unintended animation of state change as the view animates into view. Setting the fallback task can ensure a redraw cycle of the
+    // receiving element can "see" the theme prior to being inside the responder chain so the first displayed draw is the expected theme.
+    [CEVRK1Theme setFallbackTaskViewController:self];
+    
     UIColor *overrideTintColor = [[CEVRK1Theme themeForElement:self.view] taskViewControllerTintColor];
     if (overrideTintColor) {
         self.view.tintColor = overrideTintColor;


### PR DESCRIPTION
Adds a bunch of different themeable properties to CEVRK1Theme. And adds new methods to let the theme configure various label and buttons. Also makes it so ORK1Step has a theme property. And when calculating an object's theme, merges the step's theme with the task's theme.

Depends on https://github.com/CareEvolution/CEVResearchKit/pull/218. Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/717