### PR TITLE
Add Markdown support for most text pieces in RK1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Carthage/Checkouts/MarkdownAttributedString"]
+	path = Carthage/Checkouts/MarkdownAttributedString
+	url = https://github.com/CareEvolution/MarkdownAttributedString.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "CareEvolution/MarkdownAttributedString" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "CareEvolution/MarkdownAttributedString" "750e8d5cb455dcc592a9b6d1cacaa19837e7abff"

--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -572,6 +572,9 @@
 		D458520B1AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = D45852091AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m */; };
 		DA0BD9B324E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0BD9B224E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h */; };
 		DA0BD9B524E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0BD9B424E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m */; };
+		DA27D28C24F4520C00B6ECE4 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA27D28B24F4520C00B6ECE4 /* README.md */; };
+		DA27D28F24F4521E00B6ECE4 /* NSAttributedString+Markdown.h in Headers */ = {isa = PBXBuildFile; fileRef = DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */; };
+		DA27D29024F4521E00B6ECE4 /* NSAttributedString+Markdown.m in Sources */ = {isa = PBXBuildFile; fileRef = DA27D28E24F4521E00B6ECE4 /* NSAttributedString+Markdown.m */; };
 		DAF84CC922D682BC0028DE8F /* CEVRK1Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF84CC822D682BC0028DE8F /* CEVRK1Theme.m */; };
 		DAF84CCA22D683E10028DE8F /* CEVRK1Theme.h in Headers */ = {isa = PBXBuildFile; fileRef = DAF84CC722D6824E0028DE8F /* CEVRK1Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA7A9D2B1B082688005A2BEA /* ORK1ConsentDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2A1B082688005A2BEA /* ORK1ConsentDocumentTests.m */; };
@@ -1216,6 +1219,9 @@
 		D45852091AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ImageCaptureCameraPreviewView.m; sourceTree = "<group>"; };
 		DA0BD9B224E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1NavigationBarProgressView.h; sourceTree = "<group>"; };
 		DA0BD9B424E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1NavigationBarProgressView.m; sourceTree = "<group>"; };
+		DA27D28B24F4520C00B6ECE4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../../Carthage/Checkouts/MarkdownAttributedString/README.md; sourceTree = "<group>"; };
+		DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSAttributedString+Markdown.h"; path = "../../../Carthage/Checkouts/MarkdownAttributedString/NSAttributedString+Markdown.h"; sourceTree = "<group>"; };
+		DA27D28E24F4521E00B6ECE4 /* NSAttributedString+Markdown.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSAttributedString+Markdown.m"; path = "../../../Carthage/Checkouts/MarkdownAttributedString/NSAttributedString+Markdown.m"; sourceTree = "<group>"; };
 		DAF84CC722D6824E0028DE8F /* CEVRK1Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1Theme.h; sourceTree = "<group>"; };
 		DAF84CC822D682BC0028DE8F /* CEVRK1Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1Theme.m; sourceTree = "<group>"; };
 		FA7A9D2A1B082688005A2BEA /* ORK1ConsentDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ConsentDocumentTests.m; sourceTree = "<group>"; };
@@ -1429,6 +1435,9 @@
 		24B3535D1BB21137009ED6F8 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */,
+				DA27D28E24F4521E00B6ECE4 /* NSAttributedString+Markdown.m */,
+				DA27D28B24F4520C00B6ECE4 /* README.md */,
 				2433C9E11B9A506F0052D375 /* ORK1KeychainWrapper.h */,
 				2433C9E21B9A506F0052D375 /* ORK1KeychainWrapper.m */,
 				86C40B8C1A8D7C5C00081FAC /* ORK1Helpers_Internal.h */,
@@ -2678,6 +2687,7 @@
 				86C40DA01A8D7C5C00081FAC /* ORK1SurveyAnswerCell.h in Headers */,
 				86C40D941A8D7C5C00081FAC /* ORK1StepViewController.h in Headers */,
 				B8760F2B1AFBEFB0007FA16F /* ORK1ScaleRangeDescriptionLabel.h in Headers */,
+				DA27D28F24F4521E00B6ECE4 /* NSAttributedString+Markdown.h in Headers */,
 				86C40C221A8D7C5C00081FAC /* ORK1CountdownStep.h in Headers */,
 				86C40DB61A8D7C5C00081FAC /* ORK1SurveyAnswerCellForText.h in Headers */,
 				86C40E281A8D7C5C00081FAC /* ORK1SignatureView.h in Headers */,
@@ -3065,6 +3075,7 @@
 				B1A860EF1A9693C400EA57B7 /* consent_06@2x.m4v in Resources */,
 				B1A860EC1A9693C400EA57B7 /* consent_03@2x.m4v in Resources */,
 				B1A860F41A9693C400EA57B7 /* consent_04@3x.m4v in Resources */,
+				DA27D28C24F4520C00B6ECE4 /* README.md in Resources */,
 				B1A860ED1A9693C400EA57B7 /* consent_04@2x.m4v in Resources */,
 				B17FE7FD1A8DBE7C00BF9C28 /* Artwork.xcassets in Resources */,
 				B1C0F4E41A9BA65F0022C153 /* ORK1Kit.strings in Resources */,
@@ -3381,6 +3392,7 @@
 				86C40D581A8D7C5C00081FAC /* ORK1OrderedTask.m in Sources */,
 				86C40D601A8D7C5C00081FAC /* ORK1QuestionStep.m in Sources */,
 				84BD164C1FD1EBBC00FE1A3C /* ORK1WebViewStep.m in Sources */,
+				DA27D29024F4521E00B6ECE4 /* NSAttributedString+Markdown.m in Sources */,
 				86C40E381A8D7C5C00081FAC /* ORK1VisualConsentTransitionAnimator.m in Sources */,
 				BCB6E64B1B7D531C000D5B34 /* ORK1PieChartView.m in Sources */,
 				10864C9F1B27146B000F4158 /* ORK1PSATStep.m in Sources */,

--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -572,9 +572,13 @@
 		D458520B1AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = D45852091AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m */; };
 		DA0BD9B324E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0BD9B224E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h */; };
 		DA0BD9B524E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0BD9B424E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m */; };
+		DA160FFD24F6A59700587FBE /* CEVRK1TextView.h in Headers */ = {isa = PBXBuildFile; fileRef = DA160FFC24F6A59700587FBE /* CEVRK1TextView.h */; };
+		DA160FFF24F6A62300587FBE /* CEVRK1TextView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA160FFE24F6A62300587FBE /* CEVRK1TextView.m */; };
 		DA27D28C24F4520C00B6ECE4 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA27D28B24F4520C00B6ECE4 /* README.md */; };
-		DA27D28F24F4521E00B6ECE4 /* NSAttributedString+Markdown.h in Headers */ = {isa = PBXBuildFile; fileRef = DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */; };
+		DA27D28F24F4521E00B6ECE4 /* NSAttributedString+Markdown.h in Headers */ = {isa = PBXBuildFile; fileRef = DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA27D29024F4521E00B6ECE4 /* NSAttributedString+Markdown.m in Sources */ = {isa = PBXBuildFile; fileRef = DA27D28E24F4521E00B6ECE4 /* NSAttributedString+Markdown.m */; };
+		DA51341324F8607D0068A61F /* CEVRK1Label.h in Headers */ = {isa = PBXBuildFile; fileRef = DA51341224F8607D0068A61F /* CEVRK1Label.h */; };
+		DA51341524F8619A0068A61F /* CEVRK1Label.m in Sources */ = {isa = PBXBuildFile; fileRef = DA51341424F8619A0068A61F /* CEVRK1Label.m */; };
 		DAF84CC922D682BC0028DE8F /* CEVRK1Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF84CC822D682BC0028DE8F /* CEVRK1Theme.m */; };
 		DAF84CCA22D683E10028DE8F /* CEVRK1Theme.h in Headers */ = {isa = PBXBuildFile; fileRef = DAF84CC722D6824E0028DE8F /* CEVRK1Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA7A9D2B1B082688005A2BEA /* ORK1ConsentDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2A1B082688005A2BEA /* ORK1ConsentDocumentTests.m */; };
@@ -1219,9 +1223,13 @@
 		D45852091AF6CCFA00A2DE13 /* ORK1ImageCaptureCameraPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ImageCaptureCameraPreviewView.m; sourceTree = "<group>"; };
 		DA0BD9B224E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1NavigationBarProgressView.h; sourceTree = "<group>"; };
 		DA0BD9B424E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1NavigationBarProgressView.m; sourceTree = "<group>"; };
+		DA160FFC24F6A59700587FBE /* CEVRK1TextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1TextView.h; sourceTree = "<group>"; };
+		DA160FFE24F6A62300587FBE /* CEVRK1TextView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1TextView.m; sourceTree = "<group>"; };
 		DA27D28B24F4520C00B6ECE4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../../Carthage/Checkouts/MarkdownAttributedString/README.md; sourceTree = "<group>"; };
 		DA27D28D24F4521E00B6ECE4 /* NSAttributedString+Markdown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSAttributedString+Markdown.h"; path = "../../../Carthage/Checkouts/MarkdownAttributedString/NSAttributedString+Markdown.h"; sourceTree = "<group>"; };
 		DA27D28E24F4521E00B6ECE4 /* NSAttributedString+Markdown.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSAttributedString+Markdown.m"; path = "../../../Carthage/Checkouts/MarkdownAttributedString/NSAttributedString+Markdown.m"; sourceTree = "<group>"; };
+		DA51341224F8607D0068A61F /* CEVRK1Label.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1Label.h; sourceTree = "<group>"; };
+		DA51341424F8619A0068A61F /* CEVRK1Label.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1Label.m; sourceTree = "<group>"; };
 		DAF84CC722D6824E0028DE8F /* CEVRK1Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEVRK1Theme.h; sourceTree = "<group>"; };
 		DAF84CC822D682BC0028DE8F /* CEVRK1Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CEVRK1Theme.m; sourceTree = "<group>"; };
 		FA7A9D2A1B082688005A2BEA /* ORK1ConsentDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ConsentDocumentTests.m; sourceTree = "<group>"; };
@@ -1844,6 +1852,10 @@
 				86C40BDE1A8D7C5C00081FAC /* ORK1UnitLabel.m */,
 				DA0BD9B224E1AF73006AA90A /* CEVRK1NavigationBarProgressView.h */,
 				DA0BD9B424E1AFBA006AA90A /* CEVRK1NavigationBarProgressView.m */,
+				DA51341224F8607D0068A61F /* CEVRK1Label.h */,
+				DA51341424F8619A0068A61F /* CEVRK1Label.m */,
+				DA160FFC24F6A59700587FBE /* CEVRK1TextView.h */,
+				DA160FFE24F6A62300587FBE /* CEVRK1TextView.m */,
 			);
 			name = Skin;
 			sourceTree = "<group>";
@@ -2870,6 +2882,7 @@
 				86C40E081A8D7C5C00081FAC /* ORK1ConsentReviewStep.h in Headers */,
 				86C40C901A8D7C5C00081FAC /* ORK1ActiveStepViewController_Internal.h in Headers */,
 				86C40CD81A8D7C5C00081FAC /* ORK1TextFieldView.h in Headers */,
+				DA51341324F8607D0068A61F /* CEVRK1Label.h in Headers */,
 				86C40DD01A8D7C5C00081FAC /* ORK1TaskViewController_Private.h in Headers */,
 				10FF9ACF1B79F5CE00ECB5B4 /* ORK1HolePegTestRemoveContentView.h in Headers */,
 				86C40DAE1A8D7C5C00081FAC /* ORK1SurveyAnswerCellForScale.h in Headers */,
@@ -2893,6 +2906,7 @@
 				86C40DDE1A8D7C5C00081FAC /* ORK1VerticalContainerView.h in Headers */,
 				9550E67C1D58DD2000C691B8 /* ORK1TouchAnywhereStepViewController.h in Headers */,
 				BC94EF311E962F7400143081 /* ORK1Deprecated.h in Headers */,
+				DA160FFD24F6A59700587FBE /* CEVRK1TextView.h in Headers */,
 				86C40CB01A8D7C5C00081FAC /* ORK1Recorder_Internal.h in Headers */,
 				86C40E101A8D7C5C00081FAC /* ORK1ConsentSceneViewController.h in Headers */,
 				86C40DAA1A8D7C5C00081FAC /* ORK1SurveyAnswerCellForNumber.h in Headers */,
@@ -3194,6 +3208,7 @@
 				866DA5281D63D04700C9AF3F /* ORK1MotionActivityQueryOperation.m in Sources */,
 				BCFF24BD1B0798D10044EC35 /* ORK1ResultPredicate.m in Sources */,
 				106FF2B51B71F18E004EACF2 /* ORK1HolePegTestPlaceHoleView.m in Sources */,
+				DA160FFF24F6A62300587FBE /* CEVRK1TextView.m in Sources */,
 				106FF2A31B665B86004EACF2 /* ORK1HolePegTestPlaceStepViewController.m in Sources */,
 				25ECC0A41AFBDD2700F3D63B /* ORK1ReactionTimeStimulusView.m in Sources */,
 				86C40CBA1A8D7C5C00081FAC /* ORK1VoiceEngine.m in Sources */,
@@ -3229,6 +3244,7 @@
 				BC4A21401C85FC0000BFC271 /* ORK1BarGraphChartView.m in Sources */,
 				86C40D3A1A8D7C5C00081FAC /* ORK1HTMLPDFWriter.m in Sources */,
 				865EA1691ABA1AA10037C68E /* ORK1Picker.m in Sources */,
+				DA51341524F8619A0068A61F /* CEVRK1Label.m in Sources */,
 				BCB6E6511B7D533B000D5B34 /* ORK1PieChartLegendCollectionViewLayout.m in Sources */,
 				86C40D321A8D7C5C00081FAC /* ORK1HealthAnswerFormat.m in Sources */,
 				10FF9AC41B79EF2800ECB5B4 /* ORK1HolePegTestRemoveStep.m in Sources */,

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Label.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Label.h
@@ -1,0 +1,20 @@
+//
+//  CEVRK1Label.h
+//  ORK1Kit
+//
+//  Created by Eric Schramm on 8/27/20.
+//  Copyright © 2020 researchkit.org. All rights reserved.
+//
+
+@import UIKit;
+
+
+/**
+ This abstract class stores the text when set into a local property 'rawText' such that
+ Markdown can be rendered on rendering passes due to changes like dynamic text
+ */
+@interface CEVRK1Label: UILabel
+
+- (NSString * _Nullable)rawText;
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Label.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Label.m
@@ -1,0 +1,29 @@
+//
+//  CEVRK1Label.m
+//  ORK1Kit
+//
+//  Created by Eric Schramm on 8/27/20.
+//  Copyright © 2020 researchkit.org. All rights reserved.
+//
+
+#import "CEVRK1Label.h"
+#import "CEVRK1Theme.h"
+
+
+@implementation CEVRK1Label {
+    NSString *_rawText;
+}
+
+- (void)setText:(NSString * _Nullable)text {
+    _rawText = text;
+    [self updateAppearance];
+}
+
+- (NSString * _Nullable)rawText {
+    return _rawText;
+}
+
+- (void)updateAppearance {
+    // overridden in subclasses
+}
+@end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1TextView.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1TextView.h
@@ -1,0 +1,27 @@
+//
+//  CEVRKTextView.h
+//  ORK1Kit
+//
+//  Created by Eric Schramm on 8/26/20.
+//  Copyright © 2020 researchkit.org. All rights reserved.
+//
+
+@import UIKit;
+
+
+/**
+ This is a class that is being swapped in for ORK1SubheadlineLabel which allows for
+ tappable links via data detectors - specifically for links specified in Markdown.
+ */
+@interface CEVRK1TextView : UITextView
+
+@property (nonatomic, copy, nullable) NSString *textValue;
+@property (nonatomic, copy, nullable) NSString *detailTextValue;
+
+/**
+ Use textValue / detailTextValue instead.
+ */
+- (void)setText:(nullable NSString *)text NS_UNAVAILABLE;
+- (void)init_CEVRK1TextView;
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1TextView.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1TextView.m
@@ -1,0 +1,46 @@
+//
+//  CEVRK1TextView.m
+//  ORK1Kit
+//
+//  Created by Eric Schramm on 8/26/20.
+//  Copyright © 2020 researchkit.org. All rights reserved.
+//
+
+#import "CEVRK1TextView.h"
+#import "CEVRK1Theme.h"
+#import "ORK1SubheadlineLabel.h"
+
+
+@implementation CEVRK1TextView
+
+- (void)init_CEVRK1TextView {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateAppearance)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
+}
+
+- (void)setTextValue:(NSString *)textValue {
+    _textValue = textValue;
+    [self updateAppearance];
+}
+
+- (void)setDetailTextValue:(NSString *)detailTextValue {
+    _detailTextValue = detailTextValue;
+    [self updateAppearance];
+}
+
+- (void)willMoveToWindow:(UIWindow *)newWindow {
+    [super willMoveToWindow:newWindow];
+    [self updateAppearance];
+}
+
+- (void)updateAppearance {
+    // to handle any changes in dynamic text size, we update the current font and re-render
+    // NOTE: textview imitates previously used ORK1SubheadlineLabel
+    self.font = [[ORK1SubheadlineLabel class] defaultFont];
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForTextView:self];
+    [self invalidateIntrinsicContentSize];
+}
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -7,12 +7,8 @@
 //
 
 @import UIKit;
-@class ORK1TaskViewController;
 
 #import "ORK1Defines.h"
-
-extern NSString * _Nonnull const CEVRK1ThemeKey;
-extern NSString * _Nonnull const CEVThemeAttributeName;
 
 typedef NS_ENUM(NSInteger, CEVRK1ThemeType) {
     CEVRK1ThemeTypeDefault,
@@ -29,8 +25,19 @@ typedef NS_ENUM(NSInteger, CEVRK1GradientDirection) {
     CEVRK1GradientDirectionTopToBottom
 } ORK1_ENUM_AVAILABLE;
 
+typedef NS_ENUM(NSInteger, CEVRK1DisplayTextType) {
+    CEVRK1DisplayTextTypeTitle,
+    CEVRK1DisplayTextTypeText,
+    CEVRK1DisplayTextTypeDetailText
+};
+
+
 @class ORK1BorderedButton;
 @class ORK1ContinueButton;
+@class ORK1TaskViewController;
+@class CEVRK1Label;
+@class CEVRK1TextView;
+
 
 ORK1_CLASS_AVAILABLE
 @interface CEVRK1Gradient : NSObject
@@ -38,6 +45,16 @@ ORK1_CLASS_AVAILABLE
 @property (nonatomic, strong) UIColor * _Nonnull startColor;
 @property (nonatomic, strong) UIColor * _Nonnull endColor;
 @end
+
+
+ORK1_CLASS_AVAILABLE
+@interface CEVRK1TextStyle : NSObject
+@property (nonatomic, strong, nullable) NSNumber *fontSize;
+@property (nonatomic, strong, nullable) NSNumber *fontWeight;
+@property (nonatomic, strong, nullable) UIColor *color;
+@property (nonatomic, strong, nullable) NSNumber *alignment;
+@end
+
 
 ORK1_CLASS_AVAILABLE
 @interface CEVRK1Theme : NSObject
@@ -49,20 +66,9 @@ ORK1_CLASS_AVAILABLE
 
 @property (nonatomic, strong) UIColor * _Nullable tintColor;
 
-@property (nonatomic, strong) NSNumber * _Nullable titleFontSize;
-@property (nonatomic, strong) NSNumber * _Nullable titleFontWeight; // UIFontWeight
-@property (nonatomic, strong) UIColor * _Nullable titleColor;
-@property (nonatomic, strong) NSNumber * _Nullable titleAlignment; // NSTextAlignment
-
-@property (nonatomic, strong) NSNumber * _Nullable textFontSize;
-@property (nonatomic, strong) NSNumber * _Nullable textFontWeight; // UIFontWeight
-@property (nonatomic, strong) UIColor * _Nullable textColor;
-@property (nonatomic, strong) NSNumber * _Nullable textAlignment; // NSTextAlignment
-
-@property (nonatomic, strong) NSNumber * _Nullable detailTextFontSize;
-@property (nonatomic, strong) NSNumber * _Nullable detailTextFontWeight; // UIFontWeight
-@property (nonatomic, strong) UIColor * _Nullable detailTextColor;
-@property (nonatomic, strong) NSNumber * _Nullable detailTextAlignment; // NSTextAlignment
+@property (nonatomic, strong, nullable) CEVRK1TextStyle *titleStyle;
+@property (nonatomic, strong, nullable) CEVRK1TextStyle *textStyle;
+@property (nonatomic, strong, nullable) CEVRK1TextStyle *detailTextStyle;
 
 @property (nonatomic, strong) UIColor * _Nullable nextButtonBackgroundColor;
 @property (nonatomic, strong) CEVRK1Gradient * _Nullable nextButtonBackgroundGradient;
@@ -73,10 +79,10 @@ ORK1_CLASS_AVAILABLE
 
 @property (nonatomic, strong) UIColor * _Nullable progressBarColor;
 
-- (void)updateAppearanceForTitleLabel:(nonnull UILabel *)label;
-- (void)updateAppearanceForTextLabel:(nonnull UILabel *)label;
-- (void)updateAttributesForText:(nonnull NSMutableDictionary *)attributes;
-- (void)updateAttributesForDetailText:(nonnull NSMutableDictionary *)attributes;
+- (void)updateAppearanceForLabel:(nonnull CEVRK1Label *)label ofType:(CEVRK1DisplayTextType)textType;
+- (void)updateAppearanceForTextView:(nonnull CEVRK1TextView *)textView;
++ (void)renderMarkdownForLabel:(nonnull CEVRK1Label *)label;
+
 - (void)updateAppearanceForContinueButton:(nonnull ORK1ContinueButton *)continueButton;
 
 - (nullable UIColor *)taskViewControllerTintColor;

--- a/ORK1Kit/ORK1Kit/Common/ORK1ActiveStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ActiveStepView.m
@@ -69,10 +69,10 @@
 - (void)setActiveStep:(ORK1ActiveStep *)step {
     self.continueSkipContainer.useNextForSkip = step.shouldUseNextAsSkipButton;
     _activeStep = step;
-    self.headerView.instructionLabel.hidden = !(_activeStep.hasText);
+    self.headerView.instructionTextView.hidden = !(_activeStep.hasText);
     
     self.headerView.captionLabel.text = _activeStep.title;
-    self.headerView.instructionLabel.text = _activeStep.text;
+    self.headerView.instructionTextView.textValue = _activeStep.text;
     self.continueSkipContainer.optional = _activeStep.optional;
     self.stepViewFillsAvailableSpace = YES;
     
@@ -89,8 +89,8 @@
 - (void)updateTitle:(NSString *)title text:(NSString *)text {
     ORK1StepHeaderView *headerView = [self headerView];
     [headerView.captionLabel setText:title];
-    [headerView.instructionLabel setText:text];
-    headerView.instructionLabel.hidden = (text == nil);
+    [headerView.instructionTextView setTextValue:text];
+    headerView.instructionTextView.hidden = (text == nil);
     [headerView updateCaptionLabelPreferredWidth];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
@@ -48,7 +48,7 @@ extern NSString const *ORK1UpdateChoiceCellKeyCell;
 @property (nonatomic, strong, readonly) ORK1SelectionSubTitleLabel *longLabel;
 @property (nonatomic, weak) ORK1TextChoice *choice;
 
-+ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText LongText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
++ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText longText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
 
 @property (nonatomic, assign, getter=isImmediateNavigation) BOOL immediateNavigation;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
@@ -201,7 +201,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     [self updateSelectedItem];
 }
 
-+ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText LongText:(NSString *)longText inTableView:(UITableView *)tableView {
++ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText longText:(NSString *)longText inTableView:(UITableView *)tableView {
     CGFloat height = 0;
     
     CGFloat firstBaselineOffsetFromTop = ORK1GetMetricForWindow(ORK1ScreenMetricChoiceCellFirstBaselineOffsetFromTop, tableView.window);

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -429,12 +429,12 @@
     ORK1TextChoice *choice = format.textChoices[indexPath.row];
     
     NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text LongText:longText inTableView:self.tableView];
+    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
     
     [section.textChoiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]] atIndex:indexPath.row];
     
     longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text LongText:longText inTableView:self.tableView];
+    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
     
     [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
@@ -586,7 +586,7 @@
         _headerView = _tableContainer.stepHeaderView;
         _headerView.captionLabel.text = [[self formStep] title];
         _headerView.captionLabel.useSurveyMode = [[self formStep] useSurveyMode];
-        _headerView.instructionLabel.text = [[self formStep] text];
+        _headerView.instructionTextView.textValue = [[self formStep] text];
         _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
         
         _continueSkipView = _tableContainer.continueSkipContainerView;
@@ -1102,7 +1102,7 @@
     CGFloat cellHeight = [_hiddenCellItems containsObject:cellItem] ? 0 : UITableViewAutomaticDimension;
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORK1ChoiceViewCell class]]) {
         return [ORK1ChoiceViewCell suggestedCellHeightForShortText:cellItem.choice.text
-                                                          LongText:(cellItem.choice.detailTextShouldDisplay) ? cellItem.choice.detailText : nil
+                                                          longText:(cellItem.choice.detailTextShouldDisplay) ? cellItem.choice.detailText : nil
                                                        inTableView:_tableView];
     }
     return cellHeight;

--- a/ORK1Kit/ORK1Kit/Common/ORK1HeadlineLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1HeadlineLabel.m
@@ -63,8 +63,9 @@
 
 // Nasty override (hack)
 - (void)updateAppearance {
+    // to handle any changes in dynamic text size, we update the current font and re-render
     self.font = [self defaultFont];
-    [[CEVRK1Theme themeForElement:self] updateAppearanceForTitleLabel:self];
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForLabel:self ofType:CEVRK1DisplayTextTypeTitle];
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureView.m
@@ -61,7 +61,7 @@
         [self addSubview:_previewView];
         
         _headerView = [[ORK1StepHeaderView alloc] init];
-        _headerView.instructionLabel.text = @" "; // Need error placeholder string for constraints.
+        _headerView.instructionTextView.textValue = @" "; // Need error placeholder string for constraints.
         [self addSubview:_headerView];
         
         _captureButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"CAPTURE_BUTTON_CAPTURE_IMAGE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(capturePressed)];
@@ -145,7 +145,7 @@
     
     if (self.error) {
         // Display the error instruction.
-        _headerView.instructionLabel.text = [self.error.userInfo valueForKey:NSLocalizedDescriptionKey];
+        _headerView.instructionTextView.textValue = [self.error.userInfo valueForKey:NSLocalizedDescriptionKey];
         
         // Hide the template image if there is an error
         _previewView.templateImageHidden = YES;

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
@@ -145,32 +145,13 @@
     self.headerView.iconImageView.image = _instructionStep.iconImage;
     self.headerView.captionLabel.text = _instructionStep.title;
     
-    NSMutableAttributedString *attributedInstruction = [[NSMutableAttributedString alloc] init];
     NSString *detail = _instructionStep.detailText;
     NSString *text = _instructionStep.text;
     detail = detail.length ? detail : nil;
     text = text.length ? text : nil;
     
-    if (detail && text) {
-        NSMutableDictionary *textAttributes = [NSMutableDictionary dictionary];
-        [[CEVRK1Theme themeForElement:self] updateAttributesForText:textAttributes];
-        [attributedInstruction appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n", text] attributes:textAttributes]];
-
-        NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-        [style setParagraphSpacingBefore:self.headerView.instructionLabel.font.lineHeight * 0.5];
-        [style setAlignment:NSTextAlignmentCenter];
-        
-        NSMutableDictionary *detailAttributes = [@{NSParagraphStyleAttributeName: style} mutableCopy];
-        [[CEVRK1Theme themeForElement:self] updateAttributesForDetailText:detailAttributes];
-        NSAttributedString *attString = [[NSMutableAttributedString alloc] initWithString:detail
-                                                                               attributes:detailAttributes];
-        [attributedInstruction appendAttributedString:attString];
-        
-    } else if (detail || text) {
-        [attributedInstruction appendAttributedString:[[NSAttributedString alloc] initWithString:detail ? : text attributes:nil]];
-    }
-    
-    self.headerView.instructionLabel.attributedText = attributedInstruction;
+    self.headerView.instructionTextView.textValue = text;
+    self.headerView.instructionTextView.detailTextValue = detail;
     
     self.continueSkipContainer.footnoteLabel.text = _instructionStep.footnote;
     [self.continueSkipContainer updateContinueAndSkipEnabled];

--- a/ORK1Kit/ORK1Kit/Common/ORK1Label.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Label.h
@@ -32,7 +32,7 @@
 @import UIKit;
 #import "ORK1DefaultFont.h"
 #import "ORK1Defines.h"
-
+#import "CEVRK1Label.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  This is a base class, not being used directly.
  */
 ORK1_CLASS_AVAILABLE
-@interface ORK1Label : UILabel <ORK1DefaultFont>
+@interface ORK1Label : CEVRK1Label <ORK1DefaultFont>
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Label.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Label.m
@@ -67,10 +67,9 @@
 }
 
 - (void)updateAppearance {
-    // If we have styled this, don't override
-    if (self.attributedText.length > 0 && [self.attributedText attribute:CEVThemeAttributeName atIndex:0 effectiveRange:nil] == nil) {
-        self.font = [[self class] defaultFont];
-    }
+    // to handle any changes in dynamic text size, we update the current font and re-render
+    self.font = [[self class] defaultFont];
+    [CEVRK1Theme renderMarkdownForLabel:self];
     [self invalidateIntrinsicContentSize];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
@@ -94,7 +94,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
         
         _passcodeStepView = [[ORK1PasscodeStepView alloc] initWithFrame:self.view.bounds];
         _passcodeStepView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
-        _passcodeStepView.headerView.instructionLabel.text = [self passcodeStep].text;
+        _passcodeStepView.headerView.instructionTextView.textValue = [self passcodeStep].text;
         _passcodeStepView.textField.delegate = self;
         [self.view addSubview:_passcodeStepView];
         
@@ -217,7 +217,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
             
         case ORK1PasscodeStateSaved:
             _passcodeStepView.headerView.captionLabel.text = ORK1LocalizedString(@"PASSCODE_SAVED_MESSAGE", nil);
-            _passcodeStepView.headerView.instructionLabel.text = @"";
+            _passcodeStepView.headerView.instructionTextView.textValue = @"";
             _passcodeStepView.textField.hidden = YES;
             [self makePasscodeViewResignFirstResponder];
             break;

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
@@ -50,11 +50,11 @@
 - (void)setQuestionStep:(ORK1QuestionStep *)step {
     self.continueSkipContainer.useNextForSkip = (step ? NO : YES);
     _questionStep = step;
-    self.headerView.instructionLabel.hidden = ![_questionStep text].length;
+    self.headerView.instructionTextView.hidden = ![_questionStep text].length;
     
     self.headerView.captionLabel.useSurveyMode = step.useSurveyMode;
     self.headerView.captionLabel.text = _questionStep.title;
-    self.headerView.instructionLabel.text = _questionStep.text;
+    self.headerView.instructionTextView.textValue = _questionStep.text;
     self.continueSkipContainer.optional = _questionStep.optional;
     
     [self.continueSkipContainer updateContinueAndSkipEnabled];
@@ -77,8 +77,8 @@
     if (self.headerView.captionLabel != nil) {
         [elements addObject:self.headerView.captionLabel];
     }
-    if (self.headerView.instructionLabel != nil) {
-        [elements addObject:self.headerView.instructionLabel];
+    if (self.headerView.instructionTextView != nil) {
+        [elements addObject:self.headerView.instructionTextView];
     }
     if (self.headerView.learnMoreButton != nil) {
         [elements addObject:self.headerView.learnMoreButton];

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
             _headerView.captionLabel.text = self.questionStep.title;
-            _headerView.instructionLabel.text = self.questionStep.text;
+            _headerView.instructionTextView.textValue = self.questionStep.text;
             _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
             
             _continueSkipView = _tableContainer.continueSkipContainerView;
@@ -383,12 +383,12 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
     }
     ORK1TextChoice *choice = format.textChoices[index];
     NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text LongText:longText inTableView:self.tableView];
+    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
     
     [_choiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]] atIndex:index];
     
     longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text LongText:longText inTableView:self.tableView];
+    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
     
     [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
@@ -795,7 +795,7 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
 - (CGFloat)heightForChoiceItemOptionAtIndex:(NSInteger)index {
     ORK1TextChoice *option = [(ORK1TextChoiceAnswerFormat *)_answerFormat textChoices][index];
     return [ORK1ChoiceViewCell suggestedCellHeightForShortText:option.text
-                                                      LongText:(option.detailTextShouldDisplay) ? option.detailText : nil
+                                                      longText:(option.detailTextShouldDisplay) ? option.detailText : nil
                                                    inTableView:_tableView];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
@@ -131,7 +131,7 @@
         
         _tableContainer.stepHeaderView.captionLabel.useSurveyMode = self.step.useSurveyMode;
         _tableContainer.stepHeaderView.captionLabel.text = [self reviewStep].title;
-        _tableContainer.stepHeaderView.instructionLabel.text = [self reviewStep].text;
+        _tableContainer.stepHeaderView.instructionTextView.textValue = [self reviewStep].text;
         _tableContainer.stepHeaderView.learnMoreButtonItem = self.learnMoreButtonItem;
         
         _continueSkipView = _tableContainer.continueSkipContainerView;
@@ -235,7 +235,7 @@
     ORK1StepResult *stepResult = [_resultSource stepResultForStepIdentifier:step.identifier];
     NSString *shortText = step.title != nil ? step.title : step.text;
     NSString *longText = [self answerStringForStep:step withStepResult:stepResult];
-    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText LongText:longText inTableView:_tableContainer.tableView];
+    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText longText:longText inTableView:_tableContainer.tableView];
     return height;
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1SignatureStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SignatureStepViewController.m
@@ -279,7 +279,7 @@
     _signingView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     _signingView.frame = self.view.bounds;
     _signingView.headerView.captionLabel.text = self.step.title;
-    _signingView.headerView.instructionLabel.text = self.step.text;
+    _signingView.headerView.instructionTextView.textValue = self.step.text;
     
     _continueSkipView = _signingView.continueSkipContainer;
     _continueSkipView.skipButtonItem = self.skipButtonItem;

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView.m
@@ -31,6 +31,7 @@
 
 #import "ORK1StepHeaderView.h"
 #import "ORK1StepHeaderView_Internal.h"
+#import "ORK1SubheadlineLabel.h"
 
 #import "ORK1Helpers_Internal.h"
 #import "ORK1Skin.h"
@@ -58,7 +59,6 @@
     CGFloat maxLabelLayoutWidth = MAX(self.bounds.size.width - sideMargin * 2 - layoutMargins.left - layoutMargins.right, 0);
     
     _captionLabel.preferredMaxLayoutWidth = maxLabelLayoutWidth;
-    _instructionLabel.preferredMaxLayoutWidth = maxLabelLayoutWidth;
     [self setNeedsUpdateConstraints];
 }
 
@@ -108,11 +108,14 @@
         }
         
         {
-            _instructionLabel = [ORK1SubheadlineLabel new];
-            _instructionLabel.numberOfLines = 0;
-            _instructionLabel.textAlignment = NSTextAlignmentCenter;
+            _instructionTextView = [[CEVRK1TextView alloc] initWithFrame:CGRectZero];
+            _instructionTextView.editable = NO;
+            _instructionTextView.scrollEnabled = NO;
+            _instructionTextView.font = ORK1SubheadlineLabel.defaultFont;
+            _instructionTextView.textAlignment = NSTextAlignmentCenter;
+            [_instructionTextView init_CEVRK1TextView];
             
-            [self addSubview:_instructionLabel];
+            [self addSubview:_instructionTextView];
         }
         
         [_learnMoreButton setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
@@ -187,7 +190,7 @@ const CGFloat IconHeight = 60;
     const CGFloat InstructionBaselineToStepViewTopWithNoLearnMore = ORK1GetMetricForWindow(ORK1ScreenMetricLearnMoreBaselineToStepViewTopWithNoLearnMore, window);
     
     BOOL hasCaptionLabel = _captionLabel.text.length > 0 || hasIconView;
-    BOOL hasInstructionLabel = _instructionLabel.text.length > 0;
+    BOOL hasInstructionLabel = _instructionTextView.text.length > 0;
     BOOL hasLearnMoreButton = (_learnMoreButton.alpha > 0);
     
     ORK1VerticalContainerLog(@"hasCaption=%@ hasInstruction=%@ hasLearnMore=%@", @(hasCaption), @(hasInstruction), @(hasLearnMore));
@@ -197,7 +200,7 @@ const CGFloat IconHeight = 60;
     UILayoutPriority captionVerticalHugging = hasCaptionLabel && !hasInstructionLabel ? UILayoutPriorityDefaultLow - 1 : UILayoutPriorityDefaultLow;
     UILayoutPriority instructionVerticalHugging = hasInstructionLabel && !hasCaptionLabel ? UILayoutPriorityDefaultLow - 1 : UILayoutPriorityDefaultLow;
     [_captionLabel setContentHuggingPriority:captionVerticalHugging forAxis:UILayoutConstraintAxisVertical];
-    [_instructionLabel setContentHuggingPriority:instructionVerticalHugging forAxis:UILayoutConstraintAxisVertical];
+    [_instructionTextView setContentHuggingPriority:instructionVerticalHugging forAxis:UILayoutConstraintAxisVertical];
     
     {
         _headerZeroHeightConstraint.active = !(hasCaptionLabel || hasInstructionLabel || hasLearnMoreButton || hasIconView);
@@ -257,10 +260,10 @@ const CGFloat IconHeight = 60;
     widthConstraint.priority = UILayoutPriorityDefaultLow - 1;
     [constraints addObject:widthConstraint];
     
-    NSArray *views = @[_iconImageView, _captionLabel, _instructionLabel, _learnMoreButton];
+    NSArray *views = @[_iconImageView, _captionLabel, _instructionTextView, _learnMoreButton];
     [_iconImageView setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
     [_captionLabel setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
-    [_instructionLabel setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
+    [_instructionTextView setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
     [_learnMoreButton setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
     ORK1EnableAutoLayoutForViews(views);
     
@@ -299,7 +302,7 @@ const CGFloat IconHeight = 60;
     }
     
     {
-        _captionToInstructionConstraint = [NSLayoutConstraint constraintWithItem:_instructionLabel
+        _captionToInstructionConstraint = [NSLayoutConstraint constraintWithItem:_instructionTextView
                                                                        attribute:NSLayoutAttributeFirstBaseline
                                                                        relatedBy:NSLayoutRelationEqual
                                                                           toItem:_captionLabel
@@ -313,7 +316,7 @@ const CGFloat IconHeight = 60;
         _instructionToLearnMoreConstraint = [NSLayoutConstraint constraintWithItem:_learnMoreButton
                                                                          attribute:NSLayoutAttributeFirstBaseline
                                                                          relatedBy:NSLayoutRelationEqual
-                                                                            toItem:_instructionLabel
+                                                                            toItem:_instructionTextView
                                                                          attribute:NSLayoutAttributeLastBaseline
                                                                         multiplier:1.0
                                                                           constant:30.0];
@@ -372,7 +375,7 @@ const CGFloat IconHeight = 60;
         _instructionMinBottomSpacingConstraint = [NSLayoutConstraint constraintWithItem:self
                                                                               attribute:NSLayoutAttributeBottom
                                                                               relatedBy:NSLayoutRelationEqual
-                                                                                 toItem:_instructionLabel
+                                                                                 toItem:_instructionTextView
                                                                               attribute:NSLayoutAttributeLastBaseline
                                                                              multiplier:1.0
                                                                                constant:44.0];

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView_Internal.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepHeaderView_Internal.h
@@ -31,9 +31,8 @@
 
 #import "ORK1StepHeaderView.h"
 #import "ORK1HeadlineLabel.h"
-#import "ORK1SubheadlineLabel.h"
 #import "ORK1TextButton.h"
-
+#import "CEVRK1TextView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UIImageView *iconImageView;
 @property (nonatomic, strong, readonly) ORK1HeadlineLabel *captionLabel;
 @property (nonatomic, strong, readonly) ORK1TextButton *learnMoreButton;
-@property (nonatomic, strong, readonly) ORK1SubheadlineLabel *instructionLabel;
+@property (nonatomic, strong, readonly) CEVRK1TextView *instructionTextView;
 
 @property (nonatomic) BOOL hasContentAbove;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1SubheadlineLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SubheadlineLabel.m
@@ -45,7 +45,7 @@
 
 - (void)updateAppearance {
     [super updateAppearance];
-    [[CEVRK1Theme themeForElement:self] updateAppearanceForTextLabel:self];
+    [[CEVRK1Theme themeForElement:self] updateAppearanceForLabel:self ofType:CEVRK1DisplayTextTypeText];
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableStepViewController.m
@@ -124,7 +124,7 @@ ORK1DefineStringKey(ORK1BasicCellReuseIdentifier);
         
         _headerView = _tableContainer.stepHeaderView;
         _headerView.captionLabel.text = [[self step] title];
-        _headerView.instructionLabel.text = [[self step] text];
+        _headerView.instructionTextView.textValue = [[self step] text];
         _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
         
         _continueSkipView = _tableContainer.continueSkipContainerView;

--- a/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
@@ -358,7 +358,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
 - (void)updateStepViewCenteringConstraint {
     BOOL hasIllustration = (_imageView.image != nil);
     BOOL hasCaption = _headerView.captionLabel.text.length > 0;
-    BOOL hasInstruction = _headerView.instructionLabel.text.length > 0;
+    BOOL hasInstruction = _headerView.instructionTextView.text.length > 0;
     BOOL hasLearnMore = (_headerView.learnMoreButton.alpha > 0);
     BOOL hasContinueOrSkip = [_continueSkipContainer hasContinueOrSkip];
 
@@ -864,9 +864,9 @@ static const CGFloat AssumedStatusBarHeight = 20;
      
      Additional carriage returns will be added if the loop persists every 50 iterations.
      
-     For more info see: https://github.com/CareEvolution/CEVORK1Kit/issues/116,
-     https://github.com/CareEvolution/CEVORK1Kit/issues/136,
-     https://github.com/CareEvolution/CEVORK1Kit/issues/152
+     For more info see: https://github.com/CareEvolution/CEVResearchKit/issues/116,
+     https://github.com/CareEvolution/CEVResearchKit/issues/136,
+     https://github.com/CareEvolution/CEVResearchKit/issues/152
      */
     
     autoLayoutLoopCount++;
@@ -874,12 +874,12 @@ static const CGFloat AssumedStatusBarHeight = 20;
     if (autoLayoutLoopCount % 50 == 0 &&
         autoLayoutLoopCount / 50 > carriageReturnsAdded) {
         if (_scrollContainer.subviews.count > 0 && _scrollContainer.subviews[0].subviews.count > 0 && _scrollContainer.subviews[0].subviews[0].subviews.count > 3) {
-            UIView *possibleSubheadLineLabel = _scrollContainer.subviews[0].subviews[0].subviews[3];
-            if ([possibleSubheadLineLabel isKindOfClass:[ORK1SubheadlineLabel class]]) {
-                ORK1SubheadlineLabel *subheadLineLabel = (ORK1SubheadlineLabel *)possibleSubheadLineLabel;
-                NSMutableString *updatedText = [NSMutableString stringWithString:subheadLineLabel.text];
+            UIView *possibleCEVRK1TextView = _scrollContainer.subviews[0].subviews[0].subviews[3];
+            if ([possibleCEVRK1TextView isKindOfClass:[CEVRK1TextView class]]) {
+                CEVRK1TextView *textView = (CEVRK1TextView *)possibleCEVRK1TextView;
+                NSMutableString *updatedText = [NSMutableString stringWithString:textView.textValue];
                 [updatedText appendString:@"\n"];
-                subheadLineLabel.text = updatedText;
+                textView.textValue = updatedText;
                 carriageReturnsAdded++;
             }
         }

--- a/ORK1Kit/ORK1Kit/Common/ORK1VideoCaptureView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VideoCaptureView.m
@@ -68,7 +68,7 @@
         [self addSubview:_playerViewController.view];
         
         _headerView = [ORK1StepHeaderView new];
-        _headerView.instructionLabel.text = @" ";
+        _headerView.instructionTextView.textValue = @" ";
         [self addSubview:_headerView];
         
         _captureButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"CAPTURE_BUTTON_CAPTURE_VIDEO", nil)
@@ -166,7 +166,7 @@
     
     if (self.error) {
         // Display the error instruction.
-        _headerView.instructionLabel.text = [self.error.userInfo valueForKey:NSLocalizedDescriptionKey];
+        _headerView.instructionTextView.textValue = [self.error.userInfo valueForKey:NSLocalizedDescriptionKey];
         
         // Hide the template image if there is an error
         _previewView.templateImageHidden = YES;

--- a/ORK1Kit/ORK1Kit/Common/ORK1WaitStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WaitStepViewController.m
@@ -77,7 +77,7 @@
         [self.view addSubview:_waitStepView];
         
         _waitStepView.headerView.captionLabel.text = [self waitStep].title;
-        _waitStepView.headerView.instructionLabel.text = _updatedText;
+        _waitStepView.headerView.instructionTextView.textValue = _updatedText;
     }
 }
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSceneViewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSceneViewController.m
@@ -72,11 +72,11 @@
     self.verticalCenteringEnabled = isOverview;
     self.continueHugsContent =  isOverview;
     
-    self.headerView.instructionLabel.hidden = ![consentSection summary].length;
+    self.headerView.instructionTextView.hidden = ![consentSection summary].length;
     self.headerView.captionLabel.text = consentSection.title;
     
     self.imageView.image = consentSection.image;
-    self.headerView.instructionLabel.text = [consentSection summary];
+    self.headerView.instructionTextView.textValue = [consentSection summary];
     
     self.continueSkipContainer.continueEnabled = YES;
     [self.continueSkipContainer updateContinueAndSkipEnabled];

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepView.m
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepView.m
@@ -68,7 +68,7 @@
                                        [NSLayoutConstraint constraintWithItem:_resendEmailButton
                                                                     attribute:NSLayoutAttributeFirstBaseline
                                                                     relatedBy:NSLayoutRelationEqual
-                                                                       toItem:self.headerView.instructionLabel
+                                                                       toItem:self.headerView.instructionTextView
                                                                     attribute:NSLayoutAttributeLastBaseline
                                                                    multiplier:1.0
                                                                      constant:textBaselineToResendButtonBaselineMetric],

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepViewController.m
@@ -58,7 +58,7 @@
         _verificationStepView = [[ORK1VerificationStepView alloc] initWithFrame:self.view.bounds];
         _verificationStepView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
         _verificationStepView.headerView.captionLabel.text = [self verificationStep].title;
-        _verificationStepView.headerView.instructionLabel.text = [[self verificationStep].text stringByAppendingString:[NSString stringWithFormat:@"\n\n%@", ORK1LocalizedString(@"RESEND_EMAIL_LABEL_MESSAGE", nil)]];
+        _verificationStepView.headerView.instructionTextView.textValue = [[self verificationStep].text stringByAppendingString:[NSString stringWithFormat:@"\n\n%@", ORK1LocalizedString(@"RESEND_EMAIL_LABEL_MESSAGE", nil)]];
         
         [self.view addSubview:_verificationStepView];
         

--- a/RKWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/RKWorkspace.xcworkspace/contents.xcworkspacedata
@@ -19,4 +19,11 @@
    <FileRef
       location = "group:samples/ORKSample/ORKSample.xcodeproj">
    </FileRef>
+   <Group
+      location = "container:"
+      name = "Carthage">
+      <FileRef
+         location = "group:Carthage/Checkouts/MarkdownAttributedString">
+      </FileRef>
+   </Group>
 </Workspace>

--- a/dependencies
+++ b/dependencies
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+carthage_args="--use-submodules --no-build"
+
+action="$1"
+shift
+
+case $action in
+    init|bootstrap)
+        carthage bootstrap $carthage_args "$@"
+        ;;
+    update)
+        carthage update $carthage_args "$@"
+        ;;
+    *)
+        echo "Usage: $(basename $0) init|update [Dependency1 Dependency2 ...]"
+        echo "  init   - Fetches dependencies per Cartfile.resolved"
+        echo "  update - Updates to latest dependencies per Cartfile"
+        echo
+        echo "  You can optionally limit actions to one or more dependencies"
+        echo "  by providing the names (without URL or path prefix)."
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
Closes https://github.com/CareEvolution/CEVResearchKit/issues/231. The goal here is to add support for Markdown rendering for the following:
- bold (using enclosing `**`)
- italics (using enclosing `_`)
- bold & italics (using enclosing `**_` and `_**`)
- links (using `[title](URL)` or `<URL>`)- clickable currently only in InstructionStep for `text` and `detailText` and those that inherit it's view structure with the `ORK1StepHeaderView` (QuestionStep, top of FormStep and others, but not all step types)

_Note that Markdown syntax can be escaped if needed with a double-`\\`_

This relies on the hooks in our recent CEVRK1Theme style enhancements so currently this is only supported in RK1 surveys.

The Markdown rendering comes from https://github.com/chockenberry/MarkdownAttributedString which I've decided to fork because it doesn't currently support some other aspects of Markdown and this would allow us to add them if desired or pull them if someone else contributes to that repo.

To minimize risk for errors in similar, but repetitive tasks for formatting, `CEVRK1Theme` was refactored heavily in the text formatting zones. Since the draw cycle is called numerous times on a single appearance of a step and dynamic text changes can force a redraw at any time, using Markdown required a different approach such that the raw, unparsed Markdown could be stored somewhere in each text element and rendered on a redraw. A somewhat hacky approach is presented where we override `setText` for `UILabel` subclasses using an abstract super class, and a similar approach for a custom `UITextView` class (required for clickable links vs UILabel) where a `textValue` and `detailTextValue` are properties with `setText` made unavailable to prevent development errors. This takes advantage of the interesting interplay between `.text` and `.attributedText` on `UILabel` and `UITextView` where setting one overwrites the other. We simply always write to the internal text storage representation using `.attributedText` internally when rendering.

Rendering consists of : getting current default font --> rendering style overrides --> rendering Markdown overrides

Have done some testing as well to ensure that dynamic text size changes are respected. NOTE: most of this is handled by the various text pieces subscribing to `UIContentSizeCategoryDidChangeNotification` which calls `updateAppearance` which then calls our rendering pass.

Known Limitations:
- The following Markdown styles are NOT currently supported (and there are probably more)
  - Headers (e.g., `##`)
  - Lists (bulleted and numbered)
  - Tables
  - Block quotes
  - Code blocks
- Markdown is currently not rendered in text presented in a Value Picker since that is rendered internally in UIKit currently
- Underline is not formatted directly outside of links. We would need to decide on our syntax as standard Markdown does not currently support
- While Markdown technically works inside `ORK1FormStep.text`, it's utility is limited since we now bold all this text by default so italicizing text is only relevant.

Here's are some examples of Markdown rendering on plain (default style) formatting:
|InstructionStep|QuestionStep with TextChoices|
|---|---|
|![Simulator Screen Shot - iPhone 11 - 2020-08-28 at 15 57 21](https://user-images.githubusercontent.com/1008462/91614545-5d91af80-e947-11ea-9c3f-d7dcd833ca4c.png)|![Simulator Screen Shot - iPhone 11 - 2020-08-28 at 15 57 55](https://user-images.githubusercontent.com/1008462/91614552-62eefa00-e947-11ea-960c-b62411343cba.png)|

As well as crazy styling with Markdown added
![Simulator Screen Shot - iPhone 11 - 2020-08-28 at 15 59 52](https://user-images.githubusercontent.com/1008462/91614631-84e87c80-e947-11ea-87ee-0f7e99e0e358.png)



