### PR TITLE
Round the height answer to nearest hundredth of an inch when displaying to user

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -2749,7 +2749,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             double feet, inches;
             ORK1CentimetersToFeetAndInches(((NSNumber *)answer).doubleValue, &feet, &inches);
             NSString *feetString = [formatter stringFromNumber:@(feet)];
-            NSString *inchesString = [formatter stringFromNumber:@(inches)];
+            NSString *inchesString = [formatter stringFromNumber:@(round(inches * 100) / 100)];
             answerString = [NSString stringWithFormat:@"%@ %@, %@ %@",
                             feetString, ORK1LocalizedString(@"MEASURING_UNIT_FT", nil), inchesString, ORK1LocalizedString(@"MEASURING_UNIT_IN", nil)];
         }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2783,7 +2783,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
             double feet, inches;
             ORKCentimetersToFeetAndInches(((NSNumber *)answer).doubleValue, &feet, &inches);
             NSString *feetString = [formatter stringFromNumber:@(feet)];
-            NSString *inchesString = [formatter stringFromNumber:@(inches)];
+            NSString *inchesString = [formatter stringFromNumber:@(round(inches * 100) / 100)];
             answerString = [NSString stringWithFormat:@"%@ %@, %@ %@",
                             feetString, ORKLocalizedString(@"MEASURING_UNIT_FT", nil), inchesString, ORKLocalizedString(@"MEASURING_UNIT_IN", nil)];
         }


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/958

# Testing Notes

1. Open the following survey and pick 5 ft 2 in.
2. Observe that it shows `5 ft, 2 in` and not `5 ft, 1.999999999 in`
3. Submit the survey and verify that the results show `157.48` cm which is exactly 62 inches aka 5ft 2in

```
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "FormStep",
      "text": "Enter your height",
      "title": "Height Picker",
      "identifier": "New Step 1",
      "formItems": [
        {
          "identifier": "New Form Item 1",
          "type": "FormItem",
          "answerFormat": {
            "type": "HeightAnswerFormat",
            "measurementSystem": "USC"
          },
          "optional": false
        }
      ],
      "optional": false
    }
  ],
  "styles": {
    "progressBarColor": "#5381c3",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF"
  }
}
```