### PR TITLE
RK1: Fix collapsed skip/recapture button on ImageCaptureStep

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureView.m
@@ -240,8 +240,13 @@
                                                                       constant:0.0]];
         _continueSkipContainer.backgroundColor = [_continueSkipContainer.backgroundColor colorWithAlphaComponent:ContinueSkipContainerTranslucentAlpha];
     } else {
+        /*
+         CEVHack - when the vertical sections of the view apportion, this prevents the imageView from expanding too much which puts pressure
+         on the UIBarButtonItem for which the label collapses vertically and shows no text.
+         */
+        CGFloat maxPreviewSize = self.superview.bounds.size.height - 160;
         [_variableConstraints addObjectsFromArray:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_previewView]-[_continueSkipContainer]|"
+         [NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|[_previewView(<=%f)]-[_continueSkipContainer]|", maxPreviewSize]
                                                  options:NSLayoutFormatDirectionLeadingToTrailing
                                                  metrics:nil
                                                    views:views]];


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/912.

Somewhere in various adjustments to vertical components in RK1, this broke. This problem only affects portrait orientation. 

After looking at other options including adjusting priority of vertical constraints, have settled on this solution that creates no extra warnings in the console when executed.

Have also tested with an iPad and SE (hack in simulator setting image data on the viewController programmatically to get past no camera warning).

|BEFORE|AFTER|
|---|---|
|![IMG_0110](https://user-images.githubusercontent.com/1008462/105775182-04489f00-5f2c-11eb-9a75-dde2fd428799.PNG)|![IMG_0109](https://user-images.githubusercontent.com/1008462/105775190-07dc2600-5f2c-11eb-82dd-e3e28fdfdad2.PNG)|

## QA Notes

- Create a survey using `ImageCaptureStep` (can use JSON below)
- Validate the "Recapture Image" button appears after snapping an image

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "optional": true,
  "steps": [
    {
      "type": "ImageCaptureStep",
      "text": "",
      "title": "",
      "identifier": "New Step 1"
    }
  ],
  "styles": {
    "progressBarColor": "#5381c3",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF"
  }
}
```