### PR TITLE
Explicitly pass theme to progressView to ensure theme is current

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.h
@@ -12,8 +12,10 @@
  sizing (width) of the progressView
  */
 
+@class CEVRK1Theme;
+
 @interface CEVRK1NavigationBarProgressView : UIView
 
-- (void)setProgress:(float)progress;
+- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme;
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
@@ -44,9 +44,8 @@
      ]];
 }
 
-- (void)setProgress:(float)progress {
+- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme {
     _progressView.progress = progress;
-    CEVRK1Theme *theme = [CEVRK1Theme themeForElement:self];
     if (theme.progressBarColor) {
         _progressView.tintColor = theme.progressBarColor;
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1022,7 +1022,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                     } else {  // Linear
                         calculatedProgress = (float)taskProgress.current / (float)taskProgress.total;
                     }
-                    [strongSelf.progressView setProgress:calculatedProgress];
+                    [strongSelf.progressView setProgress:calculatedProgress withTheme:[CEVRK1Theme themeForElement:strongSelf.currentStepViewController]];
                     strongSelf.pageViewController.navigationItem.titleView = strongSelf.progressView;
                     
                     // for UITesting, we will add a title that will not display, but should appear via accessibility


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/249.

There is a race condition where the fallbackTaskViewController for the restored taskViewController is [not set](https://github.com/CareEvolution/ResearchKit/blob/3c95e74c79efd38142cca3968b693c5fa917f2e0/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m#L655) before the progress bar [progress is updated](https://github.com/CareEvolution/ResearchKit/blob/3c95e74c79efd38142cca3968b693c5fa917f2e0/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m#L1025) during a restored task flow.

This bug doesn't apply to RK2 because it doesn't support themes.

## Testing Notes
To test this, use a survey with the progress bar with a custom tint (can use survey below).
1. Open survey enter an answer, advance to step 2
2. Tap **Cancel**, selecting **Save for Later**
3. Re-open survey and note that the color of the progress bar is red (custom style) and not standard blue.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "QuestionStep",
      "text": "",
      "title": "Question 1",
      "identifier": "Step1",
      "answerFormat": {
        "type": "TextAnswerFormat",
        "multipleLines": false,
        "keyboardType": "Text"
      },
      "optional": false
    },
    {
      "type": "InstructionStep",
      "text": "",
      "title": "",
      "identifier": "Step2"
    }
  ],
  "styles": {
    "progressBarColor": "#e32400",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF"
  },
  "progressIndicatorType": "Bar"
}
```