### PR TITLE
RK2: Reduce minimum for Stroop attempts from 3 to 1

### DIFF
--- a/ResearchKit/ActiveTasks/ORKStroopStep.m
+++ b/ResearchKit/ActiveTasks/ORKStroopStep.m
@@ -183,7 +183,7 @@ NSString *const ORKStroopColorIdentifierBlack = @"BLACK";
 
 - (void)validateParameters {
     [super validateParameters];
-    NSInteger minimumAttempts = 3;
+    NSInteger minimumAttempts = 1;
     if (self.numberOfAttempts < minimumAttempts) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"number of attempts should be greater or equal to %ld.", (long)minimumAttempts]  userInfo:nil];
     }


### PR DESCRIPTION
To prevent having to make major changes to the Stroop test for OFFSPRING, reducing this arbitrary minimum from 3 to 1 will allow for more flexibility in survey design to be able to meet some of their requests such as:
- give the answer for each step in a practice session directly after that test
- allow the participant to establish being "in set" prior to each individual test