### PR TITLE
Fix 'text choice description icon overlays some of the text'

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.h
@@ -48,7 +48,7 @@ extern NSString const *ORK1UpdateChoiceCellKeyCell;
 @property (nonatomic, strong, readonly) ORK1SelectionSubTitleLabel *longLabel;
 @property (nonatomic, weak) ORK1TextChoice *choice;
 
-+ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText longText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
++ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText longText:(nullable NSString *)longText showDetailTextIndicator:(BOOL)showDetailTextIndicator inTableView:(nullable UITableView *)tableView;
 
 @property (nonatomic, assign, getter=isImmediateNavigation) BOOL immediateNavigation;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceViewCell.m
@@ -75,8 +75,14 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     CGFloat cellLeftMargin = self.separatorInset.left;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
-    CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORK1SelectionTitleLabel.defaultFont}].width;
-    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    CGFloat shortLabelWidth = [self.shortLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)].width;
+    
+    // Check for word wrapping
+    if (self.showDetailTextIndicator && shortLabelWidth > labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel)) {
+        shortLabelWidth = labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel);
+    } else if (shortLabelWidth > labelWidth) {
+        shortLabelWidth = labelWidth;
+    }
     
     CGFloat cellHeight = self.bounds.size.height;
     
@@ -86,10 +92,10 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
         self.shortLabel.frame = CGRectZero;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
-        self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
+        self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, shortLabelWidth, cellHeight);
         self.detailTextIndicator.frame =
         CGRectMake(
-                   cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel,
+                   cellLeftMargin + shortLabelWidth + DetailTextIndicatorPaddingFromLabel,
                    self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2,
                    DetailTextIndicatorTouchTargetWidth,
                    DetailTextIndicatorTouchTargetWidth);
@@ -100,7 +106,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     } else {
         {
             self.shortLabel.frame = CGRectMake(cellLeftMargin, 0,
-                                               labelWidth, 1);
+                                               shortLabelWidth, 1);
             
             ORK1AdjustHeightForLabel(self.shortLabel);
             
@@ -112,7 +118,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             self.shortLabel.frame = rect;
             self.detailTextIndicator.frame =
             CGRectMake(
-                       cellLeftMargin + shortLabelTextWidth + 10,
+                       cellLeftMargin + shortLabelWidth + 10,
                        self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2 + self.shortLabel.frame.origin.y,
                        DetailTextIndicatorTouchTargetWidth,
                        DetailTextIndicatorTouchTargetWidth);
@@ -201,7 +207,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     [self updateSelectedItem];
 }
 
-+ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText longText:(NSString *)longText inTableView:(UITableView *)tableView {
++ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText longText:(NSString *)longText showDetailTextIndicator:(BOOL)showDetailTextIndicator inTableView:(UITableView *)tableView {
     CGFloat height = 0;
     
     CGFloat firstBaselineOffsetFromTop = ORK1GetMetricForWindow(ORK1ScreenMetricChoiceCellFirstBaselineOffsetFromTop, tableView.window);
@@ -217,7 +223,11 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             shortLabel.numberOfLines = 0;
         }
         
-        shortLabel.frame = CGRectMake(0, 0, labelWidth, 0);
+        if (showDetailTextIndicator) {
+            shortLabel.frame = CGRectMake(0, 0, labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel), 0);
+        } else {
+            shortLabel.frame = CGRectMake(0, 0, labelWidth, 0);
+        }
         shortLabel.text = shortText;
         
         ORK1AdjustHeightForLabel(shortLabel);

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -1098,16 +1098,16 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    ORK1TableSection *section = _sections[indexPath.section];
-    ORK1FormItem *formItem = section.formItems[0];
-    ORK1TextChoiceAnswerFormat *format = (ORK1TextChoiceAnswerFormat *)formItem.answerFormat;
-    
     ORK1TableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
     CGFloat cellHeight = [_hiddenCellItems containsObject:cellItem] ? 0 : UITableViewAutomaticDimension;
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORK1ChoiceViewCell class]]) {
+        BOOL showDetailTextIndicator = false;
+        if ([[cellItem answerFormat] isKindOfClass:[ORK1TextChoiceAnswerFormat class]]) {
+            showDetailTextIndicator = ((ORK1TextChoiceAnswerFormat *)cellItem.answerFormat).descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded;
+        }
         return [ORK1ChoiceViewCell suggestedCellHeightForShortText:cellItem.choice.text
                                                           longText:(cellItem.choice.detailTextShouldDisplay) ? cellItem.choice.detailText : nil
-                                           showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded
+                                           showDetailTextIndicator:showDetailTextIndicator
                                                        inTableView:_tableView];
     }
     return cellHeight;

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -1101,7 +1101,7 @@
     ORK1TableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
     CGFloat cellHeight = [_hiddenCellItems containsObject:cellItem] ? 0 : UITableViewAutomaticDimension;
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORK1ChoiceViewCell class]]) {
-        BOOL showDetailTextIndicator = false;
+        BOOL showDetailTextIndicator = NO;
         if ([[cellItem answerFormat] isKindOfClass:[ORK1TextChoiceAnswerFormat class]]) {
             showDetailTextIndicator = ((ORK1TextChoiceAnswerFormat *)cellItem.answerFormat).descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded;
         }

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -429,12 +429,12 @@
     ORK1TextChoice *choice = format.textChoices[indexPath.row];
     
     NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
+    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
     
     [section.textChoiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]] atIndex:indexPath.row];
     
     longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
+    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
     
     [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
@@ -1098,11 +1098,16 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    ORK1TableSection *section = _sections[indexPath.section];
+    ORK1FormItem *formItem = section.formItems[0];
+    ORK1TextChoiceAnswerFormat *format = (ORK1TextChoiceAnswerFormat *)formItem.answerFormat;
+    
     ORK1TableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
     CGFloat cellHeight = [_hiddenCellItems containsObject:cellItem] ? 0 : UITableViewAutomaticDimension;
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORK1ChoiceViewCell class]]) {
         return [ORK1ChoiceViewCell suggestedCellHeightForShortText:cellItem.choice.text
                                                           longText:(cellItem.choice.detailTextShouldDisplay) ? cellItem.choice.detailText : nil
+                                           showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded
                                                        inTableView:_tableView];
     }
     return cellHeight;

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
@@ -385,12 +385,12 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
     }
     ORK1TextChoice *choice = format.textChoices[index];
     NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
+    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
     
     [_choiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]] atIndex:index];
     
     longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText inTableView:self.tableView];
+    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
     
     [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
@@ -798,6 +798,7 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
     ORK1TextChoice *option = [(ORK1TextChoiceAnswerFormat *)_answerFormat textChoices][index];
     return [ORK1ChoiceViewCell suggestedCellHeightForShortText:option.text
                                                       longText:(option.detailTextShouldDisplay) ? option.detailText : nil
+                                       showDetailTextIndicator: ((ORK1TextChoiceAnswerFormat *)_answerFormat).descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded
                                                    inTableView:_tableView];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
@@ -235,7 +235,7 @@
     ORK1StepResult *stepResult = [_resultSource stepResultForStepIdentifier:step.identifier];
     NSString *shortText = step.title != nil ? step.title : step.text;
     NSString *longText = [self answerStringForStep:step withStepResult:stepResult];
-    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText longText:longText inTableView:_tableContainer.tableView];
+    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText longText:longText showDetailTextIndicator:false inTableView:_tableContainer.tableView];
     return height;
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.m
@@ -235,7 +235,7 @@
     ORK1StepResult *stepResult = [_resultSource stepResultForStepIdentifier:step.identifier];
     NSString *shortText = step.title != nil ? step.title : step.text;
     NSString *longText = [self answerStringForStep:step withStepResult:stepResult];
-    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText longText:longText showDetailTextIndicator:false inTableView:_tableContainer.tableView];
+    CGFloat height = [ORK1ChoiceViewCell suggestedCellHeightForShortText:shortText longText:longText showDetailTextIndicator:NO inTableView:_tableContainer.tableView];
     return height;
 }
 

--- a/ResearchKit/Common/ORKChoiceViewCell.h
+++ b/ResearchKit/Common/ORKChoiceViewCell.h
@@ -48,7 +48,7 @@ extern NSString const *ORKUpdateChoiceCellKeyCell;
 @property (nonatomic, strong, readonly) ORKSelectionSubTitleLabel *longLabel;
 @property (nonatomic, weak) ORKTextChoice *choice;
 
-+ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText LongText:(nullable NSString *)longText inTableView:(nullable UITableView *)tableView;
++ (CGFloat)suggestedCellHeightForShortText:(nullable NSString *)shortText LongText:(nullable NSString *)longText showDetailTextIndicator:(BOOL)showDetailTextIndicator inTableView:(nullable UITableView *)tableView;
 
 @property (nonatomic, assign, getter=isImmediateNavigation) BOOL immediateNavigation;
 

--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -189,8 +189,14 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     CGFloat cellLeftMargin = self.separatorInset.left;
 
     CGFloat labelWidth =  self.bounds.size.width - (cellLeftMargin + LabelRightMargin);
-    CGFloat shortLabelTextWidth = [self.shortLabel.text sizeWithAttributes:@{NSFontAttributeName : ORKSelectionTitleLabel.defaultFont}].width;
-    shortLabelTextWidth = (shortLabelTextWidth > labelWidth) ? labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel) : shortLabelTextWidth;  // word wrapping will have occurred
+    CGFloat shortLabelWidth = [self.shortLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)].width;
+
+    // Check for word wrapping
+    if (self.showDetailTextIndicator && shortLabelWidth > labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel)) {
+        shortLabelWidth = labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel);
+    } else if (shortLabelWidth > labelWidth) {
+        shortLabelWidth = labelWidth;
+    }
     
     CGFloat cellHeight = self.bounds.size.height;
     
@@ -200,10 +206,10 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
         self.shortLabel.frame = CGRectZero;
         self.longLabel.frame = CGRectZero;
     } else if (self.longLabel.text.length == 0) {
-        self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, labelWidth, cellHeight);
+        self.shortLabel.frame = CGRectMake(cellLeftMargin, 0, shortLabelWidth, cellHeight);
         self.detailTextIndicator.frame =
         CGRectMake(
-                   cellLeftMargin + shortLabelTextWidth + DetailTextIndicatorPaddingFromLabel,
+                   cellLeftMargin + shortLabelWidth + DetailTextIndicatorPaddingFromLabel,
                    self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2,
                    DetailTextIndicatorTouchTargetWidth,
                    DetailTextIndicatorTouchTargetWidth);
@@ -214,7 +220,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     } else {
         {
             self.shortLabel.frame = CGRectMake(cellLeftMargin, 0,
-                                               labelWidth, 1);
+                                               shortLabelWidth, 1);
             
             ORKAdjustHeightForLabel(self.shortLabel);
             
@@ -226,7 +232,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             self.shortLabel.frame = rect;
             self.detailTextIndicator.frame =
             CGRectMake(
-                       cellLeftMargin + shortLabelTextWidth + 10,
+                       cellLeftMargin + shortLabelWidth + 10,
                        self.shortLabel.frame.size.height / 2 - DetailTextIndicatorTouchTargetWidth / 2 + self.shortLabel.frame.origin.y,
                        DetailTextIndicatorTouchTargetWidth,
                        DetailTextIndicatorTouchTargetWidth);
@@ -326,7 +332,7 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
     [self updateSelectedItem];
 }
 
-+ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText LongText:(NSString *)longText inTableView:(UITableView *)tableView {
++ (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText LongText:(NSString *)longText showDetailTextIndicator:(BOOL)showDetailTextIndicator inTableView:(UITableView *)tableView {
     CGFloat height = 0;
     
     CGFloat firstBaselineOffsetFromTop = ORKGetMetricForWindow(ORKScreenMetricChoiceCellFirstBaselineOffsetFromTop, tableView.window);
@@ -342,7 +348,11 @@ static const CGFloat DetailTextIndicatorPaddingFromLabel = 10.0;
             shortLabel.numberOfLines = 0;
         }
         
-        shortLabel.frame = CGRectMake(0, 0, labelWidth, 0);
+        if (showDetailTextIndicator) {
+            shortLabel.frame = CGRectMake(0, 0, labelWidth - (DetailTextIndicatorTouchTargetWidth + DetailTextIndicatorPaddingFromLabel), 0);
+        } else {
+            shortLabel.frame = CGRectMake(0, 0, labelWidth, 0);
+        }
         shortLabel.text = shortText;
         
         ORKAdjustHeightForLabel(shortLabel);

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -1212,9 +1212,14 @@
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
 
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORKChoiceViewCell class]]) {
-    ORKTableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
+        ORKTableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
+        BOOL showDetailTextIndicator = false;
+        if ([[cellItem answerFormat] isKindOfClass:[ORKTextChoiceAnswerFormat class]]) {
+            showDetailTextIndicator = ((ORKTextChoiceAnswerFormat *)cellItem.answerFormat).descriptionStyle == ORKChoiceDescriptionStyleDisplayWhenExpanded;
+        }
         return [ORKChoiceViewCell suggestedCellHeightForShortText:cellItem.choice.text
                                                          LongText:(cellItem.choice.detailTextShouldDisplay) ? cellItem.choice.detailText : nil
+                                          showDetailTextIndicator:showDetailTextIndicator
                                                       inTableView:_tableView];
     }
     return UITableViewAutomaticDimension;

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -1213,7 +1213,7 @@
 
     if ([[self tableView:tableView cellForRowAtIndexPath:indexPath] isKindOfClass:[ORKChoiceViewCell class]]) {
         ORKTableCellItem *cellItem = ([_sections[indexPath.section] items][indexPath.row]);
-        BOOL showDetailTextIndicator = false;
+        BOOL showDetailTextIndicator = NO;
         if ([[cellItem answerFormat] isKindOfClass:[ORKTextChoiceAnswerFormat class]]) {
             showDetailTextIndicator = ((ORKTextChoiceAnswerFormat *)cellItem.answerFormat).descriptionStyle == ORKChoiceDescriptionStyleDisplayWhenExpanded;
         }

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -900,6 +900,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKTextChoice *option = [(ORKTextChoiceAnswerFormat *)_answerFormat textChoices][index];
     return [ORKChoiceViewCell suggestedCellHeightForShortText:option.text
                                                      LongText:(option.detailTextShouldDisplay) ? option.detailText : nil
+                                      showDetailTextIndicator:((ORKTextChoiceAnswerFormat *)_answerFormat).descriptionStyle == ORKChoiceDescriptionStyleDisplayWhenExpanded
                                                   inTableView:_tableView];
 }
 

--- a/ResearchKit/Common/ORKReviewStepViewController.m
+++ b/ResearchKit/Common/ORKReviewStepViewController.m
@@ -311,7 +311,7 @@
     ORKStepResult *stepResult = [_resultSource stepResultForStepIdentifier:step.identifier];
     NSString *shortText = step.title != nil ? step.title : step.text;
     NSString *longText = [self answerStringForStep:step withStepResult:stepResult];
-    CGFloat height = [ORKChoiceViewCell suggestedCellHeightForShortText:shortText LongText:longText inTableView:_tableContainer.tableView];
+    CGFloat height = [ORKChoiceViewCell suggestedCellHeightForShortText:shortText LongText:longText showDetailTextIndicator:NO inTableView:_tableContainer.tableView];
     return height;
 }
 


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/959. Background info https://github.com/CareEvolution/ResearchKit/pull/60.

Adjusts the layout code in ORK1ChoiceViewCell to wrap around the icon. Also adds a `showDetailTextIndicator` parameter to `[ORK1ChoiceViewCell suggestedCellHeightForShortText:...]` so the cell height matches the layout changes.

# Testing Notes

1. Create a survey with this JSON https://gist.githubusercontent.com/overcyn/c71ae37654fbfc594992771a15765cb7/raw/d3b5a8bdfb0210ba50ebd58e935346f6816a5e8a/gistfile1.txt (https://gist.githubusercontent.com/overcyn/e5c62fee02c591da9858911eea3a6dfa/raw/579910f578eaf3d3d1051c6491304ae4f235c81f/gistfile1.txt to test RK2)
2. Navigate through the survey
3. Observe that the description icon does not overlap the text and the cells are sized correctly.
![Screen Shot 2021-05-04 at 10 06 23 AM](https://user-images.githubusercontent.com/758035/117042085-639f1380-acc0-11eb-9660-bce2427c853d.png)
