### PR TITLE
RK1: Fix placement of continue button with use of Day/Time picker

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -1143,6 +1143,8 @@
     if (_currentFirstResponderCell == cell) {
         _currentFirstResponderCell = nil;
     }
+    NSLog(@"`Setting NEEDS LAYOUT");
+    [_tableContainer setNeedsLayout];
 }
 
 - (void)formItemCell:(ORK1FormItemCell *)cell invalidInputAlertWithMessage:(NSString *)input {

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -1143,7 +1143,6 @@
     if (_currentFirstResponderCell == cell) {
         _currentFirstResponderCell = nil;
     }
-    NSLog(@"`Setting NEEDS LAYOUT");
     [_tableContainer setNeedsLayout];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -162,10 +162,12 @@
         _tableView.tableFooterView = _realFooterView;
     }
     
+    NSLog(@"`[layoutSubviews] _lastScrollViewContentHeight -> %f", _scrollView.contentSize.height);
     _lastScrollViewContentHeight = _scrollView.contentSize.height;
 }
 
 - (void)updateBottomConstraintConstant {
+    NSLog(@"`[updateBottomConstraintConstant] _bottomConstraint - %f --> %f", _bottomConstraint.constant, _preKeyboardBottomConstant - _keyboardOverlap);
     _bottomConstraint.constant = _preKeyboardBottomConstant - _keyboardOverlap;
 }
 
@@ -265,6 +267,7 @@
 
 - (void)adjustBottomConstraintWithExpectedOffset:(CGFloat)offset {
     _continueSkipContainerView.alpha = 0;
+    NSLog(@"`[adjustBottomConstraintWithExpectedOffset] _bottomConstraint: %f --> %f", _bottomConstraint.constant, _bottomConstraint.constant - offset);
     _bottomConstraint.constant -= offset;
     [self performSelector:@selector(showButton) withObject:nil afterDelay:0.3];
 }
@@ -281,8 +284,11 @@
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         CGFloat diff = _scrollView.contentSize.height - _lastScrollViewContentHeight;
+        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] _diff = %f - %f", _scrollView.contentSize.height, _lastScrollViewContentHeight);
+        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] _bottomConstraint: %f --> %f", _bottomConstraint.constant, _bottomConstraint.constant - diff);
         _bottomConstraint.constant -= diff;
         _lastScrollViewContentHeight = _scrollView.contentSize.height;
+        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] -> _lastScrollViewContentHeight %f", _scrollView.contentSize.height);
         [self showButton];
     });
 }
@@ -374,6 +380,7 @@
         CGSize intersectionSize = [self keyboardIntersectionSizeFromNotification:notification];
         
         // Keep track of the keyboard overlap, so we can adjust the constraint properly.
+        NSLog(@"`[animateLayoutForKeyboardNotification] _keyboardOverlap: %f --> %f", _keyboardOverlap, intersectionSize.height);
         _keyboardOverlap = intersectionSize.height;
         
         [self updateBottomConstraintConstant];
@@ -402,6 +409,7 @@
 }
 
 - (void)keyboardFrameWillChange:(NSNotification *)notification {
+    // also used for pickers
     CGSize intersectionSize = [self keyboardIntersectionSizeFromNotification:notification];
     
     /*

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -162,12 +162,10 @@
         _tableView.tableFooterView = _realFooterView;
     }
     
-    NSLog(@"`[layoutSubviews] _lastScrollViewContentHeight -> %f", _scrollView.contentSize.height);
     _lastScrollViewContentHeight = _scrollView.contentSize.height;
 }
 
 - (void)updateBottomConstraintConstant {
-    NSLog(@"`[updateBottomConstraintConstant] _bottomConstraint - %f --> %f", _bottomConstraint.constant, _preKeyboardBottomConstant - _keyboardOverlap);
     _bottomConstraint.constant = _preKeyboardBottomConstant - _keyboardOverlap;
 }
 
@@ -267,7 +265,6 @@
 
 - (void)adjustBottomConstraintWithExpectedOffset:(CGFloat)offset {
     _continueSkipContainerView.alpha = 0;
-    NSLog(@"`[adjustBottomConstraintWithExpectedOffset] _bottomConstraint: %f --> %f", _bottomConstraint.constant, _bottomConstraint.constant - offset);
     _bottomConstraint.constant -= offset;
     [self performSelector:@selector(showButton) withObject:nil afterDelay:0.3];
 }
@@ -284,11 +281,8 @@
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         CGFloat diff = _scrollView.contentSize.height - _lastScrollViewContentHeight;
-        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] _diff = %f - %f", _scrollView.contentSize.height, _lastScrollViewContentHeight);
-        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] _bottomConstraint: %f --> %f", _bottomConstraint.constant, _bottomConstraint.constant - diff);
         _bottomConstraint.constant -= diff;
         _lastScrollViewContentHeight = _scrollView.contentSize.height;
-        NSLog(@"`[adjustBottomConstraintBasedOnLastContentSize] -> _lastScrollViewContentHeight %f", _scrollView.contentSize.height);
         [self showButton];
     });
 }
@@ -380,7 +374,6 @@
         CGSize intersectionSize = [self keyboardIntersectionSizeFromNotification:notification];
         
         // Keep track of the keyboard overlap, so we can adjust the constraint properly.
-        NSLog(@"`[animateLayoutForKeyboardNotification] _keyboardOverlap: %f --> %f", _keyboardOverlap, intersectionSize.height);
         _keyboardOverlap = intersectionSize.height;
         
         [self updateBottomConstraintConstant];
@@ -409,7 +402,9 @@
 }
 
 - (void)keyboardFrameWillChange:(NSNotification *)notification {
-    // also used for pickers
+    
+    // NOTE: this is also called with some pickers
+    
     CGSize intersectionSize = [self keyboardIntersectionSizeFromNotification:notification];
     
     /*


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/251.

UI Tests in CEVResearchKit still pass after this.

## Testing Notes:
Using the survey JSON below (similar to Symptom Shark survey), follow these steps:
1. For first question (Do you want to be reminded...), tap on Yes.
2. To select a time in the new section, tap on the "field" underneath "What time do you want to be reminded?". This should pop up a Time Picker as well as add a new section (Do you want a second reminder?).
3. Tap on **Yes** from the first question which will dismiss the Time Picker.
4. Tap on **No** from the first question which should remove the sections below.
5. The Done button should be below the first (only) question and easily tappable without scrolling.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "FormStep",
      "text": "",
      "title": "Daily Reminders",
      "identifier": "Reminders",
      "formItems": [
        {
          "identifier": "Reminder1Enabled",
          "type": "FormItem",
          "answerFormat": {
            "type": "BooleanAnswerFormat",
            "defaultValue": "",
            "customField": "Reminder1Enabled"
          },
          "optional": false,
          "text": "Do you want to be reminded to log your symptoms each day?"
        },
        {
          "identifier": "ReminderTime1",
          "type": "FormItem",
          "answerFormat": {
            "type": "TimeOfDayAnswerFormat",
            "customField": "ReminderTime1",
            "defaultValue": ""
          },
          "optional": true,
          "text": "What time do you want to be reminded?",
          "hidePredicate": {
            "type": "NotCompoundPredicate",
            "subpredicate": {
              "resultIdentifier": "Reminder1Enabled",
              "stepIdentifier": "Reminders",
              "type": "BooleanQuestionResultPredicate",
              "expectedAnswer": true
            }
          }
        },
        {
          "identifier": "Reminder2Enabled",
          "type": "FormItem",
          "answerFormat": {
            "type": "BooleanAnswerFormat",
            "defaultValue": "",
            "customField": "Reminder2Enabled"
          },
          "optional": false,
          "text": "Do you want a second reminder?",
          "hidePredicate": {
            "type": "OrCompoundPredicate",
            "subpredicates": [
              {
                "type": "NotCompoundPredicate",
                "subpredicate": {
                  "resultIdentifier": "Reminder1Enabled",
                  "stepIdentifier": "Reminders",
                  "type": "BooleanQuestionResultPredicate",
                  "expectedAnswer": true
                }
              },
              {
                "resultIdentifier": "ReminderTime1",
                "stepIdentifier": "Reminders",
                "type": "NilQuestionResultPredicate"
              }
            ]
          }
        },
        {
          "identifier": "ReminderTime2",
          "type": "FormItem",
          "answerFormat": {
            "type": "TimeOfDayAnswerFormat",
            "customField": "ReminderTime2",
            "defaultValue": ""
          },
          "optional": true,
          "text": "What's the second time you want to be reminded?",
          "hidePredicate": {
            "type": "OrCompoundPredicate",
            "subpredicates": [
              {
                "type": "NotCompoundPredicate",
                "subpredicate": {
                  "resultIdentifier": "Reminder2Enabled",
                  "stepIdentifier": "Reminders",
                  "type": "BooleanQuestionResultPredicate",
                  "expectedAnswer": true
                }
              },
              {
                "type": "NotCompoundPredicate",
                "subpredicate": {
                  "resultIdentifier": "Reminder1Enabled",
                  "stepIdentifier": "Reminders",
                  "type": "BooleanQuestionResultPredicate",
                  "expectedAnswer": true
                }
              },
              {
                "resultIdentifier": "ReminderTime1",
                "stepIdentifier": "Reminders",
                "type": "NilQuestionResultPredicate"
              }
            ]
          }
        }
      ],
      "optional": true
    }
  ],
  "styles": {
    "progressBarColor": "#429be9",
    "nextButtonBackgroundColor": "#429bdf",
    "nextButtonTextColor": "#FFFFFF",
    "titleColor": "#429bdf",
    "titleAlignment": "Left",
    "textAlignment": "Left"
  },
  "progressIndicatorType": "Bar"
}
```