### PR TITLE
Fix infinite recursion in webviewstep scriptMessageHandler

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -100,21 +100,21 @@
 
 @implementation ORK1WebViewStepViewController {
     NSString *_result;
-    ORK1ScriptMessageHandlerImpl *_scriptMessageHandler;
+    ORK1ScriptMessageHandlerImpl *_scriptMessageHandlerImpl;
 }
 
 - (instancetype)initWithStep:(ORK1Step *)step {
     self = [super initWithStep:step];
     if (self) {
         __weak typeof(self) weakSelf = self;
-        _scriptMessageHandler = [[ORK1ScriptMessageHandlerImpl alloc] init];
-        _scriptMessageHandler.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
+        _scriptMessageHandlerImpl = [[ORK1ScriptMessageHandlerImpl alloc] init];
+        _scriptMessageHandlerImpl.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
             [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
         };
         
         _webView = [[ORK1WebViewPreloader shared] webViewForKey:step.identifier];
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandler name:@"ResearchKit"];
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandler name:@"GetAccessToken"];
+        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
+        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"GetAccessToken"];
         _webView.frame = self.view.bounds;
         _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _webView.navigationDelegate = self;

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -109,7 +109,7 @@
     NSString *_result;
     ORKNavigationContainerView *_navigationFooterView;
     NSArray<NSLayoutConstraint *> *_constraints;
-    ORKScriptMessageHandlerImpl *_scriptMessageHandler;
+    ORKScriptMessageHandlerImpl *_scriptMessageHandlerImpl;
 }
 
 - (ORKWebViewStep *)webViewStep {
@@ -125,14 +125,14 @@
     self = [super initWithStep:step];
     if (self) {
         __weak typeof(self) weakSelf = self;
-        _scriptMessageHandler = [[ORKScriptMessageHandlerImpl alloc] init];
-        _scriptMessageHandler.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
+        _scriptMessageHandlerImpl = [[ORKScriptMessageHandlerImpl alloc] init];
+        _scriptMessageHandlerImpl.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
             [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
         };
         
         _webView = [[ORKWebViewPreloader shared] webViewForKey:step.identifier];
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandler name:@"ResearchKit"];
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandler name:@"GetAccessToken"];
+        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
+        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"GetAccessToken"];
         _webView.frame = self.view.bounds;
         _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _webView.navigationDelegate = self;


### PR DESCRIPTION
The ORKScriptMessageHandlerImpl object introduced in #70 was stored in a private `_scriptMessageHandler` field which hides the public `scriptMessageHandler` property. When receiving a GetAccessToken message, this results in an infinite recursion:

1. WKUserContentController receives a JS message
2. ORK1ScriptMessageHandlerImpl userContentController:didReceiveScriptMessage:
3. Call didReceiveScriptMessageFunc defined in ORK1WebViewStepViewController
4. ORK1WebViewStepViewController calls `[weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage]`
5. If message.name is GetAccessToken, `[self.scriptMessageHandler userContentController:userContentController didReceiveScriptMessage:message]`
6. `self.scriptMessageHandler == _scriptMessageHandler == ORK1ScriptMessageHandlerImpl instance`, so loop back to step 2

I think the intention is for step 6 to call the the handler set via the public scriptMessageHandler property, separate from the ORK1ScriptMessageHandlerImpl instance. I fixed this by renaming the `_scriptMessageHandler` field to `_scriptMessageHandlerImpl` so it's separate from the public property.