### PR TITLE
Pad intrinsic size for ORK1FormSectionTitleLabel

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormSectionTitleLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormSectionTitleLabel.m
@@ -40,4 +40,14 @@
     return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - 0.0 weight: UIFontWeightBold];
 }
 
+- (CGSize)intrinsicContentSize {
+    /*
+     CEV HACK - have seen where a re-render pass redraws text a fraction of a point larger than when the
+     layout was calculated. This gives the intrinsic size a little padding to ensure the size of the holding
+     container leaves enough room for a potential text re-render that draws 0.3 points taller
+     */
+    CGSize size = [super intrinsicContentSize];
+    return CGSizeMake(size.width, size.height + 2);
+}
+
 @end


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/262. What appears to be happening is that on re-rendering the Markdown, CoreText is redrawing the text ~0.3 point taller than the previous render which is causing the last line of text to truncate. Have not seen this in other places in RK so will limit this fix just to `ORK1FormSectionTitleLabel`.

## Testing
Before the update, notice the behavior seen in https://github.com/CareEvolution/CEVResearchKit/issues/262 with sample JSON for the survey there. After this update, note that the survey no longer truncates the last line of text ("minutes or more over a 24-hour period.") when the affected FormStep loads.

@Suvarna-Thejas-CE 