### PR TITLE
Remove extra early layout pass on ORK1FormStepViewController

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -386,8 +386,6 @@
     
     // Reset skipped flag - result can now be non-empty
     _skipped = NO;
-    
-    [_tableContainer layoutIfNeeded];
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/1047. Removing this triggered layout update seems to fix this issue. In a regression that occurred between 15.2 and 15.4, the `ORK1StepHeaderView` renders itself partially overlapping the text of the first FormItem of a FormStep that has no header content (title or text). This does not appear to affect RK2.

Have tested this fix on 15.2 and multiple devices. The only noticeable change is that the Next/Done button is rendered about 10-20 points higher than before. This was the only change noticed in the CEVResearchKit snapshot tests. This change did not break any CEVResearchKit UI tests.

iPhone 13
iOS 15.4
|BEFORE|AFTER|
|---|---|
|<img width="564" alt="Screen Shot 2022-04-28 at 10 32 59 AM" src="https://user-images.githubusercontent.com/1008462/165815872-2685517e-e2ed-431b-9311-2fc32c7676c7.png">|<img width="564" alt="Screen Shot 2022-04-28 at 12 50 29 PM" src="https://user-images.githubusercontent.com/1008462/165816039-95b8e368-d2c6-44ce-844c-b3854156a8b0.png">|
