### PR TITLE
Add result for debug description for ORK[1]WebViewStepResult

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.m
@@ -2643,7 +2643,7 @@ static NSString *const RegionIdentifierKey = @"region.identifier";
 
 - (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
     NSMutableString *description = [NSMutableString stringWithFormat:@"%@; result:", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
-    [description appendFormat:@" %@%@", _result, self.descriptionSuffix];
+    [description appendFormat:@" \"%@\"%@", _result, self.descriptionSuffix];
     
     return [description copy];
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.m
@@ -2641,4 +2641,11 @@ static NSString *const RegionIdentifierKey = @"region.identifier";
     return result;
 }
 
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@; result:", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
+    [description appendFormat:@" %@%@", _result, self.descriptionSuffix];
+    
+    return [description copy];
+}
+
 @end

--- a/ResearchKit/Common/ORKWebViewStepResult.m
+++ b/ResearchKit/Common/ORKWebViewStepResult.m
@@ -69,4 +69,11 @@
     return result;
 }
 
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@; result:", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
+    [description appendFormat:@" %@%@", _result, self.descriptionSuffix];
+    
+    return [description copy];
+}
+
 @end

--- a/ResearchKit/Common/ORKWebViewStepResult.m
+++ b/ResearchKit/Common/ORKWebViewStepResult.m
@@ -71,7 +71,7 @@
 
 - (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
     NSMutableString *description = [NSMutableString stringWithFormat:@"%@; result:", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
-    [description appendFormat:@" %@%@", _result, self.descriptionSuffix];
+    [description appendFormat:@" \"%@\"%@", _result, self.descriptionSuffix];
     
     return [description copy];
 }


### PR DESCRIPTION
This would be nice to have when debugging predicates.

**BEFORE**
`<ORK1StepResult: 0x60000233e800; identifier: "SymptomTimeEligibility"; enabledAssistiveTechnology: None; results: (
        <ORK1WebViewStepResult: 0x600001a4e1c0; identifier: "SymptomTimeEligibility">
    )>,`

**AFTER**
`<ORK1StepResult: 0x60000233e800; identifier: "SymptomTimeEligibility"; enabledAssistiveTechnology: None; results: (
        <ORK1WebViewStepResult: 0x600001a4e1c0; identifier: "SymptomTimeEligibility"; result: "Eligible">
    )>,`