### PR TITLE
Fix cancel button for ORKWebViewStepViewController

### DIFF
--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -144,11 +144,21 @@
     return self;
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    /*
+     CEVHACK - This fixes a bug that affects RK2 where the cancel button did nothing - because the view cycle is different than
+     other subclasses of ORKStepViewController. Setting the cancelButtonItem on the _navigationFooterView needs to happen AFTER
+     the super class ORKStepViewController has had a chance to create it.
+     */
+    
+    [super viewWillAppear:animated];
+    _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+}
+
 - (void)setupNavigationFooterView {
     if (!_navigationFooterView) {
         _navigationFooterView = [[ORKNavigationContainerView alloc] initFromStepViewController:self];
     }
-    _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
     _navigationFooterView.neverHasContinueButton = YES;
     [self.view addSubview:_navigationFooterView];
 }


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/925. It appears that the timing of the standard creation of the cancel button by the super class `ORKStepViewController` is different due to how `ORKWebViewStep` is initialized. The fix presented here is to ensure we set the `_navigationFooterView`'s cancel button AFTER it has been created which occurs after initialization but before the view appears.

## Testing:
This only affects WebViewStep for RK2-versioned surveys which may not be live in any studies. Here's a simple survey that uses an RK2 WebViewStep. The cancel button should work as expected, presenting a dialog to allow canceling the current survey instance.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "rkVersion": 2,
  "steps": [
    {
      "type": "WebViewStep",
      "text": "",
      "title": "",
      "identifier": "New Step 1",
      "html": "<html>\n<head>\n<style type=\"text/css\">\nbody\n{\n  margin: 0;\n  padding: 0;\n}\ninput \n{\n  border: none;\n  padding: 10px;\n  margin-top: 10px;\n  width: 100%;\n  box-sizing: border-box;\n  font-size: 16px;\n  line-height:20px;\n  border-top: solid 1px #ddd;\n  border-bottom: solid 1px #ddd;\n}\ninput:focus\n{\n  outline:none;\n}\nbutton\n{\n  padding: 10px;\n  border: solid 1px #0067B1;\n  border-radius: 2px;\n  color: #0067B1;\n  display: inline-block;\n  margin-top: 30px;\n  min-width: 140px;\n  background: #FFF;\n  outline: none !important;\n  font-size: 16px;\n}\nbutton:hover\n{\n  background: #0067B1;\n  color: #FFF;\n  cursor: pointer;\n}\nbutton:disabled\n{\n  background: #FFF !important;\n  color: #999 !important;\n  border-color: #ccc !important;\n  cursor: auto;\n}\ndiv {\n  text-align: center;\n}\n</style>\n</head>\n<body>\n<div>Web View Step Example</div>\n<div>\n<input id=\"Answer\" type=\"text\" />\n<button onclick=\"postAnswer()\">Continue</button>\n</div>\n<script>\nfunction postAnswer() {\n  var answerInput = document.getElementById(\"Answer\");\n  var answer = answerInput.value;\n  window.webkit.messageHandlers.ResearchKit.postMessage(answer);\n}\nconsole.log(window.taskResult);\n</script>  \n</body>\n</html>",
      "height": 150
    }
  ],
  "styles": {
    "progressBarColor": "#5381c3",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF"
  }
}
```