### PR TITLE
Document selection and document review steps

### DIFF
--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -457,6 +457,10 @@
 		959A2C0E1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 959A2C0C1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m */; };
 		95E11E551D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 95E11E531D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h */; };
 		95E11E561D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95E11E541D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m */; };
+		AC9069B425080B5500910AB7 /* ORK1DocumentSelectionStep.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069B225080B5500910AB7 /* ORK1DocumentSelectionStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC9069B525080B5500910AB7 /* ORK1DocumentSelectionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */; };
+		AC9069B82508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC9069B92508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069B72508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m */; };
 		B11C54991A9EEF8800265E61 /* ORK1ConsentSharingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C54961A9EEF8800265E61 /* ORK1ConsentSharingStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B11C549B1A9EEF8800265E61 /* ORK1ConsentSharingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = B11C54971A9EEF8800265E61 /* ORK1ConsentSharingStep.m */; };
 		B11C549F1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C549C1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1068,6 +1072,10 @@
 		959A2C0C1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ShoulderRangeOfMotionStep.m; sourceTree = "<group>"; };
 		95E11E531D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ShoulderRangeOfMotionStepViewController.h; sourceTree = "<group>"; };
 		95E11E541D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ShoulderRangeOfMotionStepViewController.m; sourceTree = "<group>"; };
+		AC9069B225080B5500910AB7 /* ORK1DocumentSelectionStep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentSelectionStep.h; sourceTree = "<group>"; };
+		AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentSelectionStep.m; sourceTree = "<group>"; };
+		AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentSelectionStepViewController.h; sourceTree = "<group>"; };
+		AC9069B72508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentSelectionStepViewController.m; sourceTree = "<group>"; };
 		B11C54961A9EEF8800265E61 /* ORK1ConsentSharingStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ConsentSharingStep.h; sourceTree = "<group>"; };
 		B11C54971A9EEF8800265E61 /* ORK1ConsentSharingStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ConsentSharingStep.m; sourceTree = "<group>"; };
 		B11C549C1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ConsentSharingStepViewController.h; sourceTree = "<group>"; };
@@ -1770,6 +1778,17 @@
 			name = "Range of Motion";
 			sourceTree = "<group>";
 		};
+		AC9069B125080B2D00910AB7 /* Document Selection Step */ = {
+			isa = PBXGroup;
+			children = (
+				AC9069B225080B5500910AB7 /* ORK1DocumentSelectionStep.h */,
+				AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */,
+				AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */,
+				AC9069B72508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m */,
+			);
+			name = "Document Selection Step";
+			sourceTree = "<group>";
+		};
 		B11DF3B21AA109C8009E76D2 /* docs */ = {
 			isa = PBXGroup;
 			children = (
@@ -1893,6 +1912,7 @@
 		B12EFF341AB2111200A80147 /* Step */ = {
 			isa = PBXGroup;
 			children = (
+				AC9069B125080B2D00910AB7 /* Document Selection Step */,
 				86C40BB91A8D7C5C00081FAC /* ORK1Step.h */,
 				86C40BBA1A8D7C5C00081FAC /* ORK1Step.m */,
 				86C40BBB1A8D7C5C00081FAC /* ORK1Step_Private.h */,
@@ -2788,6 +2808,7 @@
 				86C40D7C1A8D7C5C00081FAC /* ORK1ScaleValueLabel.h in Headers */,
 				250F94081B4C5AA400FA23EB /* ORK1TowerOfHanoiStepViewController.h in Headers */,
 				86C40E2C1A8D7C5C00081FAC /* ORK1VisualConsentStep.h in Headers */,
+				AC9069B425080B5500910AB7 /* ORK1DocumentSelectionStep.h in Headers */,
 				257FCE1F1B4D14E50001EF06 /* ORK1TowerOfHanoiTowerView.h in Headers */,
 				24A4DA181B8D13FE009C797A /* ORK1PasscodeStepViewController.h in Headers */,
 				86C40CB81A8D7C5C00081FAC /* ORK1VoiceEngine.h in Headers */,
@@ -2854,6 +2875,7 @@
 				781D54141DF886AB00223305 /* ORK1TrailmakingStepViewController.h in Headers */,
 				86C40C261A8D7C5C00081FAC /* ORK1CountdownStepViewController.h in Headers */,
 				861D2AF01B8409D9008C4CD0 /* ORK1TimedWalkContentView.h in Headers */,
+				AC9069B82508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h in Headers */,
 				2489F7B31D65214D008DEF20 /* ORK1VideoCaptureStepViewController.h in Headers */,
 				86C40E0C1A8D7C5C00081FAC /* ORK1ConsentReviewStepViewController.h in Headers */,
 				86C40C321A8D7C5C00081FAC /* ORK1FitnessStepViewController.h in Headers */,
@@ -3257,6 +3279,7 @@
 				10864CA31B27146B000F4158 /* ORK1PSATContentView.m in Sources */,
 				6146D0A41B84A91E0068491D /* ORK1LineGraphAccessibilityElement.m in Sources */,
 				D42FEFB91AF7557000A124F8 /* ORK1ImageCaptureView.m in Sources */,
+				AC9069B525080B5500910AB7 /* ORK1DocumentSelectionStep.m in Sources */,
 				86C40C401A8D7C5C00081FAC /* ORK1SpatialSpanMemoryContentView.m in Sources */,
 				BCB6E6671B7D535F000D5B34 /* ORK1XAxisView.m in Sources */,
 				147503BC1AEE807C004B17F3 /* ORK1ToneAudiometryStepViewController.m in Sources */,
@@ -3280,6 +3303,7 @@
 				BC41942A1AE8453A00073D6B /* ORK1Observer.m in Sources */,
 				86C40C681A8D7C5C00081FAC /* CMAccelerometerData+ORK1JSONDictionary.m in Sources */,
 				86C40C701A8D7C5C00081FAC /* CMMotionActivity+ORK1JSONDictionary.m in Sources */,
+				AC9069B92508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m in Sources */,
 				147503B01AEE8071004B17F3 /* ORK1AudioGenerator.m in Sources */,
 				86C40D7E1A8D7C5C00081FAC /* ORK1ScaleValueLabel.m in Sources */,
 				B12EA01A1B0D76AD00F9F554 /* ORK1ToneAudiometryPracticeStepViewController.m in Sources */,

--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -461,6 +461,10 @@
 		AC9069B525080B5500910AB7 /* ORK1DocumentSelectionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */; };
 		AC9069B82508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC9069B92508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069B72508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m */; };
+		AC9069CA250911F200910AB7 /* ORK1DocumentReviewStep.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069C8250911F200910AB7 /* ORK1DocumentReviewStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC9069CB250911F200910AB7 /* ORK1DocumentReviewStep.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069C9250911F200910AB7 /* ORK1DocumentReviewStep.m */; };
+		AC9069CE250916F400910AB7 /* ORK1DocumentReviewStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069CC250916F400910AB7 /* ORK1DocumentReviewStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC9069CF250916F400910AB7 /* ORK1DocumentReviewStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069CD250916F400910AB7 /* ORK1DocumentReviewStepViewController.m */; };
 		B11C54991A9EEF8800265E61 /* ORK1ConsentSharingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C54961A9EEF8800265E61 /* ORK1ConsentSharingStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B11C549B1A9EEF8800265E61 /* ORK1ConsentSharingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = B11C54971A9EEF8800265E61 /* ORK1ConsentSharingStep.m */; };
 		B11C549F1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C549C1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1076,6 +1080,10 @@
 		AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentSelectionStep.m; sourceTree = "<group>"; };
 		AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentSelectionStepViewController.h; sourceTree = "<group>"; };
 		AC9069B72508149C00910AB7 /* ORK1DocumentSelectionStepViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentSelectionStepViewController.m; sourceTree = "<group>"; };
+		AC9069C8250911F200910AB7 /* ORK1DocumentReviewStep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentReviewStep.h; sourceTree = "<group>"; };
+		AC9069C9250911F200910AB7 /* ORK1DocumentReviewStep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentReviewStep.m; sourceTree = "<group>"; };
+		AC9069CC250916F400910AB7 /* ORK1DocumentReviewStepViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentReviewStepViewController.h; sourceTree = "<group>"; };
+		AC9069CD250916F400910AB7 /* ORK1DocumentReviewStepViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentReviewStepViewController.m; sourceTree = "<group>"; };
 		B11C54961A9EEF8800265E61 /* ORK1ConsentSharingStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ConsentSharingStep.h; sourceTree = "<group>"; };
 		B11C54971A9EEF8800265E61 /* ORK1ConsentSharingStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ConsentSharingStep.m; sourceTree = "<group>"; };
 		B11C549C1A9EF4A700265E61 /* ORK1ConsentSharingStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ConsentSharingStepViewController.h; sourceTree = "<group>"; };
@@ -1789,6 +1797,17 @@
 			name = "Document Selection Step";
 			sourceTree = "<group>";
 		};
+		AC9069C7250911CB00910AB7 /* Document Review Step */ = {
+			isa = PBXGroup;
+			children = (
+				AC9069C8250911F200910AB7 /* ORK1DocumentReviewStep.h */,
+				AC9069C9250911F200910AB7 /* ORK1DocumentReviewStep.m */,
+				AC9069CC250916F400910AB7 /* ORK1DocumentReviewStepViewController.h */,
+				AC9069CD250916F400910AB7 /* ORK1DocumentReviewStepViewController.m */,
+			);
+			name = "Document Review Step";
+			sourceTree = "<group>";
+		};
 		B11DF3B21AA109C8009E76D2 /* docs */ = {
 			isa = PBXGroup;
 			children = (
@@ -1912,7 +1931,6 @@
 		B12EFF341AB2111200A80147 /* Step */ = {
 			isa = PBXGroup;
 			children = (
-				AC9069B125080B2D00910AB7 /* Document Selection Step */,
 				86C40BB91A8D7C5C00081FAC /* ORK1Step.h */,
 				86C40BBA1A8D7C5C00081FAC /* ORK1Step.m */,
 				86C40BBB1A8D7C5C00081FAC /* ORK1Step_Private.h */,
@@ -1932,6 +1950,8 @@
 				B12EFF3C1AB211FB00A80147 /* Form Step */,
 				D44239761AF17EE700559D96 /* Image Capture Step */,
 				2489F7A61D65213D008DEF20 /* Video Capture Step */,
+				AC9069B125080B2D00910AB7 /* Document Selection Step */,
+				AC9069C7250911CB00910AB7 /* Document Review Step */,
 				24A4DA091B8D0CC8009C797A /* Passcode Step */,
 				FFDDD8461D3453A200446806 /* Page Step */,
 				FF5CA60F1D2C2630001660A3 /* Table Step */,
@@ -2665,6 +2685,7 @@
 				86C40D8E1A8D7C5C00081FAC /* ORK1Step.h in Headers */,
 				618DA04E1A93D0D600E63AA8 /* ORK1Accessibility.h in Headers */,
 				FFF65AB81E318F2D0043FB40 /* ORK1MultipleValuePicker.h in Headers */,
+				AC9069CA250911F200910AB7 /* ORK1DocumentReviewStep.h in Headers */,
 				86B781BB1AA668ED00688151 /* ORK1TimeIntervalPicker.h in Headers */,
 				24C296751BD052F800B42EF1 /* ORK1VerificationStep_Internal.h in Headers */,
 				86C40C6A1A8D7C5C00081FAC /* CMDeviceMotion+ORK1JSONDictionary.h in Headers */,
@@ -2804,6 +2825,7 @@
 				106FF2B41B71F18E004EACF2 /* ORK1HolePegTestPlaceHoleView.h in Headers */,
 				86C40D921A8D7C5C00081FAC /* ORK1Step_Private.h in Headers */,
 				86C40CC41A8D7C5C00081FAC /* ORK1CompletionStepViewController.h in Headers */,
+				AC9069CE250916F400910AB7 /* ORK1DocumentReviewStepViewController.h in Headers */,
 				FF36A49C1D1A15FC00DE8470 /* ORK1TableStepViewController_Internal.h in Headers */,
 				86C40D7C1A8D7C5C00081FAC /* ORK1ScaleValueLabel.h in Headers */,
 				250F94081B4C5AA400FA23EB /* ORK1TowerOfHanoiStepViewController.h in Headers */,
@@ -3288,6 +3310,7 @@
 				865EA1631AB8DF750037C68E /* ORK1DateTimePicker.m in Sources */,
 				866DA5241D63D04700C9AF3F /* ORK1DataCollectionManager.m in Sources */,
 				9550E6741D58DBCF00C691B8 /* ORK1TouchAnywhereStep.m in Sources */,
+				AC9069CF250916F400910AB7 /* ORK1DocumentReviewStepViewController.m in Sources */,
 				86C40C781A8D7C5C00081FAC /* HKSample+ORK1JSONDictionary.m in Sources */,
 				86C40D421A8D7C5C00081FAC /* ORK1InstructionStep.m in Sources */,
 				86C40C2C1A8D7C5C00081FAC /* ORK1FitnessContentView.m in Sources */,
@@ -3369,6 +3392,7 @@
 				106FF29F1B663FCE004EACF2 /* ORK1HolePegTestPlaceStep.m in Sources */,
 				FFAE71411DAEC66200AE82B4 /* ORK1FootnoteLabel.m in Sources */,
 				86C40C941A8D7C5C00081FAC /* ORK1AudioRecorder.m in Sources */,
+				AC9069CB250911F200910AB7 /* ORK1DocumentReviewStep.m in Sources */,
 				FF5E3CCC1D23444400ECE4B7 /* ORK1PageStepViewController.m in Sources */,
 				86C40C581A8D7C5C00081FAC /* ORK1TappingIntervalStepViewController.m in Sources */,
 				BA0AA6971EAEC0B600671ACE /* ORK1StroopStep.m in Sources */,

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStep.h
@@ -30,37 +30,51 @@
 
 
 #import <ORK1Kit/ORK1Step.h>
-#import <AVFoundation/AVFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The `ORK1DocumentSelectionStep` class represents a step that allows selection of an image or
- other file from one of multiple sources. The selected file is referenced in the step's
- `ORK1FileResult` object.
+ The `ORK1DocumentReviewStep` represents a class that displays a read-only preview of a file
+ produced by a previous step. The referenced step should produce an `ORK1FileResult`.
  */
 ORK1_CLASS_AVAILABLE
-@interface ORK1DocumentSelectionStep : ORK1Step
+@interface ORK1DocumentReviewStep : ORK1Step
+
+- (instancetype)initWithIdentifier:(NSString *)identifier NS_UNAVAILABLE;
 
 /**
- A Boolean value indicating whether the user can provide an image using the device's
- camera (if available). When the value is `YES`, a button is displayed that allows the
- user to open a camera view, after prompting for permission if necessary.
+ Returns an initialized document review step using the specified identifier
+ and source step identifier.
+  
+ @param identifier                          The string that identifies the step (see `ORK1Step`).
+ @param sourceStepIdentifier    The identifier of a previous step (e.g. an `ORK1DocumentSelectionStep` that produced the result that should be displayed by this step.
+ 
+ @return An initialized document review step object.
  */
-@property (nonatomic) BOOL allowCamera;
+- (instancetype)initWithIdentifier:(NSString *)identifier sourceStepIdentifier:(NSString *)sourceStepIdentifier NS_DESIGNATED_INITIALIZER;
 
 /**
- A Boolean value indicating whether the user can select an image from the Photos app.
- When the value is `YES`, a button is displayed that allows the user to open the photo
- picker, after prompting for permission if necessary.
+ Returns a document review step initialized from data in the given unarchiver.
+ 
+ A document review step can be serialized and deserialized with `NSKeyedArchiver`. Note
+ that this serialization includes strings that might need to be localized.
+ 
+ @param aDecoder    The coder from which to initialize the ordered task.
+ 
+ @return An initialized document review step.
  */
-@property (nonatomic) BOOL allowPhotoLibrary;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
- Configures the preferred behavior of the camera view.
- If `AVCaptureDevicePositionUnspecified` is set, then it defaults to `AVCaptureDevicePositionBack`.
+ The identifier of a previous step (e.g. an `ORK1DocumentSelectionStep` that produced the result that should be displayed by this step.
  */
-@property (nonatomic) AVCaptureDevicePosition preferredCameraPosition;
+@property (nonatomic, copy) NSString *sourceStepIdentifier;
+
+/**
+ The text to display if the source step's `ORK1FileResult` is missing, empty, or has an unsupported file type.
+ If nil, the step's `text` property is displayed instead.
+ */
+@property (nonatomic, copy, nullable) NSString *noFileText;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStep.m
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2020, CareEvolution, Inc.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#import "ORK1DocumentReviewStep.h"
+#import "ORK1DocumentReviewStepViewController.h"
+#import "ORK1Step_Private.h"
+#import "ORK1Helpers_Internal.h"
+
+@implementation ORK1DocumentReviewStep
+
++ (Class)stepViewControllerClass {
+    return [ORK1DocumentReviewStepViewController class];
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier sourceStepIdentifier:(NSString *)sourceStepIdentifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        _sourceStepIdentifier = [sourceStepIdentifier copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK1_DECODE_OBJ_CLASS(aDecoder, sourceStepIdentifier, NSString);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, noFileText, NSString);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK1_ENCODE_OBJ(aCoder, sourceStepIdentifier);
+    ORK1_ENCODE_OBJ(aCoder, noFileText);
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    ORK1DocumentReviewStep *step = [super copyWithZone:zone];
+    step.sourceStepIdentifier = [self.sourceStepIdentifier copy];
+    step.noFileText = [self.noFileText copy];
+    return step;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            ORK1EqualObjects(self.sourceStepIdentifier, castObject.sourceStepIdentifier) &&
+            ORK1EqualObjects(self.noFileText, castObject.noFileText));
+}
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.h
@@ -28,39 +28,21 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-#import <ORK1Kit/ORK1Step.h>
-#import <AVFoundation/AVFoundation.h>
+@import UIKit;
+#import <ORK1Kit/ORK1Defines.h>
+#import "ORK1StepViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The `ORK1DocumentSelectionStep` class represents a step that allows selection of an image or
- other file from one of multiple sources. The selected file is referenced in the step's
- `ORK1FileResult` object.
+ The `ORK1DocumentReviewStepViewController` class is a step view controller subclass
+ used to manage a `ORK1DocumentReviewStep`.
+ 
+ You should not need to instantiate a this step view controller directly. Instead, include
+ a `ORK1DocumentReviewStep` in a task, and present a task view controller for that task.
  */
 ORK1_CLASS_AVAILABLE
-@interface ORK1DocumentSelectionStep : ORK1Step
-
-/**
- A Boolean value indicating whether the user can provide an image using the device's
- camera (if available). When the value is `YES`, a button is displayed that allows the
- user to open a camera view, after prompting for permission if necessary.
- */
-@property (nonatomic) BOOL allowCamera;
-
-/**
- A Boolean value indicating whether the user can select an image from the Photos app.
- When the value is `YES`, a button is displayed that allows the user to open the photo
- picker, after prompting for permission if necessary.
- */
-@property (nonatomic) BOOL allowPhotoLibrary;
-
-/**
- Configures the preferred behavior of the camera view.
- If `AVCaptureDevicePositionUnspecified` is set, then it defaults to `AVCaptureDevicePositionBack`.
- */
-@property (nonatomic) AVCaptureDevicePosition preferredCameraPosition;
+@interface ORK1DocumentReviewStepViewController : ORK1StepViewController
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.m
@@ -100,7 +100,7 @@
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[_headerView]-8-[_imageView]-8-[_continueView]-36-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_headerView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_imageView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_continueView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[_continueView]-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
     
     [NSLayoutConstraint activateConstraints:constraints];
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.m
@@ -1,0 +1,155 @@
+/*
+ Copyright (c) 2020, CareEvolution, Inc.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ORK1StepViewController_Internal.h"
+#import "ORK1StepHeaderView_Internal.h"
+
+#import "ORK1DocumentReviewStepViewController.h"
+#import "ORK1DocumentReviewStep.h"
+
+#import "ORK1TaskViewController.h"
+#import "ORK1Result.h"
+#import "ORK1Step_Private.h"
+#import "ORK1Helpers_Internal.h"
+#import "ORK1NavigationContainerView_Internal.h"
+#import "ORK1Skin.h"
+
+#import "CEVRK1Theme.h"
+
+@interface ORK1DocumentReviewStepViewController ()
+
+@property (nonatomic, readonly) ORK1DocumentReviewStep* documentReviewStep;
+
+@end
+
+@implementation ORK1DocumentReviewStepViewController {
+    ORK1StepHeaderView *_headerView;
+    ORK1NavigationContainerView *_continueView;
+    UIImageView *_imageView;
+}
+
+- (ORK1DocumentReviewStep *)documentReviewStep {
+    return (ORK1DocumentReviewStep *)self.step;
+}
+
+- (instancetype)initWithStep:(ORK1Step *)step {
+    self = [super initWithStep:step];
+    if (self) {
+        NSParameterAssert([step isKindOfClass:[ORK1DocumentReviewStep class]]);
+        [self setUpViews];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = ORK1Color(ORK1BackgroundColorKey);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self displayResult];
+}
+
+- (void)setUpViews {
+    _headerView = [[ORK1StepHeaderView alloc] init];
+    _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
+    _headerView.captionLabel.text = self.step.title;
+    [self displayInstructionText:self.step.text];
+    [self.view addSubview:_headerView];
+    
+    _imageView = [[UIImageView alloc] init];
+    _imageView.contentMode = UIViewContentModeScaleAspectFit;
+    [self.view addSubview:_imageView];
+    
+    _continueView = [[ORK1NavigationContainerView alloc] init];
+    _continueView.skipEnabled = NO;
+    [self.view addSubview:_continueView];
+    
+    NSMutableArray *constraints = [NSMutableArray new];
+    NSDictionary *views = NSDictionaryOfVariableBindings(_headerView, _imageView, _continueView);
+    ORK1EnableAutoLayoutForViews([views allValues]);
+    
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[_headerView]-8-[_imageView]-8-[_continueView]-36-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_headerView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_imageView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_continueView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    
+    [NSLayoutConstraint activateConstraints:constraints];
+}
+
+- (void)displayResult {
+    ORK1StepResult *stepResult = [self.taskViewController.result stepResultForStepIdentifier:self.documentReviewStep.sourceStepIdentifier];
+    ORK1FileResult *fileResult = (ORK1FileResult *)stepResult.firstResult;
+    if (!fileResult.fileURL) {
+        [self displayImage:nil];
+        return;
+    }
+    
+    if (![fileResult.contentType hasPrefix:@"image/"]) {
+        ORK1_Log_Warning(@"Document review step: unsupported file result content type: %@", fileResult);
+        [self displayImage:nil];
+        return;
+    }
+    
+    NSData *data = [NSData dataWithContentsOfURL:fileResult.fileURL];
+    if (data) {
+        [self displayImage:[UIImage imageWithData:data]];
+    } else {
+        ORK1_Log_Warning(@"Document review step: unable to load file from result %@", fileResult);
+        [self displayImage:nil];
+    }
+}
+
+- (void)displayImage:(UIImage *)image {
+    if (image) {
+        _imageView.image = image;
+        _imageView.hidden = NO;
+        [self displayInstructionText:self.step.text];
+        _continueView.continueEnabled = YES;
+    } else {
+        _imageView.image = nil;
+        _imageView.hidden = YES;
+        [self displayInstructionText:self.documentReviewStep.noFileText ?: self.step.text];
+        _continueView.continueEnabled = self.step.isOptional;
+    }
+}
+
+- (void)displayInstructionText:(NSString *)text {
+    _headerView.instructionTextView.hidden = !text.length;
+    _headerView.instructionTextView.textValue = text;
+}
+
+- (void)setContinueButtonItem:(UIBarButtonItem *)continueButtonItem {
+    [super setContinueButtonItem:continueButtonItem];
+    _continueView.continueButtonItem = continueButtonItem;
+}
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.h
@@ -1,0 +1,67 @@
+/*
+ Copyright (c) 2020, CareEvolution, Inc.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <ORK1Kit/ORK1Step.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `ORK1WebViewStep` class represents a step that allows selection of an image or
+ other file from one of multiple sources. The selected file is referenced in the step's
+ `ORK1FileResult` object.
+ */
+ORK1_CLASS_AVAILABLE
+@interface ORK1DocumentSelectionStep : ORK1Step
+
+/**
+ A Boolean value indicating whether the user can provide an image using the device's
+ camera (if available). When the value is `YES`, a button is displayed that allows the
+ user to open a camera view, after prompting for permission if necessary.
+ */
+@property (nonatomic) BOOL allowCamera;
+
+/**
+ A Boolean value indicating whether the user can select an image from the Photos app.
+ When the value is `YES`, a button is displayed that allows the user to open the photo
+ picker, after prompting for permission if necessary.
+ */
+@property (nonatomic) BOOL allowPhotoLibrary;
+
+/**
+ Configures the preferred behavior of the camera view.
+ If `AVCaptureDevicePositionUnspecified` is set, then it defaults to `AVCaptureDevicePositionBack`.
+ */
+@property (nonatomic) AVCaptureDevicePosition preferredCameraPosition;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.m
@@ -78,4 +78,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             self.preferredCameraPosition == castObject.preferredCameraPosition);
 }
 
+- (void)validateParameters {
+    [super validateParameters];
+    if (!self.allowCamera && !self.allowPhotoLibrary) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"ORK1DocumentSelectionStep requires allowCamera or allowPhotoLibrary."
+                                     userInfo:nil];
+    }
+}
+
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStep.m
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2020, CareEvolution, Inc.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#import "ORK1DocumentSelectionStep.h"
+#import "ORK1DocumentSelectionStepViewController.h"
+#import "ORK1Step_Private.h"
+#import "ORK1Helpers_Internal.h"
+
+@implementation ORK1DocumentSelectionStep
+
++ (Class)stepViewControllerClass {
+    return [ORK1DocumentSelectionStepViewController class];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK1_DECODE_BOOL(aDecoder, allowCamera);
+        ORK1_DECODE_BOOL(aDecoder, allowPhotoLibrary);
+        ORK1_DECODE_ENUM(aDecoder, preferredCameraPosition);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK1_ENCODE_BOOL(aCoder, allowCamera);
+    ORK1_ENCODE_BOOL(aCoder, allowPhotoLibrary);
+    ORK1_ENCODE_ENUM(aCoder, preferredCameraPosition);
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    ORK1DocumentSelectionStep *step = [super copyWithZone:zone];
+    step.allowCamera = self.allowCamera;
+    step.allowPhotoLibrary = self.allowPhotoLibrary;
+    step.preferredCameraPosition = self.preferredCameraPosition;
+    return step;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            self.allowCamera == castObject.allowCamera &&
+            self.allowPhotoLibrary == castObject.allowPhotoLibrary &&
+            self.preferredCameraPosition == castObject.preferredCameraPosition);
+}
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.h
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2020, CareEvolution, Inc.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@import UIKit;
+#import <ORK1Kit/ORK1Defines.h>
+#import "ORK1StepViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `ORK1DocumentSelectionStepViewController` class is a step view controller subclass
+ used to manage a `ORK1DocumentSelectionStep`.
+ 
+ You should not need to instantiate a this step view controller directly. Instead, include
+ a `ORK1DocumentSelectionStep` in a task, and present a task view controller for that task.
+ */
+ORK1_CLASS_AVAILABLE
+@interface ORK1DocumentSelectionStepViewController : ORK1StepViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -1,0 +1,376 @@
+/*
+ Copyright (c) 2020, CareEvolution, Inc.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ORK1StepViewController_Internal.h"
+#import "ORK1StepHeaderView_Internal.h"
+
+#import "ORK1DocumentSelectionStepViewController.h"
+#import "ORK1DocumentSelectionStep.h"
+
+#import "ORK1Result.h"
+
+#import "ORK1Step_Private.h"
+#import "ORK1Helpers_Internal.h"
+#import "ORK1BorderedButton.h"
+#import "ORK1NavigationContainerView_Internal.h"
+#import "ORK1Skin.h"
+
+#import "CEVRK1Theme.h"
+
+@import AVFoundation;
+@import MobileCoreServices;
+@import Photos;
+
+@interface ORK1DocumentSelectionStepViewController () <UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+
+@property (nonatomic, readonly) BOOL isCameraAvailable;
+@property (nonatomic, readonly) BOOL isPhotoLibraryAvailable;
+@property (nonatomic, readonly) ORK1DocumentSelectionStep *documentSelectionStep;
+@property (nonatomic, strong) UIImage *selectedPhoto;
+
+@end
+
+@implementation ORK1DocumentSelectionStepViewController {
+    NSURL *_fileURL;
+    ORK1NavigationContainerView *_continueSkipContainer;
+}
+
+- (BOOL)isCameraAvailable {
+    return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+}
+
+- (BOOL)isPhotoLibraryAvailable {
+    return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary];
+}
+
+- (ORK1DocumentSelectionStep *)documentSelectionStep {
+    return (ORK1DocumentSelectionStep *)self.step;
+}
+
+- (void)setSelectedPhoto:(UIImage *)selectedPhoto {
+    _selectedPhoto = selectedPhoto;
+    if (_fileURL) {
+        [[NSFileManager defaultManager] removeItemAtURL:_fileURL error:NULL];
+        _fileURL = nil;
+    }
+}
+
+#pragma mark - Initialization
+
+- (instancetype)initWithStep:(ORK1Step *)step result:(ORK1Result *)result {
+    self = [self initWithStep:step];
+    if (self) {
+        ORK1StepResult *stepResult = (ORK1StepResult *)result;
+        if (stepResult && [stepResult results].count > 0) {
+            ORK1FileResult *fileResult = ORK1DynamicCast([stepResult results].firstObject, ORK1FileResult);
+            if (fileResult.fileURL) {
+                NSData *data = [NSData dataWithContentsOfURL:fileResult.fileURL];
+                self.selectedPhoto = [UIImage imageWithData:data];
+                if (self.selectedPhoto) {
+                    _fileURL = fileResult.fileURL;
+                }
+            }
+        }
+    }
+    return self;
+}
+
+- (instancetype)initWithStep:(ORK1Step *)step {
+    self = [super initWithStep:step];
+    if (self) {
+        NSParameterAssert([step isKindOfClass:[ORK1DocumentSelectionStep class]]);
+        [self setUpViews];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = ORK1Color(ORK1BackgroundColorKey);
+}
+
+- (void)setUpViews {
+    // Copy ORK1QuestionStepView
+    ORK1StepHeaderView *headerView = [[ORK1StepHeaderView alloc] init];
+    headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
+    headerView.captionLabel.text = self.step.title;
+    headerView.instructionTextView.hidden = !self.step.text.length;
+    headerView.instructionTextView.textValue = self.step.text;
+    [self.view addSubview:headerView];
+    
+    UIStackView *sourceStackView = [[UIStackView alloc] init];
+    sourceStackView.axis = UILayoutConstraintAxisVertical;
+    sourceStackView.alignment = UIStackViewAlignmentFill;
+    sourceStackView.distribution = UIStackViewDistributionEqualSpacing;
+    sourceStackView.spacing = 8;
+    
+    if (self.documentSelectionStep.allowCamera && self.isCameraAvailable) {
+        ORK1BorderedButton *button = [[ORK1BorderedButton alloc] init];
+        [button setTitle:ORK1LocalizedString(@"TAKE_PHOTO_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        [button addTarget:self action:@selector(takePhoto) forControlEvents:UIControlEventTouchUpInside];
+        button.contentEdgeInsets = UIEdgeInsetsMake(13, 35, 13, 35);
+        [sourceStackView addArrangedSubview:button];
+    }
+    
+    if (self.documentSelectionStep.allowPhotoLibrary && self.isPhotoLibraryAvailable) {
+        ORK1BorderedButton *button = [[ORK1BorderedButton alloc] init];
+        [button setTitle:ORK1LocalizedString(@"CHOOSE_PHOTO_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        [button addTarget:self action:@selector(choosePhoto) forControlEvents:UIControlEventTouchUpInside];
+        button.contentEdgeInsets = UIEdgeInsetsMake(13, 35, 13, 35);
+        [sourceStackView addArrangedSubview:button];
+    }
+    
+    [self.view addSubview:sourceStackView];
+    
+    _continueSkipContainer = [[ORK1NavigationContainerView alloc] init];
+    _continueSkipContainer.neverHasContinueButton = YES;
+    [self.view addSubview:_continueSkipContainer];
+    
+    NSMutableArray *constraints = [NSMutableArray new];
+    NSDictionary *views = NSDictionaryOfVariableBindings(headerView, sourceStackView, _continueSkipContainer);
+    ORK1EnableAutoLayoutForViews([views allValues]);
+
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[headerView]-8-[sourceStackView]-(>=8)-[_continueSkipContainer]-36-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[headerView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_continueSkipContainer]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+
+    id viewMarginItem = self.view;
+    if (@available(iOS 11.0, *)) {
+        viewMarginItem = self.view.safeAreaLayoutGuide;
+    }
+    
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:sourceStackView attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:viewMarginItem attribute:NSLayoutAttributeLeading multiplier:1 constant:0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:sourceStackView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationLessThanOrEqual toItem:viewMarginItem attribute:NSLayoutAttributeTrailing multiplier:1 constant:0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:sourceStackView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:viewMarginItem attribute:NSLayoutAttributeCenterX multiplier:1 constant:0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:sourceStackView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:self.view.readableContentGuide attribute:NSLayoutAttributeWidth multiplier:1 constant:0]];
+    
+    [NSLayoutConstraint activateConstraints:constraints];
+    
+    self.skipButtonItem = self.internalSkipButtonItem;
+}
+
+- (void)setSkipButtonItem:(UIBarButtonItem *)skipButtonItem {
+    [super setSkipButtonItem:skipButtonItem];
+    _continueSkipContainer.skipButtonItem = skipButtonItem;
+    _continueSkipContainer.optional = self.step.isOptional;
+    _continueSkipContainer.skipEnabled = self.step.isOptional;
+}
+
+- (void)notifyDelegateOnResultChange {
+    [super notifyDelegateOnResultChange];
+    self.skipButtonItem = self.internalSkipButtonItem;
+}
+
+#pragma mark - User interaction
+
+- (void)takePhoto {
+    ORK1WeakTypeOf(self) weakSelf = self;
+    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+        case AVAuthorizationStatusDenied:
+            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS", nil)}] showSettingsButton:YES];
+            break;
+        case AVAuthorizationStatusRestricted:
+            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS", nil)}] showSettingsButton:YES];
+            break;
+        case AVAuthorizationStatusNotDetermined:
+        case AVAuthorizationStatusAuthorized:
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (granted) {
+                        [weakSelf presentAuthorizedPicker:UIImagePickerControllerSourceTypeCamera];
+                    } else {
+                        [weakSelf handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS", nil)}] showSettingsButton:YES];
+                    }
+                });
+            }];
+            break;
+    }
+}
+
+- (void)choosePhoto {
+    ORK1WeakTypeOf(self) weakSelf = self;
+    switch ([PHPhotoLibrary authorizationStatus]) {
+        case PHAuthorizationStatusDenied:
+            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS", nil)}] showSettingsButton:YES];
+            break;
+        case PHAuthorizationStatusRestricted:
+            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS", nil)}] showSettingsButton:YES];
+            break;
+        case PHAuthorizationStatusNotDetermined:
+        case PHAuthorizationStatusAuthorized:
+            [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (status == PHAuthorizationStatusAuthorized) {
+                        [weakSelf presentAuthorizedPicker:UIImagePickerControllerSourceTypePhotoLibrary];
+                    } else {
+                        [weakSelf handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS", nil)}] showSettingsButton:YES];
+                    }
+                });
+            }];
+            break;
+    }
+}
+
+- (void)presentAuthorizedPicker:(UIImagePickerControllerSourceType)sourceType {
+    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+    picker.delegate = self;
+    picker.sourceType = sourceType;
+    picker.mediaTypes = @[(NSString *)kUTTypeImage];
+    
+    if (sourceType == UIImagePickerControllerSourceTypeCamera) {
+        switch (self.documentSelectionStep.preferredCameraPosition) {
+            case AVCaptureDevicePositionUnspecified:
+            case AVCaptureDevicePositionBack:
+                if ([UIImagePickerController isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceRear]) {
+                    picker.cameraDevice = UIImagePickerControllerCameraDeviceRear;
+                }
+                break;
+            case AVCaptureDevicePositionFront:
+                if ([UIImagePickerController isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceFront]) {
+                    picker.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+                }
+                break;
+        }
+    }
+    
+    [self presentViewController:picker animated:YES completion:NULL];
+}
+
+- (void)handleError:(NSError *)error showSettingsButton:(BOOL)showSettings {
+    ORK1_Log_Warning(@"Document selection step error: %@", error.localizedDescription);
+    self.selectedPhoto = nil;
+    [self notifyDelegateOnResultChange];
+    
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_CANCEL", nil) style:UIAlertActionStyleCancel handler:NULL]];
+    
+    if (showSettings) {
+        [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_OPEN_SETTINGS", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            NSURL *URL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            if (URL) {
+                [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:NULL];
+            }
+        }]];
+    }
+    
+    [self presentViewController:alert animated:YES completion:NULL];
+}
+
+#pragma mark - Results and file handling
+
+- (ORK1StepResult *)result {
+    ORK1StepResult *stepResult = [super result];
+    if (!stepResult) {
+        return nil;
+    }
+    
+    NSDate *now = stepResult.endDate;
+    
+    // If we have captured data, but have not yet written that data to a file, do it now
+    if (!_fileURL && _selectedPhoto) {
+        NSError *error = nil;
+        _fileURL = [self writeSelectedPhotoWithError:&error];
+        if (!_fileURL) {
+            ORK1_Log_Warning(@"Document selection step error: %@", error.localizedDescription);
+            self.selectedPhoto = nil;
+        }
+    }
+    
+    ORK1FileResult *fileResult = [[ORK1FileResult alloc] initWithIdentifier:self.step.identifier];
+    fileResult.startDate = stepResult.startDate;
+    fileResult.endDate = now;
+    fileResult.contentType = @"image/jpeg";
+    fileResult.fileURL = _fileURL;
+    
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
+    [results addObject:fileResult];
+    stepResult.results = [results copy];
+    return stepResult;
+}
+
+- (NSURL *)writeSelectedPhotoWithError:(NSError **)error {
+    NSURL *URL = [self.outputDirectory URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.jpg",self.step.identifier]];
+    if (!URL) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteInvalidFileNameError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"ERROR_RECORDER_NO_OUTPUT_DIRECTORY", nil)}];
+        }
+        return nil;
+    }
+    
+    NSData *data = UIImageJPEGRepresentation(_selectedPhoto, 0.95);
+    if (!data) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteInvalidFileNameError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"ERROR_DATALOGGER_CREATE_FILE", nil)}];
+        }
+        return nil;
+    }
+    
+    NSError *writeError = nil;
+    if (![data writeToURL:URL options:NSDataWritingAtomic|NSDataWritingFileProtectionCompleteUnlessOpen error:&writeError]) {
+        if (writeError) {
+            ORK1_Log_Warning(@"%@", writeError);
+        }
+        if (error) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteInvalidFileNameError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"ERROR_DATALOGGER_CREATE_FILE", nil)}];
+        }
+        return nil;
+    }
+    
+    return URL;
+}
+
+#pragma mark - UIImagePickerControllerDelegate
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+    self.selectedPhoto = nil;
+    [self notifyDelegateOnResultChange];
+    [picker dismissViewControllerAnimated:YES completion:NULL];
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<UIImagePickerControllerInfoKey,id> *)info {
+    ORK1WeakTypeOf(self) weakSelf = self;
+    UIImage *selectedPhoto = [info objectForKey:UIImagePickerControllerEditedImage] ?: [info objectForKey:UIImagePickerControllerOriginalImage];
+    [picker dismissViewControllerAnimated:YES completion:^{
+        ORK1StrongTypeOf(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            strongSelf.selectedPhoto = selectedPhoto;
+            // Triggers updating the result which can produce errors.
+            // Only go forward if there's no error.
+            [strongSelf notifyDelegateOnResultChange];
+            if (strongSelf.selectedPhoto) {
+                [strongSelf goForward];
+            } else {
+                [strongSelf handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteInvalidFileNameError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"ERROR_DATALOGGER_CREATE_FILE", nil)}] showSettingsButton:NO];
+            }
+        }
+    }];
+}
+
+@end

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -189,8 +189,6 @@
     ORK1WeakTypeOf(self) weakSelf = self;
     switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
         case AVAuthorizationStatusDenied:
-            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS", nil)}] showSettingsButton:YES];
-            break;
         case AVAuthorizationStatusRestricted:
             [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS", nil)}] showSettingsButton:YES];
             break;
@@ -213,8 +211,6 @@
     ORK1WeakTypeOf(self) weakSelf = self;
     switch ([PHPhotoLibrary authorizationStatus]) {
         case PHAuthorizationStatusDenied:
-            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS", nil)}] showSettingsButton:YES];
-            break;
         case PHAuthorizationStatusRestricted:
             [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORK1LocalizedString(@"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS", nil)}] showSettingsButton:YES];
             break;

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -117,7 +117,6 @@
 }
 
 - (void)setUpViews {
-    // Copy ORK1QuestionStepView
     ORK1StepHeaderView *headerView = [[ORK1StepHeaderView alloc] init];
     headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
     headerView.captionLabel.text = self.step.title;

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -268,8 +268,6 @@
     [self notifyDelegateOnResultChange];
     
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_CANCEL", nil) style:UIAlertActionStyleCancel handler:NULL]];
-    
     if (showSettings) {
         [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_OPEN_SETTINGS", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             NSURL *URL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
@@ -278,11 +276,18 @@
             }
         }]];
     }
-    
+    [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_CANCEL", nil) style:UIAlertActionStyleCancel handler:NULL]];
+
     [self presentViewController:alert animated:YES completion:NULL];
 }
 
 #pragma mark - Results and file handling
+
+- (void)skipForward {
+    self.selectedPhoto = nil;
+    [self notifyDelegateOnResultChange];
+    [super skipForward];
+}
 
 - (ORK1StepResult *)result {
     ORK1StepResult *stepResult = [super result];

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -158,7 +158,7 @@
 
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[headerView]-8-[sourceStackView]-(>=8)-[_continueSkipContainer]-36-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[headerView]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_continueSkipContainer]|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[_continueSkipContainer]-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:nil views:views]];
 
     id viewMarginItem = self.view;
     if (@available(iOS 11.0, *)) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.m
@@ -38,7 +38,7 @@
 
 #import "ORK1Step_Private.h"
 #import "ORK1Helpers_Internal.h"
-#import "ORK1BorderedButton.h"
+#import "ORK1ContinueButton.h"
 #import "ORK1NavigationContainerView_Internal.h"
 #import "ORK1Skin.h"
 
@@ -131,18 +131,14 @@
     sourceStackView.spacing = 8;
     
     if (self.documentSelectionStep.allowCamera && self.isCameraAvailable) {
-        ORK1BorderedButton *button = [[ORK1BorderedButton alloc] init];
-        [button setTitle:ORK1LocalizedString(@"TAKE_PHOTO_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        ORK1ContinueButton *button = [[ORK1ContinueButton alloc] initWithTitle:ORK1LocalizedString(@"TAKE_PHOTO_BUTTON_TITLE", nil) isDoneButton:NO];
         [button addTarget:self action:@selector(takePhoto) forControlEvents:UIControlEventTouchUpInside];
-        button.contentEdgeInsets = UIEdgeInsetsMake(13, 35, 13, 35);
         [sourceStackView addArrangedSubview:button];
     }
     
     if (self.documentSelectionStep.allowPhotoLibrary && self.isPhotoLibraryAvailable) {
-        ORK1BorderedButton *button = [[ORK1BorderedButton alloc] init];
-        [button setTitle:ORK1LocalizedString(@"CHOOSE_PHOTO_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        ORK1ContinueButton *button = [[ORK1ContinueButton alloc] initWithTitle:ORK1LocalizedString(@"CHOOSE_PHOTO_BUTTON_TITLE", nil) isDoneButton:NO];
         [button addTarget:self action:@selector(choosePhoto) forControlEvents:UIControlEventTouchUpInside];
-        button.contentEdgeInsets = UIEdgeInsetsMake(13, 35, 13, 35);
         [sourceStackView addArrangedSubview:button];
     }
     

--- a/ORK1Kit/ORK1Kit/Localized/en.lproj/ORK1Kit.strings
+++ b/ORK1Kit/ORK1Kit/Localized/en.lproj/ORK1Kit.strings
@@ -214,6 +214,7 @@
 "BUTTON_CLEAR_ANSWER" = "Clear answer";
 "BUTTON_READ_ONLY_MODE" = "This answer cannot be modified.";
 "BUTTON_COPYRIGHT" = "Copyright";
+"BUTTON_OPEN_SETTINGS" = "Settings";
 
 /* General active tasks. */
 "COUNTDOWN_LABEL" = "Starting activity in";
@@ -234,6 +235,12 @@
 "CAPTURE_BUTTON_CAPTURE_VIDEO" = "Start Recording";
 "CAPTURE_BUTTON_STOP_CAPTURE_VIDEO" = "Stop Recording";
 "CAPTURE_BUTTON_RECAPTURE_VIDEO" = "Recapture Video";
+
+/* Document selection step. */
+"TAKE_PHOTO_BUTTON_TITLE" = "Take Photo";
+"CHOOSE_PHOTO_BUTTON_TITLE" = "Choose Photo";
+"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS" = "This app does not have access to your camera. You can enable access in Settings.";
+"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS" = "This app does not have access to your photos. You can enable access in Settings.";
 
 /* Fitness active task. */
 "FITNESS_TASK_TITLE" = "Fitness";

--- a/ORK1Kit/ORK1Kit/Localized/es.lproj/ORK1Kit.strings
+++ b/ORK1Kit/ORK1Kit/Localized/es.lproj/ORK1Kit.strings
@@ -211,6 +211,7 @@
 "BUTTON_CLEAR_ANSWER" = "Borrar respuesta";
 "BUTTON_READ_ONLY_MODE" = "Esta respuesta no puede modificarse.";
 "BUTTON_COPYRIGHT" = "Copyright";
+"BUTTON_OPEN_SETTINGS" = "Ajustes";
 
 /* General active tasks. */
 "COUNTDOWN_LABEL" = "Iniciando actividad en";
@@ -231,6 +232,12 @@
 "CAPTURE_BUTTON_CAPTURE_VIDEO" = "Iniciar grabación";
 "CAPTURE_BUTTON_STOP_CAPTURE_VIDEO" = "Detener grabación";
 "CAPTURE_BUTTON_RECAPTURE_VIDEO" = "Volver a capturar vídeo";
+
+/* Document selection step. */
+"TAKE_PHOTO_BUTTON_TITLE" = "Tomar foto";
+"CHOOSE_PHOTO_BUTTON_TITLE" = "Elegir foto";
+"DOCUMENT_SELECTION_ERROR_NO_CAMERA_PERMISSIONS" = "Esta app no tiene acceso a la cámara. Puedes habilitar el acceso en Ajustes.";
+"DOCUMENT_SELECTION_ERROR_NO_PHOTO_PERMISSIONS" = "Esta app no tiene acceso a los fotos. Puedes habilitar el acceso en Ajustes.";
 
 /* Fitness active task. */
 "FITNESS_TASK_TITLE" = "Forma física";

--- a/ORK1Kit/ORK1Kit/ORK1Kit.h
+++ b/ORK1Kit/ORK1Kit/ORK1Kit.h
@@ -35,6 +35,7 @@
 #import <ORK1Kit/ORK1ActiveStep.h>
 #import <ORK1Kit/ORK1ConsentReviewStep.h>
 #import <ORK1Kit/ORK1ConsentSharingStep.h>
+#import <ORK1Kit/ORK1DocumentSelectionStep.h>
 #import <ORK1Kit/ORK1FormStep.h>
 #import <ORK1Kit/ORK1ImageCaptureStep.h>
 #import <ORK1Kit/ORK1InstructionStep.h>
@@ -73,6 +74,7 @@
 #import <ORK1Kit/ORK1StepViewController.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 #import <ORK1Kit/ORK1CompletionStepViewController.h>
+#import <ORK1Kit/ORK1DocumentSelectionStepViewController.h>
 #import <ORK1Kit/ORK1FormStepViewController.h>
 #import <ORK1Kit/ORK1InstructionStepViewController.h>
 #import <ORK1Kit/ORK1LoginStepViewController.h>

--- a/ORK1Kit/ORK1Kit/ORK1Kit.h
+++ b/ORK1Kit/ORK1Kit/ORK1Kit.h
@@ -35,6 +35,7 @@
 #import <ORK1Kit/ORK1ActiveStep.h>
 #import <ORK1Kit/ORK1ConsentReviewStep.h>
 #import <ORK1Kit/ORK1ConsentSharingStep.h>
+#import <ORK1Kit/ORK1DocumentReviewStep.h>
 #import <ORK1Kit/ORK1DocumentSelectionStep.h>
 #import <ORK1Kit/ORK1FormStep.h>
 #import <ORK1Kit/ORK1ImageCaptureStep.h>
@@ -74,6 +75,7 @@
 #import <ORK1Kit/ORK1StepViewController.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 #import <ORK1Kit/ORK1CompletionStepViewController.h>
+#import <ORK1Kit/ORK1DocumentReviewStepViewController.h>
 #import <ORK1Kit/ORK1DocumentSelectionStepViewController.h>
 #import <ORK1Kit/ORK1FormStepViewController.h>
 #import <ORK1Kit/ORK1InstructionStepViewController.h>


### PR DESCRIPTION
For https://github.com/CareEvolution/CEVResearchKit/issues/232

CEVResearchKit pull request: https://github.com/CareEvolution/CEVResearchKit/pull/234

Implements two new ResearchKit steps:

### ORK1DocumentSelectionStep

This is an adaptation of the profile photo selection survey found in myFHR/MyDataHelps. Depending on how the step is configured, a "Take Photo" and/or "Choose Photo" button is shown; these buttons prompt the user for permissions if needed and then display the system camera or photo library picker.

The standard `title` and `text` properties are supported. The step can be optional, if needed.

TODO: in order to migrate the profile photo selection survey to use this step, we need to add support for cropping to a square, and add the RSKImageCropper dependency. I would rather defer that to a separate pull request. We would ideally want to update the server anyway, e.g. by using a web visualization and server-configured survey for profile photo updates, similar to the new myFHR document upload feature, and deprecate the dedicated profile photo API endpoint.

### ORK1DocumentReviewStep

Given a source step identifier, displays the file in the ORK1FileResult produced by the source step. Currently assumes the file result is an image; if we enhance ORK1DocumentSelectionStep to handle other file types, then ORK1DocumentReviewStep should be updated to use a web view to display arbitrary files. But for now, assuming it's an image makes for a much simpler implementation.

The standard `title` and `text` properties are supported, as well as a `noFileText` property to show alternate text if no file result is found. If the step is optional, you are allowed to continue even if no file result is found.

### Alternatives

Overall, I figured this is a sufficiently unique use case that it warranted a specialized step implementation.

_Enhancing ORK1ImageCaptureStep to allow photo library selection:_ I thought it would be best to keep that unchanged, focused on its single purpose, as that provides a more streamlined UX for tasks where you do want to present the camera in a controlled fashion (and also avoids changing the UX for existing task implementations).

_Adding ORK1ImageSelectionStep:_ another approach would be to create a single purpose photo library picker step. If you want to support both that and camera capture, you could start with a question step that presents "Take Photo" and "Choose Photo" choices, and use a navigation rule to present either an ORK1ImageCaptureStep or ORK1ImageSelectionStep. This would be a worse user experience however (especially the way the UIImagePickerController would display modally immediately over the image selection step), and also could complicate handling the actual file data since two different steps could produce the file result.

### Screen shots

(A little out of date: the take/choose photo buttons now have the standard solid background and support custom themes/styles)

<img src="https://user-images.githubusercontent.com/2637734/92620157-54320c80-f290-11ea-97fd-c0352c904450.PNG" width="375"> <img src="https://user-images.githubusercontent.com/2637734/92620215-66ac4600-f290-11ea-8266-ef2b00c75c42.PNG" width="375"> <img src="https://user-images.githubusercontent.com/2637734/92620519-bdb21b00-f290-11ea-9591-6af08bd15879.jpeg" width="375"> <img src="https://user-images.githubusercontent.com/2637734/92620252-73309e80-f290-11ea-8e60-43d6b4bcd434.PNG" width="375"> <img src="https://user-images.githubusercontent.com/2637734/92620554-c276cf00-f290-11ea-9d1c-ed355dfa4343.jpeg" width="375">