### PR TITLE
Fix issue where next button appears as done

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -196,7 +196,7 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
 - (void)updateTextForContinueButton:(ORK1ContinueButton *)continueButton {
     switch (self.themeType) {
         case CEVRK1ThemeTypeAllOfUs: {
-            if (!continueButton.titleLabel.text) {
+            if (![continueButton titleForState:UIControlStateNormal]) {
                 return;
             }
             
@@ -206,7 +206,7 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
             NSDictionary *attributes = @{           NSFontAttributeName            : [UIFont boldSystemFontOfSize:fontToMakeBold.pointSize],
                                                     NSForegroundColorAttributeName : textColor,
                                                     NSKernAttributeName            : @(3)};  // 3 pts = 0.25 em
-            NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:[continueButton.titleLabel.text uppercaseString] attributes:attributes];
+            NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:[[continueButton titleForState:UIControlStateNormal] uppercaseString] attributes:attributes];
             [continueButton setAttributedTitle:attributedString forState:UIControlStateNormal];
             break;
         }


### PR DESCRIPTION
Regression from https://github.com/CareEvolution/ResearchKit/pull/65/files#diff-d93daa5eaf45ff953bdb75e7f1217db8L143. It's causing the button to get styled earlier, and attributedTitleForState takes priority over titleForState so calling continueButton.titleLabel.text is not reading in the most recently set title