### PR TITLE
Fix issue where urls with special characters were not correctly deserialized

### DIFF
--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		618DA0521A93D0D600E63AA8 /* ORK1AccessibilityFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04A1A93D0D600E63AA8 /* ORK1AccessibilityFunctions.m */; };
 		618DA0541A93D0D600E63AA8 /* UIView+ORK1Accessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 618DA04B1A93D0D600E63AA8 /* UIView+ORK1Accessibility.h */; };
 		618DA0561A93D0D600E63AA8 /* UIView+ORK1Accessibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04C1A93D0D600E63AA8 /* UIView+ORK1Accessibility.m */; };
+		67DDF56A25BF5BA4002AC56E /* ORK1HelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 67DDF56925BF5BA4002AC56E /* ORK1HelpersTests.m */; };
 		781D54101DF886AB00223305 /* ORK1TrailmakingContentView.h in Headers */ = {isa = PBXBuildFile; fileRef = 781D540A1DF886AB00223305 /* ORK1TrailmakingContentView.h */; };
 		781D54111DF886AB00223305 /* ORK1TrailmakingContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = 781D540B1DF886AB00223305 /* ORK1TrailmakingContentView.m */; };
 		781D54121DF886AB00223305 /* ORK1TrailmakingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 781D540C1DF886AB00223305 /* ORK1TrailmakingStep.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -744,6 +745,7 @@
 		618DA04A1A93D0D600E63AA8 /* ORK1AccessibilityFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1AccessibilityFunctions.m; sourceTree = "<group>"; };
 		618DA04B1A93D0D600E63AA8 /* UIView+ORK1Accessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "UIView+ORK1Accessibility.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		618DA04C1A93D0D600E63AA8 /* UIView+ORK1Accessibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "UIView+ORK1Accessibility.m"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		67DDF56925BF5BA4002AC56E /* ORK1HelpersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1HelpersTests.m; sourceTree = "<group>"; };
 		781D540A1DF886AB00223305 /* ORK1TrailmakingContentView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1TrailmakingContentView.h; sourceTree = "<group>"; };
 		781D540B1DF886AB00223305 /* ORK1TrailmakingContentView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1TrailmakingContentView.m; sourceTree = "<group>"; };
 		781D540C1DF886AB00223305 /* ORK1TrailmakingStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1TrailmakingStep.h; sourceTree = "<group>"; };
@@ -1740,6 +1742,7 @@
 				86CC8EA91AC09383001CCD89 /* ORK1ChoiceAnswerFormatHelperTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORK1DataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORK1DataLoggerTests.m */,
+				67DDF56925BF5BA4002AC56E /* ORK1HelpersTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORK1HKSampleTests.m */,
 				86D348001AC16175006DB02B /* ORK1RecorderTests.m */,
 				86CC8EAF1AC09383001CCD89 /* ORK1ResultTests.m */,
@@ -3180,6 +3183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67DDF56A25BF5BA4002AC56E /* ORK1HelpersTests.m in Sources */,
 				86CC8EB71AC09383001CCD89 /* ORK1DataLoggerTests.m in Sources */,
 				248604061B4C98760010C8A0 /* ORK1AnswerFormatTests.m in Sources */,
 				86CC8EBA1AC09383001CCD89 /* ORK1ResultTests.m in Sources */,

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
@@ -485,16 +485,7 @@ NSURL *ORK1URLForRelativePath(NSString *relativePath) {
     }
     
     NSURL *homeDirectoryURL = ORK1HomeDirectoryURL();
-    NSURL *url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:NO relativeToURL:homeDirectoryURL];
-    
-    if (url != nil) {
-        BOOL isDirectory = NO;;
-        BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url.path isDirectory:&isDirectory];
-        if (fileExists && isDirectory) {
-            url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:YES relativeToURL:homeDirectoryURL];
-        }
-    }
-    return url;
+    return [NSURL URLWithString:relativePath relativeToURL:homeDirectoryURL];
 }
 NSString *ORK1RelativePathForURL(NSURL *url) {
     if (!url) {

--- a/ORK1Kit/ORK1KitTests/ORK1HelpersTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1HelpersTests.m
@@ -1,0 +1,74 @@
+//
+/*
+ Copyright (c) 2021, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "ORK1Helpers_Internal.h"
+
+@interface ORK1HelpersTests : XCTestCase
+
+@end
+
+@implementation ORK1HelpersTests
+
+- (void)testURLForRelativePath {
+    {
+        NSURL *url = [NSURL fileURLWithPath:NSHomeDirectory()];
+        NSString *path = ORK1RelativePathForURL(url);
+        NSURL *resolvedUrl = ORK1URLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"test"];
+        NSString *path = ORK1RelativePathForURL(url);
+        NSURL *resolvedUrl = ORK1URLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@" !\"#$%&'()*+,-./:;<=>?"];
+        NSString *path = ORK1RelativePathForURL(url);
+        NSURL *resolvedUrl = ORK1URLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"a/a/a/a/a/a/a/a/a/"];
+        NSString *path = ORK1RelativePathForURL(url);
+        NSURL *resolvedUrl = ORK1URLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+        NSString *path = ORK1RelativePathForURL(url);
+        NSURL *resolvedUrl = ORK1URLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+}
+
+@end

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		618DA0521A93D0D600E63AA8 /* ORKAccessibilityFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04A1A93D0D600E63AA8 /* ORKAccessibilityFunctions.m */; };
 		618DA0541A93D0D600E63AA8 /* UIView+ORKAccessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 618DA04B1A93D0D600E63AA8 /* UIView+ORKAccessibility.h */; };
 		618DA0561A93D0D600E63AA8 /* UIView+ORKAccessibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04C1A93D0D600E63AA8 /* UIView+ORKAccessibility.m */; };
+		67DDF56225BF5AB5002AC56E /* ORKHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 67DDF56125BF5AB5002AC56E /* ORKHelpersTests.m */; };
 		7118AC5A20BF6A0000D7A6BB /* Noise.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC5920BF6A0000D7A6BB /* Noise.wav */; };
 		7118AC5D20BF6A1200D7A6BB /* Window.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC5B20BF6A1200D7A6BB /* Window.wav */; };
 		7118AC6720BF6A3A00D7A6BB /* Sentence7.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC6020BF6A3900D7A6BB /* Sentence7.wav */; };
@@ -887,6 +888,7 @@
 		618DA04A1A93D0D600E63AA8 /* ORKAccessibilityFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKAccessibilityFunctions.m; sourceTree = "<group>"; };
 		618DA04B1A93D0D600E63AA8 /* UIView+ORKAccessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "UIView+ORKAccessibility.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		618DA04C1A93D0D600E63AA8 /* UIView+ORKAccessibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "UIView+ORKAccessibility.m"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		67DDF56125BF5AB5002AC56E /* ORKHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHelpersTests.m; sourceTree = "<group>"; };
 		7118AC5920BF6A0000D7A6BB /* Noise.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Noise.wav; sourceTree = "<group>"; };
 		7118AC5B20BF6A1200D7A6BB /* Window.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Window.wav; sourceTree = "<group>"; };
 		7118AC6020BF6A3900D7A6BB /* Sentence7.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Sentence7.wav; sourceTree = "<group>"; };
@@ -2123,6 +2125,7 @@
 				86CC8EA91AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORKDataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORKDataLoggerTests.m */,
+				67DDF56125BF5AB5002AC56E /* ORKHelpersTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORKHKSampleTests.m */,
 				86D348001AC16175006DB02B /* ORKRecorderTests.m */,
 				86CC8EAF1AC09383001CCD89 /* ORKResultTests.m */,
@@ -3708,6 +3711,7 @@
 				86D348021AC161B0006DB02B /* ORKRecorderTests.m in Sources */,
 				86CC8EB61AC09383001CCD89 /* ORKDataLoggerManagerTests.m in Sources */,
 				86CC8EB31AC09383001CCD89 /* ORKAccessibilityTests.m in Sources */,
+				67DDF56225BF5AB5002AC56E /* ORKHelpersTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -485,16 +485,7 @@ NSURL *ORKURLForRelativePath(NSString *relativePath) {
     }
     
     NSURL *homeDirectoryURL = ORKHomeDirectoryURL();
-    NSURL *url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:NO relativeToURL:homeDirectoryURL];
-    
-    if (url != nil) {
-        BOOL isDirectory = NO;;
-        BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url.path isDirectory:&isDirectory];
-        if (fileExists && isDirectory) {
-            url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:YES relativeToURL:homeDirectoryURL];
-        }
-    }
-    return url;
+    return [NSURL URLWithString:relativePath relativeToURL:homeDirectoryURL];
 }
 NSString *ORKRelativePathForURL(NSURL *url) {
     if (!url) {

--- a/ResearchKitTests/ORKHelpersTests.m
+++ b/ResearchKitTests/ORKHelpersTests.m
@@ -1,0 +1,74 @@
+//
+/*
+ Copyright (c) 2021, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "ORKHelpers_Internal.h"
+
+@interface ORKHelpersTests : XCTestCase
+
+@end
+
+@implementation ORKHelpersTests
+
+- (void)testURLForRelativePath {
+    {
+        NSURL *url = [NSURL fileURLWithPath:NSHomeDirectory()];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"test"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@" !\"#$%&'()*+,-./:;<=>?"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"a/a/a/a/a/a/a/a/a/"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+}
+
+@end


### PR DESCRIPTION
Cherry-pick https://github.com/ResearchKit/ResearchKit/pull/1444

`ORKPathRelativeToURL` and `ORKURLForRelativePath` do not correctly mirror each other. `ORKPathRelativeToURL` percent encodes it's output whereas `ORKURLForRelativePath` does not percent decode it's input. These methods are used during serialization/deserialization, causing a restored `ORKFileResult` to not point at the same path as the original file result.

Fix is to replace the call to `[NSURL fileURLWithFileSystemRepresentation:...]` with `[NSURL URLWithString:...]`. This matches with the `[standardizedURL absoluteString]` call in `ORKPathRelativeToURL`.  I do not believe it is necessary to check if the file is a directory given that we are not modifying the relative path. If the original url had a trailing slash, then the output path will have a trailing slash and vice versa.