### PR TITLE
Reassess specialEndSurveyStepIdentifier on every step

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
@@ -157,6 +157,8 @@
     if ([_specialEndSurveyStepIdentifiers containsObject:nextStepIdentifier]) {
         _specialEndSurveyStepIdentifier = nextStepIdentifier;
         nextStepIdentifier = ORK1NullStepIdentifier;
+    } else {
+        _specialEndSurveyStepIdentifier = nil;
     }
     
     if (![nextStepIdentifier isEqualToString:ORK1NullStepIdentifier]) { // If ORK1NullStepIdentifier, return nil to end task

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -152,6 +152,8 @@
     if ([_specialEndSurveyStepIdentifiers containsObject:nextStepIdentifier]) {
         _specialEndSurveyStepIdentifier = nextStepIdentifier;
         nextStepIdentifier = ORKNullStepIdentifier;
+    } else {
+        _specialEndSurveyStepIdentifier = nil;
     }
     
     if (![nextStepIdentifier isEqualToString:ORKNullStepIdentifier]) { // If ORKNullStepIdentifier, return nil to end task


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/1036. We should set this to `nil` if we don't have one otherwise it can persist beyond its intended step.

Added UI tests for this case in https://github.com/CareEvolution/CEVResearchKit/pull/265