### PR TITLE
RK2: Normalized Reaction Time - prevent early start of next test

### DIFF
--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
@@ -67,8 +67,10 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
 }
 
 - (void)resetAfterDelay:(NSTimeInterval)delay completion:(nullable void (^)(void))completion {
+    _button.hidden = YES;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         _stimulusView.hidden = YES;
+        _button.hidden = NO;
         if (completion) {
             completion();
         }

--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeViewController.m
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeViewController.m
@@ -166,7 +166,7 @@ static const NSTimeInterval OutcomeAnimationDuration = 0.3;
     _timerStartDate = 0;
     _reactionDate = 0;
     _stimulusStartDate = 0;
-    [self reactionTimeStep].currentInterval = 0;
+    [self reactionTimeStep].currentInterval = @0;
     
     [self attemptDidFinish];
 }


### PR DESCRIPTION
A study has reported that participants are struggling with the Normalized Reaction Test and getting unexpected failing results. Upon further investigation, it appears that there is no "lock out" after a test results so if a user taps on the **hold** button during the 2 sec result, it will start the stimulus timer for the next test. And if they lift the finger again when they see this success/failure animation disappear, they will cause another failure because the stimulus will not have yet appeared.

While a state machine would probably be ideal, this simple solution removes the **hold** button when the result display is occurring.  This approach both prevents an early tap from occurring but also to signals to the user that the test has not started yet - the button reappearing will signal the start of the next test period. This will not affecting any timings because there can be any amount of time between the end of one test and the beginning of another.

To simulate the behavior they are seeing, run the following survey before this fix.
1. Press and hold the **hold** button until the stimulus (circle in box) appears.
2. Lift finger off the **hold** button and tap the stimulus. 
3. While the result animation is playing, press the **hold** button.
4. When the animation disappears, lift your finger as if realizing you started too early.
5. A failure will occur since the stimulus timer has not completed - i.e. an early lift.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "rkVersion": 2,
  "steps": [
    {
      "type": "NormalizedReactionTimeStep",
      "text": "Place your finger on the hold button. When the blue circle appears, tap it as quickly as you can then return your finger to the hold button.",
      "title": "Reaction Time Test",
      "identifier": "REACTION_TIME_PRACTICE",
      "minimumStimulusInterval": 4,
      "maximumStimulusInterval": 10,
      "numberOfAttempts": 3,
      "timeout": 3,
      "optional": false
      }
  ]
}
```