### PR TITLE
More security fixes

### DIFF
--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -3699,7 +3699,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ORK1Kit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ORK1Kit/ORK1Kit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -3731,7 +3731,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ORK1Kit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ORK1Kit/ORK1Kit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ORK1Kit/ORK1Kit/Common/ORK1DataCollectionManager.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DataCollectionManager.m
@@ -133,7 +133,10 @@ static inline void dispatch_sync_if_not_on_queue(dispatch_queue_t queue, dispatc
 
 - (NSArray<ORK1Collector *> *)collectors {
     if (_collectors == nil) {
-        _collectors = [NSKeyedUnarchiver unarchiveObjectWithFile:[self persistFilePath]];
+        NSData *data = [NSData dataWithContentsOfFile:[self persistFilePath]];
+        if (data != nil) {
+            _collectors = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [ORK1Collector class], nil] fromData:data error:NULL];
+        }
         if (_collectors == nil) {
             @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to read from path %@", [self persistFilePath]] userInfo:nil];
         }

--- a/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.h
@@ -60,13 +60,29 @@ ORK1_CLASS_AVAILABLE
  Returns the object in the keychain for the provided key.
  
  @param key         The key used to set the data in the keychain.
+ @param classes     The type of object to return (or types if it is a dictionary or array). Must conform to NSSecureCoding.
  @param error       If failure occurred, an `NSError` object indicating the reason for the
                     failure. The value of this parameter is `nil` if `result` does not
                     indicate failure.
  
  @return An object or `nil` if key is not valid.
  */
-+ (id<NSSecureCoding>)objectForKey:(NSString *)key error:(NSError * _Nullable *)error;
++ (id<NSSecureCoding>)objectForKey:(NSString *)key
+                         ofClasses:(NSSet *)classes
+                             error:(NSError * _Nullable *)error;
+
+/**
+ Returns the passcode dictionary object in the keychain for the provided key.
+ 
+ @param key         The key used to set the data in the keychain.
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return An object or `nil` if key is not valid.
+ */
++ (NSDictionary *)passcodeDictionaryForKey:(NSString *)key
+                                     error:(NSError * _Nullable *)error;
 
 /**
  Removes the object in the keychain for the provided key.

--- a/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.m
@@ -59,12 +59,18 @@ static NSString *ORK1KeychainWrapperDefaultService() {
 }
 
 + (id<NSSecureCoding>)objectForKey:(NSString *)key
-             error:(NSError **)error {
+                         ofClasses:(NSSet *)classes
+                             error:(NSError **)error {
     NSData *data = [self dataForKey:key
                             service:ORK1KeychainWrapperDefaultService()
                         accessGroup:nil
                               error:error];
-    return data ? [NSKeyedUnarchiver unarchiveObjectWithData:data] : nil;
+    return data ? [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:error] : nil;
+}
+
++ (NSDictionary *)passcodeDictionaryForKey:(NSString *)key
+                                     error:(NSError **)error {
+    return (NSDictionary *) [self objectForKey:key ofClasses:[NSSet setWithObjects:[NSDictionary class], [NSString class], nil] error:error];
 }
 
 + (BOOL)removeObjectForKey:(NSString *)key

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
@@ -453,7 +453,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)removePasscodeFromKeychain {
     NSError *error;
-    [ORK1KeychainWrapper objectForKey:PasscodeKey error:&error];
+    [ORK1KeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     
     if (!error) {
         [ORK1KeychainWrapper removeObjectForKey:PasscodeKey error:&error];
@@ -466,7 +466,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (BOOL)passcodeMatchesKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary *) [ORK1KeychainWrapper objectForKey:PasscodeKey error:&error];
+    NSDictionary *dictionary = [ORK1KeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     if (error) {
         [self throwExceptionWithKeychainError:error];
     }
@@ -477,7 +477,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)setValuesFromKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary*) [ORK1KeychainWrapper objectForKey:PasscodeKey error:&error];
+    NSDictionary *dictionary = [ORK1KeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     if (error) {
         [self throwExceptionWithKeychainError:error];
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.m
@@ -100,7 +100,7 @@
 }
 
 + (BOOL)isPasscodeStoredInKeychain {
-    NSDictionary *dictionary = (NSDictionary *)[ORK1KeychainWrapper objectForKey:PasscodeKey error:nil];
+    NSDictionary *dictionary = (NSDictionary *)[ORK1KeychainWrapper passcodeDictionaryForKey:PasscodeKey error:nil];
     return ([dictionary objectForKey:KeychainDictionaryPasscodeKey]) ? YES : NO;
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -185,7 +185,7 @@
             }
         
         if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
-            [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
+            [[UIApplication sharedApplication] openURL:navigationAction.request.URL options:@{} completionHandler:NULL];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;
         }

--- a/ResearchKit/Common/ORKDataCollectionManager.m
+++ b/ResearchKit/Common/ORKDataCollectionManager.m
@@ -133,7 +133,10 @@ static inline void dispatch_sync_if_not_on_queue(dispatch_queue_t queue, dispatc
 
 - (NSArray<ORKCollector *> *)collectors {
     if (_collectors == nil) {
-        _collectors = [NSKeyedUnarchiver unarchiveObjectWithFile:[self persistFilePath]];
+        NSData *data = [NSData dataWithContentsOfFile:[self persistFilePath]];
+        if (data != nil) {
+            _collectors = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [ORKCollector class], nil] fromData:data error:NULL];
+        }
         if (_collectors == nil) {
             @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to read from path %@", [self persistFilePath]] userInfo:nil];
         }

--- a/ResearchKit/Common/ORKKeychainWrapper.h
+++ b/ResearchKit/Common/ORKKeychainWrapper.h
@@ -60,13 +60,29 @@ ORK_CLASS_AVAILABLE
  Returns the object in the keychain for the provided key.
  
  @param key         The key used to set the data in the keychain.
+ @param classes     The type of object to return (or types if it is a dictionary or array). Must conform to NSSecureCoding. 
  @param error       If failure occurred, an `NSError` object indicating the reason for the
                     failure. The value of this parameter is `nil` if `result` does not
                     indicate failure.
  
  @return An object or `nil` if key is not valid.
  */
-+ (nullable id<NSSecureCoding>)objectForKey:(nonnull NSString *)key error:(NSError * __autoreleasing _Nullable *)error;
++ (nullable id<NSSecureCoding>)objectForKey:(nonnull NSString *)key
+                                  ofClasses:(NSSet *)classes
+                                      error:(NSError * __autoreleasing _Nullable *)error;
+
+/**
+ Returns the passcode dictionary object in the keychain for the provided key.
+ 
+ @param key         The key used to set the data in the keychain.
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return An object or `nil` if key is not valid.
+ */
++ (NSDictionary *)passcodeDictionaryForKey:(NSString *)key
+                                     error:(NSError * _Nullable *)error;
 
 /**
  Removes the object in the keychain for the provided key.

--- a/ResearchKit/Common/ORKKeychainWrapper.m
+++ b/ResearchKit/Common/ORKKeychainWrapper.m
@@ -59,12 +59,18 @@ static NSString *ORKKeychainWrapperDefaultService() {
 }
 
 + (id<NSSecureCoding>)objectForKey:(NSString *)key
-             error:(NSError **)error {
+                         ofClasses:(NSSet *)classes
+                             error:(NSError **)error {
     NSData *data = [self dataForKey:key
                             service:ORKKeychainWrapperDefaultService()
                         accessGroup:nil
                               error:error];
-    return data ? [NSKeyedUnarchiver unarchiveObjectWithData:data] : nil;
+    return data ? [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:error] : nil;
+}
+
++ (NSDictionary *)passcodeDictionaryForKey:(NSString *)key
+                                     error:(NSError **)error {
+    return (NSDictionary *) [self objectForKey:key ofClasses:[NSSet setWithObjects:[NSDictionary class], [NSString class], nil] error:error];
 }
 
 + (BOOL)removeObjectForKey:(NSString *)key

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -526,7 +526,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)removePasscodeFromKeychain {
     NSError *error;
-    [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
+    [ORKKeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     
     if (!error) {
         [ORKKeychainWrapper removeObjectForKey:PasscodeKey error:&error];
@@ -539,7 +539,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (BOOL)passcodeMatchesKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary *) [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
+    NSDictionary *dictionary = [ORKKeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     if (error) {
         [self throwExceptionWithKeychainError:error];
     }
@@ -550,7 +550,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)setValuesFromKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary*) [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
+    NSDictionary *dictionary = [ORKKeychainWrapper passcodeDictionaryForKey:PasscodeKey error:&error];
     if (error) {
         [self throwExceptionWithKeychainError:error];
     }

--- a/ResearchKit/Common/ORKPasscodeViewController.m
+++ b/ResearchKit/Common/ORKPasscodeViewController.m
@@ -100,7 +100,7 @@
 }
 
 + (BOOL)isPasscodeStoredInKeychain {
-    NSDictionary *dictionary = (NSDictionary *)[ORKKeychainWrapper objectForKey:PasscodeKey error:nil];
+    NSDictionary *dictionary = [ORKKeychainWrapper passcodeDictionaryForKey:PasscodeKey error:nil];
     return ([dictionary objectForKey:KeychainDictionaryPasscodeKey]) ? YES : NO;
 }
 

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -285,7 +285,7 @@
             }
         
         if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
-            [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
+            [[UIApplication sharedApplication] openURL:navigationAction.request.URL options:@{} completionHandler:NULL];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;
         }

--- a/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
+++ b/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 				fr,
@@ -706,7 +707,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKTest/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKTest";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -730,7 +731,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKTest/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKTest";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Testing/ORKTest/ORKTest/Tasks/TaskFactory+UtilitySteps.m
+++ b/Testing/ORKTest/ORKTest/Tasks/TaskFactory+UtilitySteps.m
@@ -671,7 +671,7 @@
     "</body>"
     "</html>";
     
-    ORKWebViewStep *webViewStep = [ORKWebViewStep webViewStepWithIdentifier:@"webViewStep" html:html];
+    ORKWebViewStep *webViewStep = [ORKWebViewStep webViewStepWithIdentifier:@"webViewStep" html:html baseURL:[NSURL URLWithString:@"https://researchkit.org/"]];
     webViewStep.title = @"Web View";
     [steps addObject:webViewStep];
     

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -967,7 +967,7 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
     
     NSDateComponents *a = [NSDateComponents new];
     NSData *d1 = [NSKeyedArchiver archivedDataWithRootObject:a];
-    NSDateComponents *b = [NSKeyedUnarchiver unarchiveObjectWithData:d1];
+    NSDateComponents *b = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDateComponents class] fromData:d1 error:NULL];
     NSData *d2 = [NSKeyedArchiver archivedDataWithRootObject:b];
     
     XCTAssertEqualObjects(d1, d2);

--- a/Testing/ORKTest/ORKTestTests/ORKKeychainWrapperTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKKeychainWrapperTests.m
@@ -44,6 +44,10 @@ static NSString *const invalidKey = @"RK invalid key";
 
 @implementation ORKKeychainWrapperTests
 
+- (NSSet *)objectForKeyClassSet {
+    return [NSSet setWithObject:[NSString class]];
+}
+
 - (void)testSetObjectInKeychain {
     NSError *error;
 
@@ -56,6 +60,7 @@ static NSString *const invalidKey = @"RK invalid key";
     
     // Test that the object set is equal to the object retrieved.
     NSString *outObject = (NSString *) [ORKKeychainWrapper objectForKey:key
+                                                              ofClasses:[self objectForKeyClassSet]
                                                                   error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(inObject, outObject);
@@ -74,13 +79,15 @@ static NSString *const invalidKey = @"RK invalid key";
     
     // Test that the object set is equal to the object retrieved.
     NSString *outObject = (NSString *) [ORKKeychainWrapper objectForKey:key
+                                                              ofClasses:[self objectForKeyClassSet]
                                                                   error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(inObject, outObject);
     
     // Test that there is an error for invalid key.
     id object = [ORKKeychainWrapper objectForKey:invalidKey
-                               error:&error];
+                                       ofClasses:[self objectForKeyClassSet]
+                                           error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);
 }
@@ -103,6 +110,7 @@ static NSString *const invalidKey = @"RK invalid key";
     
     // Test that there is no object for the key.
     id object = [ORKKeychainWrapper objectForKey:key
+                                       ofClasses:[self objectForKeyClassSet]
                                            error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);
@@ -125,6 +133,7 @@ static NSString *const invalidKey = @"RK invalid key";
     
     // Test that there is no object for the key.
     id object = [ORKKeychainWrapper objectForKey:key
+                                       ofClasses:[self objectForKeyClassSet]
                                            error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);


### PR DESCRIPTION
Follow-up to #105. Addresses some notes in https://github.com/CareEvolution/RKStudio-Participant/issues/972

- Replace `unarchiveObjectWithFile` and `unarchiveObjectWithData` with newer, more secure variations
- Use the newer version of UIApplication `openURL`
- Updates iOS deployment target so that it's possible to use some of these more secure APIs

## Testing

We don't use the passcode views anywhere, and I don't think we use keychain wrapper anywhere?

So I believe the only thing to test here would be to ensure that active tasks still record and upload data correctly.