### PR TITLE
NilQuestionPredicate should match with steps that have not been reached

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.m
@@ -253,9 +253,14 @@ NSString *const ORK1ResultPredicateTaskIdentifierVariableName = @"ORK1_TASK_IDEN
 }
 
 + (NSPredicate *)predicateForNilQuestionResultWithResultSelector:(ORK1ResultSelector *)resultSelector {
-    return [self predicateMatchingResultSelector:resultSelector
-                         subPredicateFormatArray:@[ @"answer == nil" ]
-                 subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *nilPredicate = [self predicateMatchingResultSelector:resultSelector
+                                              subPredicateFormatArray:@[ @"answer == nil" ]
+                                      subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *foundPredicate = [self predicateMatchingResultSelector:resultSelector
+                                                subPredicateFormatArray:@[ ]
+                                        subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *notFoundPredicate = [NSCompoundPredicate notPredicateWithSubpredicate:foundPredicate];
+    return [NSCompoundPredicate orPredicateWithSubpredicates:@[nilPredicate, notFoundPredicate]];
 }
 
 + (NSPredicate *)predicateForScaleQuestionResultWithResultSelector:(ORK1ResultSelector *)resultSelector

--- a/ORK1Kit/ORK1KitTests/ORK1TaskTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1TaskTests.m
@@ -618,6 +618,7 @@ ORK1DefineStringKey(TextFormItemIdentifier);
 ORK1DefineStringKey(NumericFormItemIdentifier);
 
 ORK1DefineStringKey(NilTextStepIdentifier);
+ORK1DefineStringKey(NonExistentStepIdentifier);
 
 ORK1DefineStringKey(AdditionalTaskIdentifier);
 ORK1DefineStringKey(AdditionalFormStepIdentifier);
@@ -1370,6 +1371,9 @@ static ORK1StepResult *(^getConsentStepResult)(NSString *, NSString *, BOOL) = ^
     
     // Result with nil value
     resultSelector.resultIdentifier = NilTextStepIdentifier;
+    XCTAssertTrue([[ORK1ResultPredicate predicateForNilQuestionResultWithResultSelector:resultSelector] evaluateWithObject:taskResults substitutionVariables:substitutionVariables]);
+    
+    resultSelector.resultIdentifier = NonExistentStepIdentifier;
     XCTAssertTrue([[ORK1ResultPredicate predicateForNilQuestionResultWithResultSelector:resultSelector] evaluateWithObject:taskResults substitutionVariables:substitutionVariables]);
     
     resultSelector.resultIdentifier = TextStepIdentifier;

--- a/ResearchKit/Common/ORKResultPredicate.m
+++ b/ResearchKit/Common/ORKResultPredicate.m
@@ -253,9 +253,14 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
 }
 
 + (NSPredicate *)predicateForNilQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector {
-    return [self predicateMatchingResultSelector:resultSelector
-                         subPredicateFormatArray:@[ @"answer == nil" ]
-                 subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *nilPredicate = [self predicateMatchingResultSelector:resultSelector
+                                              subPredicateFormatArray:@[ @"answer == nil" ]
+                                      subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *foundPredicate = [self predicateMatchingResultSelector:resultSelector
+                                                subPredicateFormatArray:@[ ]
+                                        subPredicateFormatArgumentArray:@[ ]];
+    NSPredicate *notFoundPredicate = [NSCompoundPredicate notPredicateWithSubpredicate:foundPredicate];
+    return [NSCompoundPredicate orPredicateWithSubpredicates:@[nilPredicate, notFoundPredicate]];
 }
 
 + (NSPredicate *)predicateForScaleQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -618,6 +618,7 @@ ORKDefineStringKey(TextFormItemIdentifier);
 ORKDefineStringKey(NumericFormItemIdentifier);
 
 ORKDefineStringKey(NilTextStepIdentifier);
+ORKDefineStringKey(NonExistentStepIdentifier);
 
 ORKDefineStringKey(AdditionalTaskIdentifier);
 ORKDefineStringKey(AdditionalFormStepIdentifier);
@@ -1370,6 +1371,9 @@ static ORKStepResult *(^getConsentStepResult)(NSString *, NSString *, BOOL) = ^O
     
     // Result with nil value
     resultSelector.resultIdentifier = NilTextStepIdentifier;
+    XCTAssertTrue([[ORKResultPredicate predicateForNilQuestionResultWithResultSelector:resultSelector] evaluateWithObject:taskResults substitutionVariables:substitutionVariables]);
+    
+    resultSelector.resultIdentifier = NonExistentStepIdentifier;
     XCTAssertTrue([[ORKResultPredicate predicateForNilQuestionResultWithResultSelector:resultSelector] evaluateWithObject:taskResults substitutionVariables:substitutionVariables]);
     
     resultSelector.resultIdentifier = TextStepIdentifier;


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/247. 

# Testing notes

Run this survey https://gist.github.com/overcyn/015ffc07051f572f4ed5d7f45127a00a and observe the following steps.
1. Navigation Rule 1 (You have a choice here to skip or not skip)
2. Either "You Skipped" or "You Answered" based on the previous step.
3. Navigation Rule 2
4. Success!
5. Navigation Rule 3
6. Success!

If the survey deviates from this then something is wrong.