### PR TITLE
Better handle dynamic text in ORK1VideoCaptureStep

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1VideoCaptureView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VideoCaptureView.m
@@ -306,8 +306,13 @@
                                                                       constant:0.0]];
         _continueSkipContainer.backgroundColor = [_continueSkipContainer.backgroundColor colorWithAlphaComponent:ContinueSkipContainerTranslucentAlpha];
     } else {
+        /*
+         CEVHack - when the vertical sections of the view apportion, this prevents the imageView from expanding too much which puts pressure
+         on the UIBarButtonItem for which the label collapses vertically and shows no text.
+         */
+        CGFloat maxPreviewSize = self.superview.bounds.size.height - 160;
         [_variableConstraints addObjectsFromArray:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_previewView]-[_continueSkipContainer]|"
+         [NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|[_previewView(<=%f)]-[_continueSkipContainer]|", maxPreviewSize]
                                                  options:NSLayoutFormatDirectionLeadingToTrailing
                                                  metrics:nil
                                                    views:views]];


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/248. Also noted in testing is that extreme small text sizes also broke the buttons for ORK1VideoCaptureStep. This fix, which the same as used for ORK1ImageCaptureStep, fixes for all "normal" dynamic text sizes. At the largest available size with **Larger Accessibility Sizes** enabled, there is some button overlap, but everything still appears on the screen. 

## Testing Notes
Use the example survey JSON for RK1 (first one) in https://github.com/CareEvolution/CEVResearchKit/pull/245. In Settings > Display & Brightness > Text Size, adjust to the extremes on this screen and verify the buttons in the VideoCaptureStep look acceptable and not squashed where the text cannot be read (like screenshot in https://github.com/CareEvolution/CEVResearchKit/issues/248).