### PR TITLE
Adjust bottomConstraint for any non-zero offset when keyboard/picker disappears

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -55,6 +55,7 @@
     
     CGFloat _keyboardOverlap;
     BOOL _keyboardIsUp;
+    CGFloat _preKeyboardBottomConstant;
     
     UIScrollView *_scrollView;
     
@@ -165,7 +166,7 @@
 }
 
 - (void)updateBottomConstraintConstant {
-    _bottomConstraint.constant = -_keyboardOverlap;
+    _bottomConstraint.constant = _preKeyboardBottomConstant - _keyboardOverlap;
 }
 
 - (void)setUpConstraints {
@@ -402,6 +403,17 @@
 
 - (void)keyboardFrameWillChange:(NSNotification *)notification {
     CGSize intersectionSize = [self keyboardIntersectionSizeFromNotification:notification];
+    
+    /*
+     HACK: the _bottomConstraint is not always zero. If a hidePredicate causes a formItem to be added/removed,
+     this can be non-zero. Here we detect current state when the keyboard is about to appear so we can add
+     this offset to the keyboard overlap. Without this, the Done/Continue button will appear above or below
+     where it is expected after the keyboard is dismissed.
+    */
+    
+    if (!_keyboardIsUp) {
+        _preKeyboardBottomConstant = _bottomConstraint.constant;
+    }
     
     // Assume the overlap is at the bottom of the view
     ORK1UpdateScrollViewBottomInset(self.tableView, intersectionSize.height);


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/868. The original RK1 code here I think slid up the Done/Continue button and the rest of the view structure above the keyboard and pickers. It seems that has been broken for awhile and after playing with this a little, I think fixing that would a more significant lift due to some of our customizations we've added. For now, I kept the fix simple.

To reproduce the issue, run the CEVRKUITestVehicle target in CEVResearchKit and select the FormStepHidePredicate2 Test JSON. Then select 5 on the discrete scale FormItem which causes the __hidePredicate__ item to appear at the bottom ("Found It!"). This causes the bottomConstraint to become non-zero. Then tap on the Date FormItem which summons the picker. Then tap above the discrete scale to dismiss the picker. This will cause the button to slide below the safe area before this change.

|BEFORE|AFTER|
|---|---|
|![broken](https://user-images.githubusercontent.com/1008462/101658311-8297c300-3a0a-11eb-96eb-3fb7fd417698.gif)|![fixed](https://user-images.githubusercontent.com/1008462/101659019-37ca7b00-3a0b-11eb-9854-d102d5dafe40.gif)|

