### PR TITLE
Handle textView.textValue as nil when breaking the auto-layout loop

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1VerticalContainerView.m
@@ -864,9 +864,11 @@ static const CGFloat AssumedStatusBarHeight = 20;
      
      Additional carriage returns will be added if the loop persists every 50 iterations.
      
-     For more info see: https://github.com/CareEvolution/CEVResearchKit/issues/116,
-     https://github.com/CareEvolution/CEVResearchKit/issues/136,
-     https://github.com/CareEvolution/CEVResearchKit/issues/152
+     For more info see:
+     - https://github.com/CareEvolution/CEVResearchKit/issues/116
+     - https://github.com/CareEvolution/CEVResearchKit/issues/136
+     - https://github.com/CareEvolution/CEVResearchKit/issues/152
+     - https://github.com/CareEvolution/CEVResearchKit/issues/258
      */
     
     autoLayoutLoopCount++;
@@ -877,7 +879,8 @@ static const CGFloat AssumedStatusBarHeight = 20;
             UIView *possibleCEVRK1TextView = _scrollContainer.subviews[0].subviews[0].subviews[3];
             if ([possibleCEVRK1TextView isKindOfClass:[CEVRK1TextView class]]) {
                 CEVRK1TextView *textView = (CEVRK1TextView *)possibleCEVRK1TextView;
-                NSMutableString *updatedText = [NSMutableString stringWithString:textView.textValue];
+                NSString *textViewValue = textView.textValue ?: @"";
+                NSMutableString *updatedText = [NSMutableString stringWithString:textViewValue];
                 [updatedText appendString:@"\n"];
                 textView.textValue = updatedText;
                 carriageReturnsAdded++;


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/258.

### Testing
Using an iPhone 12 with standard settings (default text size, not zoomed), verify that this survey which throws an exception crashing the app PRIOR to this fix, works properly with this fix.

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "InstructionStep",
      "title": "Now we would like to ask you some questions about how you interact with your neighbors. Please take the time to answer carefully, but do not spend too much time on any one question. Remember that there are no right or wrong answers.",
      "identifier": "ActivitiesNeighbors_I1",
      "localizations": {},
      "excludeFromProgressCalculation": true
    }
  ]
}
```