### PR TITLE
Move button (Next/Done) update to only occur upon cell selection

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -517,13 +517,6 @@
     _savedAnswerDates[identifier] = [NSDate date];
     _savedSystemCalendars[identifier] = [NSCalendar currentCalendar];
     _savedSystemTimeZones[identifier] = [NSTimeZone systemTimeZone];
-    
-    if (self.hasNextStep == NO) {
-        self.continueButtonItem = self.internalDoneButtonItem;
-    } else {
-        self.continueButtonItem = self.internalContinueButtonItem;
-    }
-    //check if next step and update buttons?
 }
 
 // Override to monitor button title change
@@ -1069,6 +1062,11 @@
         NSString *formItemIdentifier = cellItem.formItem.identifier;
         if (answer && formItemIdentifier) {
             [self setAnswer:answer forIdentifier:formItemIdentifier];
+            if (self.hasNextStep == NO) {
+                self.continueButtonItem = self.internalDoneButtonItem;
+            } else {
+                self.continueButtonItem = self.internalContinueButtonItem;
+            }
         } else if (answer == nil && formItemIdentifier) {
             [self removeAnswerForIdentifier:formItemIdentifier];
         }

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -497,12 +497,6 @@
     _savedAnswerDates[identifier] = [NSDate date];
     _savedSystemCalendars[identifier] = [NSCalendar currentCalendar];
     _savedSystemTimeZones[identifier] = [NSTimeZone systemTimeZone];
-    
-    if (self.hasNextStep == YES) {
-        self.continueButtonItem = self.internalContinueButtonItem;
-    } else {
-        self.continueButtonItem = self.internalDoneButtonItem;
-    }
 }
 
 // Override to monitor button title change
@@ -1190,6 +1184,11 @@
         NSString *formItemIdentifier = cellItem.formItem.identifier;
         if (answer && formItemIdentifier) {
             [self setAnswer:answer forIdentifier:formItemIdentifier];
+            if (self.hasNextStep == NO) {
+                self.continueButtonItem = self.internalDoneButtonItem;
+            } else {
+                self.continueButtonItem = self.internalContinueButtonItem;
+            }
         } else if (answer == nil && formItemIdentifier) {
             [self removeAnswerForIdentifier:formItemIdentifier];
         }


### PR DESCRIPTION
Fixes a crash that would occur when navigating backwards into a FormStep - on both RK1/RK2. Have also made the code used identical between RK2 and RK1 for consistency.