### PR TITLE
Simplified handling of next/done button placement

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -410,13 +410,6 @@
 
 - (void)adjustUIforChangesToDetailTextAtIndexPath:(NSIndexPath *)indexPath {
     
-    /*
-     Due to the complexity of the layout, animating the expansion and contaction of the textDetail will
-     move the continue button up or down out of ideal position. To prevent this, we calculate the expected
-     difference in tableView size and pass this to the ORK1TableContainerView which will hide the continue
-     button, adjust the constraint and then animate the button alpha to 1.
-     */
-    
     [self.tableView beginUpdates];
     
     ORK1TableSection *section = _sections[indexPath.section];
@@ -426,18 +419,11 @@
         [self.tableView endUpdates];
         return;
     }
-    ORK1TextChoice *choice = format.textChoices[indexPath.row];
-    
-    NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
-    
     [section.textChoiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]] atIndex:indexPath.row];
     
-    longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
-    
-    [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
+    
+    [_tableContainer setNeedsLayout];
 }
 
 - (void)updateDefaults:(NSMutableDictionary *)defaults {
@@ -787,7 +773,7 @@
         }
     }
     
-    [_tableContainer adjustBottomConstraintBasedOnLastContentSize];
+    [_tableContainer setNeedsLayout];
 }
 
 - (NSIndexPath *)unhiddenIndexPathForIndexPath:(NSIndexPath *)hiddenIndexPath {

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
@@ -368,13 +368,6 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
 
 - (void)adjustUIforChangesToDetailTextAtIndex:(NSUInteger)index {
     
-    /*
-     Due to the complexity of the layout, animating the expansion and contraction of the textDetail will
-     move the continue button up or down out of ideal position. To prevent this, we calculate the expected
-     difference in tableView size and pass this to the ORK1TableContainerView which will hide the continue
-     button, adjust the constraint and then animate the button alpha to 1.
-     */
-    
     [self.tableView beginUpdates];
     
     ORK1QuestionStep *questionStep = (ORK1QuestionStep *)self.step;
@@ -383,17 +376,11 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
         [self.tableView endUpdates];
         return;
     }
-    ORK1TextChoice *choice = format.textChoices[index];
-    NSString *longText = !choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeBeforeResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
-    
     [_choiceCellGroup updateLabelsForCell:[self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]] atIndex:index];
     
-    longText = choice.detailTextShouldDisplay ? choice.detailText : nil;
-    CGFloat sizeAfterResize = [ORK1ChoiceViewCell suggestedCellHeightForShortText:choice.text longText:longText showDetailTextIndicator:format.descriptionStyle == ORK1ChoiceDescriptionStyleDisplayWhenExpanded inTableView:self.tableView];
-    
-    [_tableContainer adjustBottomConstraintWithExpectedOffset:(sizeAfterResize - sizeBeforeResize)];
     [self.tableView endUpdates];
+    
+    [_tableContainer setNeedsLayout];
 }
 
 - (void)setCustomQuestionView:(ORK1QuestionStepCustomView *)customQuestionView {

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
@@ -65,10 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
     
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style;
 
-- (void)adjustBottomConstraintWithExpectedOffset:(CGFloat)offset;
-
-- (void)adjustBottomConstraintBasedOnLastContentSize;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/251. 

The goal for layout of the Next/Done button is to sit at the bottom of the view unless the content requires scrolling where it simply is at the bottom of the content. RK2 takes a totally different approach with a view that simply hovers on the bottom.

After a long time wrestling with this, I found that simply calling `setNeedsLayout` forces a recalculation of the `_realFooterView` height [HERE](https://github.com/CareEvolution/ResearchKit/blob/b4d0b79cce2746f63dd18b6bf4f15fbcbe636e6a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m#L160-L168) which is where the magic happens. No need to do any extra work around this so long as this gets called. So happy to cut out a lot of hacky code we added to handle our enhancements such as hidePredicate and disclosable info button text.

### Testing

Some regression testing of surveys using the following features would be helpful as there is a lot of code change here. 
- FormSteps with hiding logic
- TextChoices with description text - especially with **Display When Expanded** turned on
- Short QuestionSteps which trigger keyboard or picker slide-ups (Answer Formats of Text, Date, Time of Day, Height, Weight)

I do have one survey that has instructions of what is expected and how to perform in various conditions:
- [Survey JSON](https://gist.github.com/eschramm/961d1fe51e6c09afacd3b61e9ce61cb0#file-nextbuttontesting-json)