### PR TITLE
Guarantee non-nil result startDate

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -781,7 +781,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 - (ORK1TaskResult *)result {
     
     ORK1TaskResult *result = [[ORK1TaskResult alloc] initWithTaskIdentifier:[self.task identifier] taskRunUUID:self.taskRunUUID outputDirectory:self.outputDirectory];
-    result.startDate = _presentedDate;
+    result.startDate = _presentedDate ?: [NSDate date];
     result.endDate = _dismissedDate ? :[NSDate date];
     
     // Update current step result

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -852,7 +852,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 - (ORKTaskResult *)result {
     
     ORKTaskResult *result = [[ORKTaskResult alloc] initWithTaskIdentifier:[self.task identifier] taskRunUUID:self.taskRunUUID outputDirectory:self.outputDirectory];
-    result.startDate = _presentedDate;
+    result.startDate = _presentedDate ?: [NSDate date];
     result.endDate = _dismissedDate ? :[NSDate date];
     
     // Update current step result


### PR DESCRIPTION
Fixes the crash in https://github.com/CareEvolution/RKStudio-Participant/issues/880:

- ORK[1]TaskViewController sets `result.startDate = _presentedDate` when creating a result object
- Its `_presentedDate` is nil until after viewDidAppear. So if you fetch the result object before or during viewDidAppear, the result's startDate is nil
- RKStudioWebViewStep dynamically injects the task result into the HTML string so JavaScript can reference it. This involves serializing the result
- Our Swift code to serialize will crash if startDate is nil, because ORK[1]Result.h annotates the `startDate` property as nonnull

So when launching a task from restoration data that has a WebViewStep, it attempts to the serialize task result during viewDidAppear, and thus crashes.

I opted to modify the TaskViewControllers to ensure they don't set a nil startDate. It makes sense to leave the nonnull annotation on the startDate property: the ORK[1]Result class initializes it as `[NSDate date]` so I think the real problem is the task view controller then setting the startDate to nil, and not the nonnull guarantee itself. There are few places that _set_ the result startDate, but many places that access it.