### PR TITLE
Remove old static reference for font size in Style handling

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -255,7 +255,8 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
     } else if (textStyle.fontSize) {
         attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:textStyle.fontSize.floatValue weight:UIFontWeightRegular];
     } else if (textStyle.fontWeight) {
-        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:15 weight:textStyle.fontWeight.floatValue];
+        CGFloat currentFontSize = ((UIFont *)attributes[NSFontAttributeName]).pointSize;
+        attributes[NSFontAttributeName] = [UIFont cevrk1_preferredFontOfSize:currentFontSize weight:textStyle.fontWeight.floatValue];
     }
     
     if (textStyle.color) {


### PR DESCRIPTION
Addresses the font size bug from https://github.com/CareEvolution/RKStudio-Participant/issues/822. This is a remnant from a recent refactor. The new way to handle this is to let ResearchKit set the font size of the text element first (usually using `defaultFont`), then using that font as the base font for any restyling.