### PR TITLE
Break infinite loop/call stack overflow in ORK1CountdownLabel rendering

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1CountdownLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1CountdownLabel.m
@@ -50,10 +50,6 @@
     return self;
 }
 
-- (void)updateAppearance {
-    [self setCountDownValue:_currentCountDownValue];
-}
-
 - (void)setCountDownValue:(NSInteger)value {
     _currentCountDownValue = value;
     [self renderText];
@@ -71,11 +67,6 @@
    
     [self setText:[durationFormatter stringFromTimeInterval:_currentCountDownValue]];
     [self invalidateIntrinsicContentSize];
-}
-
-- (void)setFont:(UIFont *)font {
-    [super setFont:font];
-    [self renderText];
 }
 
 - (CGSize)intrinsicContentSize {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/250.

The changes [for adding Markdown](https://github.com/CareEvolution/ResearchKit/pull/76) cause the font to be changed on each rendering pass. However, in ORK1CountdownLabel, setting the font causes the text to be re-rendered. This essentially created an infinite loop when this draws. This affects any ActiveTasks that show a timer during the task (including the Tremor Task in RKStudio).

This fix simply removes the call at the class level, allowing the super class to handle. Since font is only set initially and any time the text changes (via Markdown rendering here), there is no need to render the text explicitly here.

Did not address the RK2 version since we currently do not support Markdown for RK2 text.

## Testing Notes
This fix can be tested by simply running the standard survey in RKStudio where Survey Type is **Tremor Test**. Prior to this change, the survey will crash as soon as the countdown timer to begin the task reaches zero.
