### PR TITLE
Align text / titles with buttons and text choices

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -377,6 +377,8 @@
     
     // Reset skipped flag - result can now be non-empty
     _skipped = NO;
+    
+    [_tableContainer layoutIfNeeded];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Skin.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Skin.m
@@ -248,7 +248,7 @@ CGFloat ORK1GetMetricForWindow(ORK1ScreenMetric metric, UIWindow *window) {
 }
 
 const CGFloat ORK1LayoutMarginWidthRegularBezel = 15.0;
-const CGFloat ORK1LayoutMarginWidthThinBezelRegular = 20.0;
+const CGFloat ORK1LayoutMarginWidthThinBezelRegular = 15.0;
 const CGFloat ORK1LayoutMarginWidthiPad = 115.0;
 
 CGFloat ORK1StandardLeftTableViewCellMarginForWindow(UIWindow *window) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView.m
@@ -132,6 +132,7 @@
 #endif
         [self setUpConstraints];
         [self setNeedsUpdateConstraints];
+        self.layoutMargins = UIEdgeInsetsMake(8, 15, 8, 15);
     }
     return self;
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -150,7 +150,7 @@
         CGSize footerSize = [_continueSkipContainerView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
         CGRect footerBounds = (CGRect){{0,0},footerSize};
         
-        CGFloat boundsHeightUnused = _tableView.bounds.size.height - _tableView.contentSize.height;
+        CGFloat boundsHeightUnused = _tableView.bounds.size.height - _tableView.contentSize.height - _tableView.adjustedContentInset.bottom - _tableView.adjustedContentInset.top;
         if (boundsHeightUnused > footerBounds.size.height) {
             _tableView.scrollEnabled = YES;
             footerBounds.size.height = boundsHeightUnused;

--- a/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
@@ -100,6 +100,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
         
         {
             _headerView = [ORK1StepHeaderView new];
+            _headerView.layoutMargins = UIEdgeInsetsZero;
             _headerView.translatesAutoresizingMaskIntoConstraints = NO;
             [_container addSubview:_headerView];
         }
@@ -372,7 +373,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
     UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
     self.layoutMargins = layoutMargins;
     _scrollContainer.layoutMargins = layoutMargins;
-    _container.layoutMargins = UIEdgeInsetsZero;
+    _container.layoutMargins = layoutMargins;
 }
 
 - (void)updateConstraintConstantsForWindow:(UIWindow *)window {

--- a/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
@@ -100,7 +100,6 @@ static const CGFloat AssumedStatusBarHeight = 20;
         
         {
             _headerView = [ORK1StepHeaderView new];
-            _headerView.layoutMargins = UIEdgeInsetsZero;
             _headerView.translatesAutoresizingMaskIntoConstraints = NO;
             [_container addSubview:_headerView];
         }
@@ -373,7 +372,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
     UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
     self.layoutMargins = layoutMargins;
     _scrollContainer.layoutMargins = layoutMargins;
-    _container.layoutMargins = layoutMargins;
+    _container.layoutMargins = UIEdgeInsetsZero;
 }
 
 - (void)updateConstraintConstantsForWindow:(UIWindow *)window {


### PR DESCRIPTION
ResearchKit layout code is gnarly. Most of this was found through trial and error. Explanations inline. Running the CEVRK1SnapshotTests shows the expected alignment changes.
![IMG_E89041C4A338-1](https://user-images.githubusercontent.com/758035/83703220-bad5c900-a5c3-11ea-9360-43ba46b479da.jpeg)


Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/739