### PR TITLE
Improve hidePredicate animation

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -776,14 +776,14 @@
         }
         [_tableView beginUpdates];
         if (sectionsToDelete.count > 0) {
-            [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
+            [_tableView deleteSections:sectionsToDelete withRowAnimation:UITableViewRowAnimationFade];
         }
         if (sectionsToInsert.count > 0) {
-            [_tableView insertSections:sectionsToInsert withRowAnimation:UITableViewRowAnimationAutomatic];
+            [_tableView insertSections:sectionsToInsert withRowAnimation:UITableViewRowAnimationFade];
         }
         [_tableView endUpdates];
         if (sectionsToUpdateCells.count > 0) {
-            [_tableView reloadSections:sectionsToUpdateCells withRowAnimation:UITableViewRowAnimationAutomatic];
+            [_tableView reloadSections:sectionsToUpdateCells withRowAnimation:UITableViewRowAnimationFade];
         }
     }
     

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -855,16 +855,16 @@
             _sections = newSections;
             _hiddenCellItems = newHiddenCellItems;
             if (deleteRows.count > 0) {
-                [_tableView deleteRowsAtIndexPaths:deleteRows withRowAnimation:UITableViewRowAnimationAutomatic];
+                [_tableView deleteRowsAtIndexPaths:deleteRows withRowAnimation:UITableViewRowAnimationFade];
             }
             if (deleteSections.count > 0) {
-                [_tableView deleteSections:deleteSections withRowAnimation:UITableViewRowAnimationAutomatic];
+                [_tableView deleteSections:deleteSections withRowAnimation:UITableViewRowAnimationFade];
             }
             if (insertSections.count > 0) {
-                [_tableView insertSections:insertSections withRowAnimation:UITableViewRowAnimationAutomatic];
+                [_tableView insertSections:insertSections withRowAnimation:UITableViewRowAnimationFade];
             }
             if (insertRows.count > 0) {
-                [_tableView insertRowsAtIndexPaths:insertRows withRowAnimation:UITableViewRowAnimationAutomatic];
+                [_tableView insertRowsAtIndexPaths:insertRows withRowAnimation:UITableViewRowAnimationFade];
             }
             [_tableView endUpdates];
         } else {
@@ -872,7 +872,7 @@
             _hiddenCellItems = newHiddenCellItems;
         }
         if (sectionsToReload.count > 0) {
-            [_tableView reloadSections:sectionsToReload withRowAnimation:UITableViewRowAnimationAutomatic];
+            [_tableView reloadSections:sectionsToReload withRowAnimation:UITableViewRowAnimationFade];
         }
     } else {
         _sections = newSections;


### PR DESCRIPTION
@mmertsock [pointed out](https://github.com/CareEvolution/CEVResearchKit/issues/251#issuecomment-857133686) that this animation seems a little weird. I really like his suggestion and think it adds a little polish to the animation. Instead of flying in/out laterally, it cascades vertically which seems more appropriate.

|Version|BEFORE|AFTER|
|---|---|---|
|RK1|https://user-images.githubusercontent.com/1008462/121435854-325fd600-c945-11eb-9db1-e7e06b4b6bbe.mov|https://user-images.githubusercontent.com/1008462/121435863-37bd2080-c945-11eb-8761-25816257d8bf.mov|
|RK2|https://user-images.githubusercontent.com/1008462/121435881-40155b80-c945-11eb-84a7-32e7dc3dd923.mov|https://user-images.githubusercontent.com/1008462/121435897-44417900-c945-11eb-84c8-f427708f14f3.mov|

## Testing

Verify the new animation of a survey with hide item logic appears like the videos above. Can use https://github.com/CareEvolution/ResearchKit/pull/107 testing instructions for Survey JSON which includes some steps that cause hide/unhiding of FormStep items.






