### PR TITLE
Fix hidePredicate behavior and UI formatting

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Caption1Label.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Caption1Label.m
@@ -37,10 +37,9 @@
 @implementation ORK1Caption1Label
 
 + (UIFont *)defaultFont {
-    // medium , 17
-    UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleCaption1];
-    const CGFloat defaultSize = 12;
-    return ORK1MediumFontWithSize([[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] + 17.0 - defaultSize);
+    // bold, 17
+    UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
+    return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - 0.0 weight: UIFontWeightBold];
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -282,11 +282,11 @@
     // This is a hacky way to align the section header leading margin to that of the ORK1FormCell's leading margin,
     CGFloat marginOffset;
     if ([[[UIDevice currentDevice] model] isEqualToString:@"iPad"]) {
-        marginOffset = 10.0;
-    } else {
         marginOffset = 13.0;
+    } else {
+        marginOffset = 18.0;
     }
-    self.leftMarginConstraint.constant = marginOffset; //_tableView.layoutMargins.left + marginOffset;
+    self.leftMarginConstraint.constant = marginOffset;
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -277,7 +277,15 @@
 
 - (void)updateConstraints {
     [super updateConstraints];
-    self.leftMarginConstraint.constant = _tableView.layoutMargins.left;
+    
+    // This is a hacky way to align the section header leading margin to that of the ORK1FormCell's leading margin,
+    CGFloat marginOffset;
+    if ([[[UIDevice currentDevice] model] isEqualToString:@"iPad"]) {
+        marginOffset = 10.0;
+    } else {
+        marginOffset = 13.0;
+    }
+    self.leftMarginConstraint.constant = _tableView.layoutMargins.left + marginOffset;
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -286,7 +286,7 @@
     } else {
         marginOffset = 13.0;
     }
-    self.leftMarginConstraint.constant = _tableView.layoutMargins.left + marginOffset;
+    self.leftMarginConstraint.constant = marginOffset; //_tableView.layoutMargins.left + marginOffset;
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -171,6 +171,7 @@
         
         [textChoiceAnswerFormat.textChoices enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             ORK1TableCellItem *cellItem = [[ORK1TableCellItem alloc] initWithFormItem:item choiceIndex:idx];
+            _cellItemForFormItem[item] = cellItem;
             [(NSMutableArray *)self.items addObject:cellItem];
         }];
         
@@ -734,6 +735,7 @@
     
     for (ORK1TableSection *section in _allSections) {
         BOOL hideSection = YES;
+        BOOL sectionHasChanges = NO;
         for (ORK1FormItem *formItem in section.formItems) {
             BOOL formItemIsHidden = [formItem.hidePredicate evaluateWithObject:@[taskResult]
                                                          substitutionVariables:@{ORK1ResultPredicateTaskIdentifierVariableName : taskResult.identifier}];
@@ -741,9 +743,15 @@
             if (formItemIsHidden) {
                 if (cellItem) {
                     [_hiddenCellItems addObject:cellItem];
+                    if (![oldHiddenCellItems containsObject:cellItem]) {
+                        sectionHasChanges = YES;
+                    }
                 }
                 [_hiddenFormItems addObject:formItem];
             } else {
+                if (cellItem && [oldHiddenCellItems containsObject:cellItem]) {
+                    sectionHasChanges = YES;
+                }
                 hideSection = NO;
             }
         }
@@ -752,7 +760,7 @@
             if (![oldSections containsObject:section]) {
                 [sectionsToInsert addIndex:_sections.count - 1];
             }
-            if (section.formItems.count > 1 && ![oldHiddenCellItems isEqualToArray:_hiddenCellItems]) {
+            if (section.formItems.count > 1 && sectionHasChanges) {
                 [sectionsToUpdateCells addIndex:_sections.count - 1];
             }
         } else {

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -1140,8 +1140,10 @@
 - (void)formItemCell:(ORK1FormItemCell *)cell answerDidChangeTo:(id)answer {
     if (answer && cell.formItem.identifier) {
         [self setAnswer:answer forIdentifier:cell.formItem.identifier];
+        [self hideSections];
     } else if (answer == nil && cell.formItem.identifier) {
         [self removeAnswerForIdentifier:cell.formItem.identifier];
+        [self hideSections];
     }
     
     _skipped = NO;

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -174,6 +174,7 @@
         [textChoiceAnswerFormat.textChoices enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             ORKTableCellItem *cellItem = [[ORKTableCellItem alloc] initWithFormItem:item choiceIndex:idx];
             [(NSMutableArray *)self.items addObject:cellItem];
+            _cellItemForFormItem[item] = cellItem;
         }];
         
     } else {
@@ -829,11 +830,6 @@
                 hideSection = NO;
             }
         }
-        
-        /*
-         Due to cell re-creation to fix rounded corners with changes, the tableview resigns any first responder so if in the middle of
-         editing a text field, we need to capture and re
-         */
         
         if (hideSection) {
             if (currentSectionIndex != NSNotFound) {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/761. The `hideSections()` method was only being called based on tableViewCell selection. However, there are other cases which modify the answers which could affect cell visibility. These two cases: textField edits and picker selections are now handled appropriately. 

There were some other issues in RK2 that @chrisnowak mentioned to me earlier that are also fixed here because the firstResponder was being dismissed when cells were being greedily recreated when there were no changes in hiding/visibility. 

Added a [slew of tests for this in CEVResearchKit](https://github.com/CareEvolution/CEVResearchKit/pull/224) to "embed these in amber" and prevent regression as the code in here is nasty.

In reviewing UI inconsistencies, since RK mixes and matches sections and tableViewCells based on the answerFormat, there is a difference now in font weight occasionally as well as leading margin of a question based on answerFormat. 

This PR addresses this by updating `ORK1Caption1Label` to have same font weight/size as `ORK1FormSectionTitleLabel` which was changed in [this PR](https://github.com/CareEvolution/ResearchKit/pull/48). The side-effect here is that this format will also affect the Consent Review as both share this class. If we don't want this, we can look at separating this out. Aligning the margin is difficult because of view cycle for layout of a tableViewSectionHeader and tableViewCells. Ideally we would have a constraint lining these up, instead of relying on constants.

UI Changes
|BEFORE|AFTER|
|---|---|
|![Simulator Screen Shot - iPhone 11 - 2020-07-11 at 11 46 21](https://user-images.githubusercontent.com/1008462/87229252-3f0e2f80-c36c-11ea-959b-46a9aa5375bb.png)|![Simulator Screen Shot - iPhone 11 - 2020-07-11 at 11 48 14](https://user-images.githubusercontent.com/1008462/87229276-68c75680-c36c-11ea-805a-ddedd63b7cdd.png)|



