### PR TITLE
Update UIDatePicker for iOS 14

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1DateTimePicker.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DateTimePicker.m
@@ -72,6 +72,9 @@
 - (UIDatePicker *)pickerView {
     if (_pickerView == nil) {
         _pickerView = [[UIDatePicker alloc] init];
+        if (@available(iOS 14, *)) {
+            _pickerView.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
         [_pickerView addTarget:self action:@selector(valueDidChange:) forControlEvents:UIControlEventValueChanged];
         self.answerFormat = _answerFormat;
         self.answer = _answer;

--- a/ORK1Kit/ORK1Kit/Common/ORK1TimeIntervalPicker.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TimeIntervalPicker.m
@@ -86,6 +86,9 @@
 - (UIView *)pickerView {
     if (_pickerView == nil) {
         _pickerView = [[ORK1DatePicker alloc] init];
+        if (@available(iOS 14, *)) {
+            _pickerView.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
         _pickerView.datePickerMode = UIDatePickerModeCountDownTimer;
         [_pickerView addTarget:self action:@selector(valueDidChange:) forControlEvents:UIControlEventValueChanged];
         [self setAnswerFormat:_answerFormat];

--- a/ResearchKit/Common/ORKDateTimePicker.m
+++ b/ResearchKit/Common/ORKDateTimePicker.m
@@ -72,6 +72,9 @@
 - (UIDatePicker *)pickerView {
     if (_pickerView == nil) {
         _pickerView = [[UIDatePicker alloc] init];
+        if (@available(iOS 14, *)) {
+            _pickerView.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
         [_pickerView addTarget:self action:@selector(valueDidChange:) forControlEvents:UIControlEventValueChanged];
         self.answerFormat = _answerFormat;
         self.answer = _answer;

--- a/ResearchKit/Common/ORKTimeIntervalPicker.m
+++ b/ResearchKit/Common/ORKTimeIntervalPicker.m
@@ -86,6 +86,9 @@
 - (UIView *)pickerView {
     if (_pickerView == nil) {
         _pickerView = [[ORKDatePicker alloc] init];
+        if (@available(iOS 14, *)) {
+            _pickerView.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
         _pickerView.datePickerMode = UIDatePickerModeCountDownTimer;
         [_pickerView addTarget:self action:@selector(valueDidChange:) forControlEvents:UIControlEventValueChanged];
         [self setAnswerFormat:_answerFormat];


### PR DESCRIPTION
Sticking with the default iOS 13 wheels style for now. Switching to either the new inline or compact picker types is significantly more involved.

https://github.com/CareEvolution/RKStudio-Participant/issues/820