### PR TITLE
ResearchKit: Support 'disableDisagree', 'hideDefaultHeader' options on ConsentReviewStep

### DIFF
--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ORK1ConsentReviewController : UIViewController
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORK1ConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom;
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORK1ConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom disableDisagree:(BOOL)disableDisagree;
 
 @property (nonatomic, strong, nullable) WKWebView *webView;
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.m
@@ -53,7 +53,7 @@
     BOOL _webViewFinishedLoading;
 }
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORK1ConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom {
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORK1ConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom disableDisagree:(BOOL)disableDisagree {
     self = [super init];
     if (self) {
         _htmlString = html;
@@ -66,10 +66,12 @@
             _agreeButton.accessibilityHint = @"must scroll to the bottom to enable this button";
         }
         
-        self.toolbarItems = @[
-                             [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"BUTTON_DISAGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancel)],
-                             [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil],
-                             _agreeButton];
+        UIBarButtonItem *disagreeButton = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"BUTTON_DISAGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancel)];
+        if (disableDisagree) {
+            self.toolbarItems = @[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]];
+        } else {
+            self.toolbarItems = @[disagreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton];
+        }
     }
     return self;
 }

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.h
@@ -113,6 +113,9 @@ ORK1_CLASS_AVAILABLE
   */
 @property (nonatomic, copy, nullable) NSString *reasonForConsent;
 
+@property (nonatomic, assign) BOOL disableDisagree;
+@property (nonatomic, assign) BOOL hideDefaultHeader;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.m
@@ -54,6 +54,8 @@
         _signature = signature;
         _requiresScrollToBottom = NO;
         _autoAgree = NO;
+        _disableDisagree = NO;
+        _hideDefaultHeader = NO;
     }
     return self;
 }
@@ -65,6 +67,8 @@
     step->_reasonForConsent = self.reasonForConsent;
     step->_requiresScrollToBottom = self.requiresScrollToBottom;
     step->_autoAgree = self.autoAgree;
+    step->_disableDisagree = self.disableDisagree;
+    step->_hideDefaultHeader = self.hideDefaultHeader;
     return step;
 }
 
@@ -76,6 +80,8 @@
         ORK1_DECODE_OBJ_CLASS(aDecoder, reasonForConsent, NSString);
         ORK1_DECODE_BOOL(aDecoder, requiresScrollToBottom);
         ORK1_DECODE_BOOL(aDecoder, autoAgree);
+        ORK1_DECODE_BOOL(aDecoder, disableDisagree);
+        ORK1_DECODE_BOOL(aDecoder, hideDefaultHeader);
     }
     return self;
 }
@@ -87,6 +93,8 @@
     ORK1_ENCODE_OBJ(aCoder, reasonForConsent);
     ORK1_ENCODE_BOOL(aCoder, requiresScrollToBottom);
     ORK1_ENCODE_BOOL(aCoder, autoAgree);
+    ORK1_ENCODE_BOOL(aCoder, disableDisagree);
+    ORK1_ENCODE_BOOL(aCoder, hideDefaultHeader);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -102,11 +110,13 @@
             ORK1EqualObjects(self.signature, castObject.signature) &&
             ORK1EqualObjects(self.reasonForConsent, castObject.reasonForConsent)) &&
             (self.requiresScrollToBottom == castObject.requiresScrollToBottom) &&
-            (self.autoAgree == castObject.autoAgree);
+            (self.autoAgree == castObject.autoAgree) &&
+            (self.disableDisagree == castObject.disableDisagree) &&
+            (self.hideDefaultHeader == castObject.hideDefaultHeader);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xe : 0x1);
+    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xe : 0x1) ^ (_disableDisagree ? 0xd : 0x2) ^ (_hideDefaultHeader ? 0xc : 0x3);
 }
 
 - (BOOL)showsProgress {

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
@@ -218,7 +218,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
         }
     }
     
-    NSString *html = [document mobileHTMLWithTitle:ORK1LocalizedString(@"CONSENT_REVIEW_TITLE", nil)
+    NSString *html = [document mobileHTMLWithTitle:[self consentReviewStep].hideDefaultHeader ? nil : ORK1LocalizedString(@"CONSENT_REVIEW_TITLE", nil)
                                             detail:[self consentReviewStep].hideDefaultHeader ? nil : ORK1LocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
 
     ORK1ConsentReviewController *reviewViewController = [[ORK1ConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom] disableDisagree:[[self consentReviewStep] disableDisagree]];

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
@@ -219,9 +219,9 @@ static NSString *const _FamilyNameIdentifier = @"family";
     }
     
     NSString *html = [document mobileHTMLWithTitle:ORK1LocalizedString(@"CONSENT_REVIEW_TITLE", nil)
-                                             detail:ORK1LocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
+                                            detail:[self consentReviewStep].hideDefaultHeader ? nil : ORK1LocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
 
-    ORK1ConsentReviewController *reviewViewController = [[ORK1ConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom]];
+    ORK1ConsentReviewController *reviewViewController = [[ORK1ConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom] disableDisagree:[[self consentReviewStep] disableDisagree]];
     reviewViewController.localizedReasonForConsent = [[self consentReviewStep] reasonForConsent];
     return reviewViewController;
 }

--- a/ResearchKit/Consent/ORKConsentReviewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewController.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ORKConsentReviewController : UIViewController
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom;
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom disableDisagree:(BOOL)disableDisagree;
 
 @property (nonatomic, strong, nullable) WKWebView *webView;
 

--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -56,7 +56,7 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
     BOOL _webViewFinishedLoading;
 }
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom {
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom disableDisagree:(BOOL)disableDisagree {
     self = [super init];
     if (self) {
         _htmlString = html;
@@ -69,10 +69,12 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
             _agreeButton.accessibilityHint = @"must scroll to the bottom to enable this button";
         }
         
-        self.toolbarItems = @[
-                             [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_DISAGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancel)],
-                             [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil],
-                             _agreeButton];
+        UIBarButtonItem *disagreeButton = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_DISAGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancel)];
+        if (disableDisagree) {
+            self.toolbarItems = @[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]];
+        } else {
+            self.toolbarItems = @[disagreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton];
+        }
     }
     return self;
 }

--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -71,7 +71,7 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
         
         UIBarButtonItem *disagreeButton = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_DISAGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancel)];
         if (disableDisagree) {
-            self.toolbarItems = @[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]];
+            self.toolbarItems = @[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton];
         } else {
             self.toolbarItems = @[disagreeButton, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _agreeButton];
         }

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -106,6 +106,9 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic) BOOL autoAgree;
 
+@property (nonatomic, assign) BOOL disableDisagree;
+@property (nonatomic, assign) BOOL hideDefaultHeader;
+
 /**
  A user-visible description of the reason for agreeing to consent in a localized string.
  

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -54,6 +54,8 @@
         _signature = signature;
         _requiresScrollToBottom = NO;
         _autoAgree = NO;
+        _disableDisagree = NO;
+        _hideDefaultHeader = NO;
     }
     return self;
 }
@@ -65,6 +67,8 @@
     step->_reasonForConsent = self.reasonForConsent;
     step->_requiresScrollToBottom = self.requiresScrollToBottom;
     step->_autoAgree = self.autoAgree;
+    step->_disableDisagree = self.disableDisagree;
+    step->_hideDefaultHeader = self.hideDefaultHeader;
     return step;
 }
 
@@ -76,6 +80,8 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, reasonForConsent, NSString);
         ORK_DECODE_BOOL(aDecoder, requiresScrollToBottom);
         ORK_DECODE_BOOL(aDecoder, autoAgree);
+        ORK_DECODE_BOOL(aDecoder, disableDisagree);
+        ORK_DECODE_BOOL(aDecoder, hideDefaultHeader);
     }
     return self;
 }
@@ -87,6 +93,8 @@
     ORK_ENCODE_OBJ(aCoder, reasonForConsent);
     ORK_ENCODE_BOOL(aCoder, requiresScrollToBottom);
     ORK_ENCODE_BOOL(aCoder, autoAgree);
+    ORK_ENCODE_BOOL(aCoder, disableDisagree);
+    ORK_ENCODE_BOOL(aCoder, hideDefaultHeader);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -102,11 +110,13 @@
             ORKEqualObjects(self.signature, castObject.signature) &&
             ORKEqualObjects(self.reasonForConsent, castObject.reasonForConsent)) &&
             (self.requiresScrollToBottom == castObject.requiresScrollToBottom) &&
-            (self.autoAgree == castObject.autoAgree);
+            (self.autoAgree == castObject.autoAgree) &&
+            (self.disableDisagree == castObject.disableDisagree) &&
+            (self.hideDefaultHeader == castObject.hideDefaultHeader);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xe : 0x1);
+    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0) ^ (_autoAgree ? 0xe : 0x1) ^ (_disableDisagree ? 0xd : 0x2) ^ (_hideDefaultHeader ? 0xc : 0x3);
 }
 
 - (BOOL)showsProgress {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -223,8 +223,8 @@ static NSString *const _FamilyNameIdentifier = @"family";
         }
     }
     
-    NSString *html = [document mobileHTMLWithTitle:ORKLocalizedString(@"CONSENT_REVIEW_TITLE", nil)
-                                             detail:[self consentReviewStep].hideDefaultHeader ? nil : ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
+    NSString *html = [document mobileHTMLWithTitle:[self consentReviewStep].hideDefaultHeader ? nil : ORKLocalizedString(@"CONSENT_REVIEW_TITLE", nil)
+                                            detail:[self consentReviewStep].hideDefaultHeader ? nil : ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
 
     ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom] disableDisagree:[self consentReviewStep].disableDisagree];
     if (ORKNeedWideScreenDesign(self.view)) {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -224,9 +224,9 @@ static NSString *const _FamilyNameIdentifier = @"family";
     }
     
     NSString *html = [document mobileHTMLWithTitle:ORKLocalizedString(@"CONSENT_REVIEW_TITLE", nil)
-                                             detail:ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
+                                             detail:[self consentReviewStep].hideDefaultHeader ? nil : ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
 
-    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom]];
+    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom] disableDisagree:[self consentReviewStep].disableDisagree];
     if (ORKNeedWideScreenDesign(self.view)) {
         [reviewViewController setTextForiPadStepTitleLabel:self.title];
     }


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/984
Related CEVResearchKit change https://github.com/CareEvolution/CEVResearchKit/pull/257

Adds flags to hide the disagree button and to hide the default header.

### ResearchKit 1
![Screen Shot 2021-08-10 at 4 29 38 PM](https://user-images.githubusercontent.com/758035/128947733-a7cefb43-91c1-42f9-b2d5-83394545be23.png)

### ResearchKit 2
![Screen Shot 2021-08-10 at 4 27 27 PM](https://user-images.githubusercontent.com/758035/128947738-85b7055e-aff0-46b3-8bed-cd0796cb6f80.png)

# Testing notes

1. Create a survey with the following JSON https://gist.githubusercontent.com/overcyn/8c5b2c2205454528a00f85dd0212db3d/raw/2394638508b588de3a004f871321e2b592c545a3/gistfile1.txt
2. Open the survey and navigate through
3. Note that the disagree button is hidden and the Review header is missing.
