### PR TITLE
Fix TimeOfDay predicate composition and invalid logic

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.m
@@ -429,8 +429,7 @@ return [self predicateMatchingResultSelector:resultSelector
                                                 @(minimumExpectedMinute),
                                                 @(maximumExpectedHour),
                                                 @(maximumExpectedHour),
-                                                @(maximumExpectedMinute) ]
-              areSubPredicateFormatsSubquery: NO];
+                                                @(maximumExpectedMinute) ]];
 }
 
 + (NSPredicate *)predicateForTimeIntervalQuestionResultWithResultSelector:(ORK1ResultSelector *)resultSelector

--- a/ResearchKit/Common/ORKResultPredicate.m
+++ b/ResearchKit/Common/ORKResultPredicate.m
@@ -215,7 +215,15 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
             // or part of an additional subquery predicate (for question results with an array of answers, like ORKChoiceQuestionResult).
             for (NSString *subPredicateFormat in subPredicateFormatArray) {
                 if (!areSubPredicateFormatsSubquery) {
-                    [format appendString:@" AND $z."];
+                    if ([subPredicateFormat hasPrefix:@"("]) {
+                        /*
+                           For complex queries (e.g. TimeOfDay) where nested logic is needed, we will skip the $z. prefix
+                           and allow the caller to handle. NOTE: caller will need to prefix any key references with '$z'
+                         */
+                        [format appendString:@" AND "];
+                    } else {
+                        [format appendString:@" AND $z."];
+                    }
                     [format appendString:subPredicateFormat];
                 } else {
                     [format appendString:@" AND SUBQUERY($z."];
@@ -410,19 +418,18 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
 }
 
 + (NSPredicate *)predicateForTimeOfDayQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector
-                                                   minimumExpectedHour:(NSInteger)minimumExpectedHour
-                                                 minimumExpectedMinute:(NSInteger)minimumExpectedMinute
-                                                   maximumExpectedHour:(NSInteger)maximumExpectedHour
-                                                 maximumExpectedMinute:(NSInteger)maximumExpectedMinute {
-    return [self predicateMatchingResultSelector:resultSelector
-                         subPredicateFormatArray:@[ @"answer.hour >= %@",
-                                                    @"answer.minute >= %@",
-                                                    @"answer.hour <= %@",
-                                                    @"answer.minute <= %@" ]
-                 subPredicateFormatArgumentArray:@[ @(minimumExpectedHour),
-                                                    @(minimumExpectedMinute),
-                                                    @(maximumExpectedHour),
-                                                    @(maximumExpectedMinute) ]];
+                                               minimumExpectedHour:(NSInteger)minimumExpectedHour
+                                             minimumExpectedMinute:(NSInteger)minimumExpectedMinute
+                                               maximumExpectedHour:(NSInteger)maximumExpectedHour
+                                             maximumExpectedMinute:(NSInteger)maximumExpectedMinute {
+return [self predicateMatchingResultSelector:resultSelector
+                     subPredicateFormatArray:@[ @"($z.answer.hour > %@ OR ($z.answer.hour == %@ AND $z.answer.minute >= %@)) AND ($z.answer.hour < %@ OR ($z.answer.hour == %@ AND $z.answer.minute <= %@))" ]
+             subPredicateFormatArgumentArray:@[ @(minimumExpectedHour),
+                                                @(minimumExpectedHour),
+                                                @(minimumExpectedMinute),
+                                                @(maximumExpectedHour),
+                                                @(maximumExpectedHour),
+                                                @(maximumExpectedMinute) ]];
 }
 
 + (NSPredicate *)predicateForTimeIntervalQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/225. The logic here was incorrect. The assumption made here is that we test hours and minutes independently, however, we should only test minutes if the hour is equal. 

Currently (pseudocode):
```pseudocode
if selectedHour > minimumHour AND selectedMinute > minimumMinute ...
```
but it should be:
```pseudocode
if selectedHour == minimumHour {
  // now check minutes 
}
```

... repeat for maximums. The fix is a bit of a hack where we need to insert custom logic inside a `SUBQUERY` of an `NSPredicate`. I needed to override standard behavior for this case so I could use parentheses for a more complex expression. Tests added in CEVResearchKit.

Once approved, I will also take a few minutes and drop a PR against the most recent version of ResearchKit since this would affect ALL users of ResearchKit.