### PR TITLE
Add progressBarColor

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 
 #import "CEVRK1NavigationBarProgressView.h"
+#import "CEVRK1Theme.h"
 
 
 @implementation CEVRK1NavigationBarProgressView {
@@ -45,6 +46,10 @@
 
 - (void)setProgress:(float)progress {
     _progressView.progress = progress;
+    CEVRK1Theme *theme = [CEVRK1Theme themeForElement:self];
+    if (theme.progressBarColor) {
+        _progressView.tintColor = theme.progressBarColor;
+    }
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -71,6 +71,8 @@ ORK1_CLASS_AVAILABLE
 @property (nonatomic, strong) NSNumber * _Nullable nextButtonLetterSpacing; // in points
 @property (nonatomic, strong) UIColor * _Nullable nextButtonTextColor;
 
+@property (nonatomic, strong) UIColor * _Nullable progressBarColor;
+
 - (void)updateAppearanceForTitleLabel:(nonnull UILabel *)label;
 - (void)updateAppearanceForTextLabel:(nonnull UILabel *)label;
 - (void)updateAttributesForText:(nonnull NSMutableDictionary *)attributes;

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -67,6 +67,9 @@ NSString *const CEVRK1ThemeKey = @"cev_theme";
     merged.nextButtonTextTransform = theme2.nextButtonTextTransform ?: theme.nextButtonTextTransform;
     merged.nextButtonLetterSpacing = theme2.nextButtonLetterSpacing ?: theme.nextButtonLetterSpacing;
     merged.nextButtonTextColor = theme2.nextButtonTextColor ?: theme.nextButtonTextColor;
+    
+    merged.progressBarColor = theme2.progressBarColor ?: theme.progressBarColor;
+    
     return merged;
 }
 


### PR DESCRIPTION
Closes https://github.com/CareEvolution/RKStudio-Participant/issues/800. This adds `progressBarColor` to the `CEVRK1Theme` and colors the new progress bar according to current theme/style. 

NOTE: Since themes are not currently supported in RK2, this will NOT work in RK2 currently.