### PR TITLE
Update indexPath after hideSections before scrollToIndexpath

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -780,6 +780,10 @@
     return [NSIndexPath indexPathForRow:hiddenIndexPath.row inSection:[_allSections indexOfObject:_sections[hiddenIndexPath.section]]];
 }
 
+- (NSIndexPath *)hiddenIndexPathForIndexPath:(NSIndexPath *)unhiddenIndexPath {
+    return [NSIndexPath indexPathForRow:unhiddenIndexPath.row inSection:[_sections indexOfObject:_allSections[unhiddenIndexPath.section]]];
+}
+
 - (void)updateButtonStates {
     _continueSkipView.continueEnabled = [self continueButtonEnabled];
     _continueSkipView.skipEnabled = [self skipButtonEnabled];
@@ -1079,8 +1083,15 @@
         [self updateButtonStates];
         [self notifyDelegateOnResultChange];
     }
+    
+    // need to "recalculate" indexPath in case it changes during hideSections
+    NSIndexPath *unhiddenIndexPath = [self unhiddenIndexPathForIndexPath:indexPath];
+    
     [self hideSections];
-    [_tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+    
+    NSIndexPath *updatedIndexPath = [self hiddenIndexPathForIndexPath: unhiddenIndexPath];
+    
+    [_tableView scrollToRowAtIndexPath:updatedIndexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/259. 

### Testing

Using the survey JSON below, attempt to tap on **My symptoms are ongoing** which should cause the Date field to hide. MyDataHelps should not crash.


```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "FormStep",
      "text": "",
      "title": "On what day did your symptoms end?",
      "identifier": "symptomsEnd",
      "formItems": [
        {
          "identifier": "enterDate",
          "type": "FormItem",
          "answerFormat": {
            "type": "DateAnswerFormat",
            "style": "Date"
          },
          "optional": false,
          "hidePredicate": {
            "resultIdentifier": "onGoing",
            "stepIdentifier": "symptomsEnd",
            "type": "ChoiceQuestionResultPredicate",
            "expectedString": "ongoing"
          },
          "text": "Select Date"
        },
        {
          "identifier": "onGoing",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextChoiceAnswerFormat",
            "textChoices": [
              {
                "type": "TextChoice",
                "value": "ongoing",
                "text": "My symptoms are ongoing",
                "localizations": {
                  "es": {
                    "text": "Mis síntomas están en curso"
                  }
                }
              }
            ],
            "style": "Single",
            "customField": null
          },
          "optional": false,
          "hidePredicate": {
            "type": "NotCompoundPredicate",
            "subpredicate": {
              "resultIdentifier": "enterDate",
              "stepIdentifier": "symptomsEnd",
              "type": "NilQuestionResultPredicate"
            }
          }
        }
      ],
      "optional": false
    }
  ],
  "styles": {
    "progressBarColor": "#5381c3",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF"
  }
}
```
