### PR TITLE
Simple security fixes

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
@@ -40,7 +40,7 @@
 
 
 NSURL *ORK1CreateRandomBaseURL() {
-    return [NSURL URLWithString:[NSString stringWithFormat:@"http://researchkit.%@/", [NSUUID UUID].UUIDString]];
+    return [NSURL URLWithString:[NSString stringWithFormat:@"https://researchkit.%@/", [NSUUID UUID].UUIDString]];
 }
 
 NSBundle *ORK1AssetsBundle(void) {

--- a/ORK1Kit/ORK1Kit/Consent/ORK1EAGLMoviePlayerView.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1EAGLMoviePlayerView.m
@@ -658,9 +658,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetShaderiv(*shader, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetShaderInfoLog(*shader, logLength, &logLength, log);
-        ORK1_Log_Debug(@"Shader compile log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetShaderInfoLog(*shader, logLength, &logLength, log);
+            ORK1_Log_Debug(@"Shader compile log:\n%s", log);
+            free(log);
+        }
     }
 #endif
     
@@ -688,9 +690,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetProgramInfoLog(prog, logLength, &logLength, log);
-        ORK1_Log_Debug(@"Program link log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetProgramInfoLog(prog, logLength, &logLength, log);
+            ORK1_Log_Debug(@"Program link log:\n%s", log);
+            free(log);
+        }
     }
 #endif
     
@@ -712,9 +716,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetProgramInfoLog(prog, logLength, &logLength, log);
-        ORK1_Log_Debug(@"Program validate log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetProgramInfoLog(prog, logLength, &logLength, log);
+            ORK1_Log_Debug(@"Program validate log:\n%s", log);
+            free(log);
+        }
     }
     
     glGetProgramiv(prog, GL_VALIDATE_STATUS, &status);

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -40,7 +40,7 @@
 
 
 NSURL *ORKCreateRandomBaseURL() {
-    return [NSURL URLWithString:[NSString stringWithFormat:@"http://researchkit.%@/", [NSUUID UUID].UUIDString]];
+    return [NSURL URLWithString:[NSString stringWithFormat:@"https://researchkit.%@/", [NSUUID UUID].UUIDString]];
 }
 
 NSBundle *ORKAssetsBundle(void) {

--- a/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
+++ b/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
@@ -658,9 +658,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetShaderiv(*shader, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetShaderInfoLog(*shader, logLength, &logLength, log);
-        ORK_Log_Debug(@"Shader compile log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetShaderInfoLog(*shader, logLength, &logLength, log);
+            ORK_Log_Debug(@"Shader compile log:\n%s", log);
+            free(log);
+        }
     }
 #endif
     
@@ -688,9 +690,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetProgramInfoLog(prog, logLength, &logLength, log);
-        ORK_Log_Debug(@"Program link log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetProgramInfoLog(prog, logLength, &logLength, log);
+            ORK_Log_Debug(@"Program link log:\n%s", log);
+            free(log);
+        }
     }
 #endif
     
@@ -712,9 +716,11 @@ const GLfloat DefaultPreferredRotation = 0;
     glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength > 0) {
         GLchar *log = (GLchar *)malloc(logLength);
-        glGetProgramInfoLog(prog, logLength, &logLength, log);
-        ORK_Log_Debug(@"Program validate log:\n%s", log);
-        free(log);
+        if (log) {
+            glGetProgramInfoLog(prog, logLength, &logLength, log);
+            ORK_Log_Debug(@"Program validate log:\n%s", log);
+            free(log);
+        }
     }
     
     glGetProgramiv(prog, GL_VALIDATE_STATUS, &status);


### PR DESCRIPTION
- Check result of `malloc`. Note this is debug-only code, only used to produce some log statements. So there is nothing important to do if malloc fails
- Use https instead of http for the random base URLs generated for various web views. These are used for PDF generation, consent review steps, etc.

## Testing notes

General regression testing of consent review steps, and verifying correct generation/upload of signed consent PDFs. Ideally for surveys in both ResearchKit v1 and ResearchKit v2 modes.