### PR TITLE
Support password autofill and textContextType

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
@@ -1345,6 +1345,28 @@ ORK1_CLASS_AVAILABLE
  */
 @property (nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
+/**
+ If `secureTextEntry` is YES, determines if passwordAutofill is enabled.
+ 
+ By default, the value fo this property is NO.
+ */
+@property (nonatomic) BOOL allowPasswordAutofill;
+
+/**
+ The semantic UITextContentType that applies to the user's input.
+  
+ If specified the system can improve keyboard suggestions to help with filling forms and other
+ input. By default, the value of this property is `nil` meaning no specific type.
+*/
+ @property (nonatomic, copy, nullable) UITextContentType textContentType;
+
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ */
+@property (nonatomic, copy, nullable) UITextInputPasswordRules *passwordRules;
+
 @end
 
 
@@ -1356,6 +1378,17 @@ ORK1_CLASS_AVAILABLE
  */
 ORK1_CLASS_AVAILABLE
 @interface ORK1EmailAnswerFormat : ORK1AnswerFormat
+
+/**
+ Identifies whether this email answer format is being used as a username.
+ 
+ For integration with iOS 12's password management functionality. Use this answer format if your
+ username is also an email address, if it is not and guaranteed to be an email address, use
+ `ORKTextAnswerFormat` and set the `textContentType` to `UITextContentTypeUsername`.
+  
+ By default, the value of this property is NO.
+ */
+@property (nonatomic,getter=isUsernameField) BOOL usernameField;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
@@ -1348,7 +1348,7 @@ ORK1_CLASS_AVAILABLE
 /**
  If `secureTextEntry` is YES, determines if passwordAutofill is enabled.
  
- By default, the value fo this property is NO.
+ By default, the value for this property is NO.
  */
 @property (nonatomic) BOOL allowPasswordAutofill;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -2330,6 +2330,10 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     answerFormat->_keyboardType = _keyboardType;
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
+    answerFormat->_allowPasswordAutofill = _allowPasswordAutofill;
+    answerFormat->_textContentType = _textContentType;
+    answerFormat->_passwordRules = _passwordRules;
+    
     return answerFormat;
 }
 
@@ -2391,7 +2395,10 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     answerFormat->_keyboardType = _keyboardType;
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
+    answerFormat->_allowPasswordAutofill = _allowPasswordAutofill;
     answerFormat->_autocapitalizationType = _autocapitalizationType;
+    answerFormat->_textContentType = _textContentType;
+    answerFormat->_passwordRules = _passwordRules;
     
     // Always set to no autocorrection or spell checking
     answerFormat->_autocorrectionType = UITextAutocorrectionTypeNo;
@@ -2415,6 +2422,9 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
         ORK1_DECODE_ENUM(aDecoder, keyboardType);
         ORK1_DECODE_BOOL(aDecoder, multipleLines);
         ORK1_DECODE_BOOL(aDecoder, secureTextEntry);
+        ORK1_DECODE_BOOL(aDecoder, allowPasswordAutofill);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, textContentType, NSString);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, passwordRules, UITextInputPasswordRules);
     }
     return self;
 }
@@ -2424,12 +2434,15 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
     ORK1_ENCODE_INTEGER(aCoder, maximumLength);
     ORK1_ENCODE_OBJ(aCoder, validationRegularExpression);
     ORK1_ENCODE_OBJ(aCoder, invalidMessage);
+    ORK1_ENCODE_OBJ(aCoder, textContentType);
+    ORK1_ENCODE_OBJ(aCoder, passwordRules);
     ORK1_ENCODE_ENUM(aCoder, autocapitalizationType);
     ORK1_ENCODE_ENUM(aCoder, autocorrectionType);
     ORK1_ENCODE_ENUM(aCoder, spellCheckingType);
     ORK1_ENCODE_ENUM(aCoder, keyboardType);
     ORK1_ENCODE_BOOL(aCoder, multipleLines);
     ORK1_ENCODE_BOOL(aCoder, secureTextEntry);
+    ORK1_ENCODE_BOOL(aCoder, allowPasswordAutofill);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -2448,8 +2461,11 @@ static NSArray *ork_processTextChoices(NSArray<ORK1TextChoice *> *textChoices) {
              self.autocorrectionType == castObject.autocorrectionType &&
              self.spellCheckingType == castObject.spellCheckingType &&
              self.keyboardType == castObject.keyboardType &&
-             self.multipleLines == castObject.multipleLines) &&
-            self.secureTextEntry == castObject.secureTextEntry);
+             ORK1EqualObjects(self.passwordRules, castObject.passwordRules) &&
+             self.multipleLines == castObject.multipleLines &&
+             self.secureTextEntry == castObject.secureTextEntry &&
+             self.allowPasswordAutofill == castObject.allowPasswordAutofill &&
+             ORK1EqualObjects(self.textContentType, castObject.textContentType)));
 }
 
 static NSString *const kSecureTextEntryEscapeString = @"*";
@@ -2493,12 +2509,21 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _impliedAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         _impliedAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         _impliedAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        _impliedAnswerFormat.textContentType = UITextContentTypeEmailAddress;
     }
     return _impliedAnswerFormat;
 }
 
 - (NSString *)stringForAnswer:(id)answer {
     return [self.impliedAnswerFormat stringForAnswer:answer];
+}
+
+- (void)setUsernameField:(BOOL)usernameField {
+    _usernameField = usernameField;
+    if ([self.impliedAnswerFormat isMemberOfClass:[ORK1TextAnswerFormat class]]) {
+        ORK1TextAnswerFormat *textFormat = (ORK1TextAnswerFormat *)self.impliedAnswerFormat;
+        textFormat.textContentType = usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
+    }
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -2509,7 +2509,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _impliedAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         _impliedAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         _impliedAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-        _impliedAnswerFormat.textContentType = UITextContentTypeEmailAddress;
+        _impliedAnswerFormat.textContentType = _usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
     }
     return _impliedAnswerFormat;
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormItemCell.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormItemCell.m
@@ -527,6 +527,11 @@ static const CGFloat HorizontalMargin = 15.0;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
+    ORK1TextAnswerFormat *answerFormat = (ORK1TextAnswerFormat *)self.formItem.answerFormat;
+    // For password auto-fill, we don't want to clear the auto-populated confirmed password since it's filled at the same time as the password
+    if (answerFormat.textContentType == UITextContentTypeNewPassword) {
+        return;
+    }
     if ([keyPath isEqual:[self originalItemIdentifier]]) {
         self.textField.text = nil;
         if (self.answer) {
@@ -592,9 +597,11 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
-    if (answerFormat.secureTextEntry) {
+    self.textField.textContentType = answerFormat.textContentType;
+    if (answerFormat.secureTextEntry && !answerFormat.allowPasswordAutofill) {
         ORK1DisablePasswordAutofill(self.textField);
     }
+    self.textField.passwordRules = answerFormat.passwordRules;
     
     [self answerDidChange];
 }
@@ -815,7 +822,9 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
-        if (textAnswerFormat.secureTextEntry) {
+        _textView.textContentType = textAnswerFormat.textContentType;
+        _textView.passwordRules = textAnswerFormat.passwordRules;
+        if (textAnswerFormat.secureTextEntry && !textAnswerFormat.allowPasswordAutofill) {
             ORK1DisablePasswordAutofill(_textView);
         }
     } else {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
@@ -546,11 +546,7 @@ NSNumberFormatter *ORK1DecimalNumberFormatter() {
 }
 
 void ORK1DisablePasswordAutofill(id<UITextInputTraits> input) {
-    if (@available(iOS 12.0, *)) {
-        input.textContentType = UITextContentTypeOneTimeCode;
-    } else {
-        input.textContentType = @"";
-    }
+    input.textContentType = UITextContentTypeOneTimeCode;
     
     // iOS displays the keychain autofill interface for secureTextEntry fields and the one previous to it.
     // Inject an invisble text field above the current one, so no other textfields inadvertantly show keychain autofill.

--- a/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SurveyAnswerCellForText.m
@@ -63,7 +63,9 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
-        if (textAnswerFormat.secureTextEntry) {
+        self.textView.textContentType = textAnswerFormat.textContentType;
+        self.textView.passwordRules = textAnswerFormat.passwordRules;
+        if (textAnswerFormat.secureTextEntry && !textAnswerFormat.allowPasswordAutofill) {
             ORK1DisablePasswordAutofill(self.textView);
         }
     } else {
@@ -271,7 +273,9 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
-        if (textFormat.secureTextEntry) {
+        self.textField.textContentType = textFormat.textContentType;
+        self.textField.passwordRules = textFormat.passwordRules;
+        if (textFormat.secureTextEntry && !textFormat.allowPasswordAutofill) {
             ORK1DisablePasswordAutofill(self.textField);
         }
     }

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
@@ -161,19 +161,26 @@ static NSString *const _FamilyNameIdentifier = @"family";
                                                              text:self.step.text];
     formStep.useSurveyMode = NO;
     
-    ORK1TextAnswerFormat *nameAnswerFormat = [ORK1TextAnswerFormat textAnswerFormat];
-    nameAnswerFormat.multipleLines = NO;
-    nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-    nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    ORK1TextAnswerFormat *givenNameAnswerFormat = [ORK1TextAnswerFormat textAnswerFormat];
+    givenNameAnswerFormat.multipleLines = NO;
+    givenNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    givenNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    givenNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    givenNameAnswerFormat.textContentType = UITextContentTypeGivenName;
     ORK1FormItem *givenNameFormItem = [[ORK1FormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                               text:ORK1LocalizedString(@"CONSENT_NAME_GIVEN", nil)
-                                                      answerFormat:nameAnswerFormat];
+                                                      answerFormat:givenNameAnswerFormat];
     givenNameFormItem.placeholder = ORK1LocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
+    ORK1TextAnswerFormat *familyNameAnswerFormat = [ORK1TextAnswerFormat textAnswerFormat];
+    familyNameAnswerFormat.multipleLines = NO;
+    familyNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    familyNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    familyNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    familyNameAnswerFormat.textContentType = UITextContentTypeFamilyName;
     ORK1FormItem *familyNameFormItem = [[ORK1FormItem alloc] initWithIdentifier:_FamilyNameIdentifier
                                                              text:ORK1LocalizedString(@"CONSENT_NAME_FAMILY", nil)
-                                                     answerFormat:nameAnswerFormat];
+                                                     answerFormat:familyNameAnswerFormat];
     familyNameFormItem.placeholder = ORK1LocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
     givenNameFormItem.optional = NO;

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStep.m
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStep.m
@@ -79,6 +79,7 @@ NSString *const ORK1LoginFormItemIdentifierPassword = @"ORK1LoginFormItemPasswor
     
     {
         ORK1EmailAnswerFormat *answerFormat = [ORK1AnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1LoginFormItemIdentifierEmail
                                                                text:ORK1LocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -93,9 +94,11 @@ NSString *const ORK1LoginFormItemIdentifierPassword = @"ORK1LoginFormItemPasswor
         ORK1TextAnswerFormat *answerFormat = [ORK1AnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
         answerFormat.secureTextEntry = YES;
+        answerFormat.allowPasswordAutofill = YES;
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1LoginFormItemIdentifierPassword
                                                                text:ORK1LocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.h
@@ -140,6 +140,33 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
  */
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
 
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ The `passcodeRules` should match the `passcodeValidationRegularExpression` or else a passcode
+ may be generated that fails validation.
+ */
+@property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules;
+
+/**
+ The regular expression used to validate the phone number form item.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number invalid message property must also be set along with this property.
+ By default, there is no validation on the phone number.
+ */
+@property (nonatomic, copy, nullable) NSRegularExpression *phoneNumberValidationRegularExpression;
+
+/**
+ The invalid message displayed if the phone number does not match the validation regular expression.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number validation regular expression property must also be set along with this property.
+ By default, there is no invalid message.
+ */
+@property (nonatomic, copy, nullable) NSString *phoneNumberInvalidMessage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.m
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.m
@@ -53,6 +53,7 @@ static NSArray <ORK1FormItem*> *ORK1RegistrationFormItems(ORK1RegistrationStepOp
     
     {
         ORK1EmailAnswerFormat *answerFormat = [ORK1AnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1RegistrationFormItemIdentifierEmail
                                                                text:ORK1LocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -68,9 +69,11 @@ static NSArray <ORK1FormItem*> *ORK1RegistrationFormItems(ORK1RegistrationStepOp
         ORK1TextAnswerFormat *answerFormat = [ORK1AnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
         answerFormat.secureTextEntry = YES;
+        answerFormat.allowPasswordAutofill = YES;
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1RegistrationFormItemIdentifierPassword
                                                                text:ORK1LocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
@@ -86,6 +89,8 @@ static NSArray <ORK1FormItem*> *ORK1RegistrationFormItems(ORK1RegistrationStepOp
         ORK1FormItem *item = [passwordFormItem confirmationAnswerFormItemWithIdentifier:ORK1RegistrationFormItemIdentifierConfirmPassword
                                                 text:ORK1LocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil)
                                                 errorMessage:ORK1LocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
+        ORK1TextAnswerFormat *answerFormat = (ORK1TextAnswerFormat *)item.answerFormat;
+        answerFormat.textContentType = UITextContentTypeNewPassword;
         item.placeholder = ORK1LocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_PLACEHOLDER", nil);
         
         [formItems addObject:item];
@@ -100,6 +105,7 @@ static NSArray <ORK1FormItem*> *ORK1RegistrationFormItems(ORK1RegistrationStepOp
     if (options & ORK1RegistrationStepIncludeGivenName) {
         ORK1TextAnswerFormat *answerFormat = [ORK1AnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeGivenName;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1RegistrationFormItemIdentifierGivenName
                                                                text:ORK1LocalizedString(@"CONSENT_NAME_GIVEN", nil)
@@ -113,6 +119,7 @@ static NSArray <ORK1FormItem*> *ORK1RegistrationFormItems(ORK1RegistrationStepOp
     if (options & ORK1RegistrationStepIncludeFamilyName) {
         ORK1TextAnswerFormat *answerFormat = [ORK1AnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeFamilyName;
         
         ORK1FormItem *item = [[ORK1FormItem alloc] initWithIdentifier:ORK1RegistrationFormItemIdentifierFamilyName
                                                                text:ORK1LocalizedString(@"CONSENT_NAME_FAMILY", nil)
@@ -259,6 +266,14 @@ passcodeValidationRegularExpression:nil
 
 - (void)setPasscodeInvalidMessage:(NSString *)passcodeInvalidMessage {
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
+}
+
+- (UITextInputPasswordRules *)passcodeRules {
+    return [self passwordAnswerFormat].passwordRules;
+}
+
+- (void)setPasscodeRules:(UITextInputPasswordRules *)passcodeRules {
+    [self passwordAnswerFormat].passwordRules = passcodeRules;
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ORK1Kit/ORK1KitTests/ORK1AnswerFormatTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1AnswerFormatTests.m
@@ -92,6 +92,7 @@
     answerFormat.multipleLines = NO;
     answerFormat.secureTextEntry = YES;
     answerFormat.keyboardType = UIKeyboardTypeASCIICapable;
+    answerFormat.textContentType = UITextContentTypeNewPassword;
     answerFormat.maximumLength = 12;
     NSRegularExpression *validationRegularExpression =
     [NSRegularExpression regularExpressionWithPattern:@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{10,}"
@@ -133,6 +134,7 @@
     XCTAssertFalse(confirmAnswer.multipleLines);
     XCTAssertTrue(confirmAnswer.secureTextEntry);
     XCTAssertEqual(confirmAnswer.keyboardType, UIKeyboardTypeASCIICapable);
+    XCTAssertEqual(confirmAnswer.textContentType, UITextContentTypeNewPassword);
     XCTAssertEqual(confirmAnswer.maximumLength, 12);
     
     // This property should match the input answer format so that cases that

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1413,6 +1413,28 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
+/**
+ If `secureTextEntry` is YES, determines if passwordAutofill is enabled.
+ 
+ By default, the value fo this property is NO.
+ */
+@property (nonatomic) BOOL allowPasswordAutofill;
+
+/**
+ The semantic UITextContentType that applies to the user's input.
+  
+ If specified the system can improve keyboard suggestions to help with filling forms and other
+ input. By default, the value of this property is `nil` meaning no specific type.
+*/
+ @property (nonatomic, copy, nullable) UITextContentType textContentType;
+
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ */
+@property (nonatomic, copy, nullable) UITextInputPasswordRules *passwordRules  API_AVAILABLE(ios(12.0));
+
 @end
 
 
@@ -1424,6 +1446,17 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKEmailAnswerFormat : ORKAnswerFormat
+
+/**
+ Identifies whether this email answer format is being used as a username.
+ 
+ For integration with iOS 12's password management functionality. Use this answer format if your
+ username is also an email address, if it is not and guaranteed to be an email address, use
+ `ORKTextAnswerFormat` and set the `textContentType` to `UITextContentTypeUsername`.
+  
+ By default, the value of this property is NO.
+ */
+@property (nonatomic,getter=isUsernameField) BOOL usernameField;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1416,7 +1416,7 @@ ORK_CLASS_AVAILABLE
 /**
  If `secureTextEntry` is YES, determines if passwordAutofill is enabled.
  
- By default, the value fo this property is NO.
+ By default, the value for this property is NO.
  */
 @property (nonatomic) BOOL allowPasswordAutofill;
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2556,7 +2556,7 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _impliedAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         _impliedAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         _impliedAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-        _impliedAnswerFormat.textContentType = UITextContentTypeEmailAddress;
+        _impliedAnswerFormat.textContentType = _usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
     }
     return _impliedAnswerFormat;
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2361,6 +2361,13 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     answerFormat->_keyboardType = _keyboardType;
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
+    answerFormat->_allowPasswordAutofill = _allowPasswordAutofill;
+    answerFormat->_textContentType = _textContentType;
+    
+    if (@available(iOS 12.0, *)) {
+        answerFormat->_passwordRules = _passwordRules;
+    }
+    
     return answerFormat;
 }
 
@@ -2422,7 +2429,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     answerFormat->_keyboardType = _keyboardType;
     answerFormat->_multipleLines = _multipleLines;
     answerFormat->_secureTextEntry = _secureTextEntry;
+    answerFormat->_allowPasswordAutofill = _allowPasswordAutofill;
     answerFormat->_autocapitalizationType = _autocapitalizationType;
+    answerFormat->_textContentType = _textContentType;
+    if (@available(iOS 12.0, *)) {
+        answerFormat->_passwordRules = _passwordRules;
+    }
     
     // Always set to no autocorrection or spell checking
     answerFormat->_autocorrectionType = UITextAutocorrectionTypeNo;
@@ -2447,6 +2459,11 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_ENUM(aDecoder, keyboardType);
         ORK_DECODE_BOOL(aDecoder, multipleLines);
         ORK_DECODE_BOOL(aDecoder, secureTextEntry);
+        ORK_DECODE_BOOL(aDecoder, allowPasswordAutofill);
+        ORK_DECODE_OBJ_CLASS(aDecoder, textContentType, NSString);
+        if (@available(iOS 12.0, *)) {
+            ORK_DECODE_OBJ_CLASS(aDecoder, passwordRules, UITextInputPasswordRules);
+        }
     }
     return self;
 }
@@ -2456,6 +2473,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_INTEGER(aCoder, maximumLength);
     ORK_ENCODE_OBJ(aCoder, validationRegularExpression);
     ORK_ENCODE_OBJ(aCoder, invalidMessage);
+    ORK_ENCODE_OBJ(aCoder, textContentType);
+    ORK_ENCODE_OBJ(aCoder, passwordRules);
     ORK_ENCODE_OBJ(aCoder, defaultTextAnswer);
     ORK_ENCODE_ENUM(aCoder, autocapitalizationType);
     ORK_ENCODE_ENUM(aCoder, autocorrectionType);
@@ -2463,6 +2482,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_ENUM(aCoder, keyboardType);
     ORK_ENCODE_BOOL(aCoder, multipleLines);
     ORK_ENCODE_BOOL(aCoder, secureTextEntry);
+    ORK_ENCODE_BOOL(aCoder, allowPasswordAutofill);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -2471,8 +2491,14 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
+    BOOL equalPasswordRules = YES;
     
     __typeof(self) castObject = object;
+    
+    if (@available(iOS 12.0, *)) {
+        equalPasswordRules = ORKEqualObjects(self.passwordRules, castObject.passwordRules);
+    }
+    
     return (isParentSame &&
             (self.maximumLength == castObject.maximumLength &&
              ORKEqualObjects(self.validationRegularExpression, castObject.validationRegularExpression) &&
@@ -2482,8 +2508,11 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
              self.autocorrectionType == castObject.autocorrectionType &&
              self.spellCheckingType == castObject.spellCheckingType &&
              self.keyboardType == castObject.keyboardType &&
-             self.multipleLines == castObject.multipleLines) &&
-             self.secureTextEntry == castObject.secureTextEntry);
+             equalPasswordRules &&
+             self.multipleLines == castObject.multipleLines &&
+             self.secureTextEntry == castObject.secureTextEntry &&
+             self.allowPasswordAutofill == castObject.allowPasswordAutofill &&
+             ORKEqualObjects(self.textContentType, castObject.textContentType)));
 }
 
 static NSString *const kSecureTextEntryEscapeString = @"*";
@@ -2527,12 +2556,21 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         _impliedAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         _impliedAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         _impliedAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        _impliedAnswerFormat.textContentType = UITextContentTypeEmailAddress;
     }
     return _impliedAnswerFormat;
 }
 
 - (NSString *)stringForAnswer:(id)answer {
     return [self.impliedAnswerFormat stringForAnswer:answer];
+}
+
+- (void)setUsernameField:(BOOL)usernameField {
+    _usernameField = usernameField;
+    if ([self.impliedAnswerFormat isMemberOfClass:[ORKTextAnswerFormat class]]) {
+        ORKTextAnswerFormat *textFormat = (ORKTextAnswerFormat *)self.impliedAnswerFormat;
+        textFormat.textContentType = usernameField ? UITextContentTypeUsername : UITextContentTypeEmailAddress;
+    }
 }
 
 @end

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -630,6 +630,13 @@ static const CGFloat HorizontalMargin = 15.0;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
+    if (@available(iOS 12.0, *)) {
+        ORKTextAnswerFormat *answerFormat = (ORKTextAnswerFormat *)self.formItem.answerFormat;
+        // For password auto-fill, we don't want to clear the auto-populated confirmed password since it's filled at the same time as the password
+        if (answerFormat.textContentType == UITextContentTypeNewPassword) {
+            return;
+        }
+    }
     if ([keyPath isEqual:[self originalItemIdentifier]]) {
         self.textField.text = nil;
         if (self.answer) {
@@ -698,8 +705,12 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
-    if (answerFormat.secureTextEntry) {
+    self.textField.textContentType = answerFormat.textContentType;
+    if (answerFormat.secureTextEntry && !answerFormat.allowPasswordAutofill) {
         ORKDisablePasswordAutofill(self.textField);
+    }
+    if (@available(iOS 12.0, *)) {
+        self.textField.passwordRules = answerFormat.passwordRules;
     }
     
     [self answerDidChange];
@@ -951,7 +962,11 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
-        if (textAnswerFormat.secureTextEntry) {
+        _textView.textContentType = textAnswerFormat.textContentType;
+        if (@available(iOS 12.0, *)) {
+            _textView.passwordRules = textAnswerFormat.passwordRules;
+        }
+        if (textAnswerFormat.secureTextEntry && !textAnswerFormat.allowPasswordAutofill) {
             ORKDisablePasswordAutofill(_textView);
         }
     } else {

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -65,6 +65,10 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        self.textView.textContentType = textAnswerFormat.textContentType;
+        if (@available(iOS 12.0, *)) {
+            self.textView.passwordRules = textAnswerFormat.passwordRules;
+        }
         if (textAnswerFormat.secureTextEntry) {
             ORKDisablePasswordAutofill(self.textView);
         }
@@ -287,7 +291,11 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
-        if (textFormat.secureTextEntry) {
+        self.textField.textContentType = textFormat.textContentType;
+        if (@available(iOS 12.0, *)) {
+            self.textField.passwordRules = textFormat.passwordRules;
+        }
+        if (textFormat.secureTextEntry && !textFormat.allowPasswordAutofill) {
             ORKDisablePasswordAutofill(self.textField);
         }
     }

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -166,19 +166,26 @@ static NSString *const _FamilyNameIdentifier = @"family";
                                                              text:self.step.text];
     formStep.useSurveyMode = NO;
     
-    ORKTextAnswerFormat *nameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
-    nameAnswerFormat.multipleLines = NO;
-    nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-    nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    ORKTextAnswerFormat *givenNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    givenNameAnswerFormat.multipleLines = NO;
+    givenNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    givenNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    givenNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    givenNameAnswerFormat.textContentType = UITextContentTypeGivenName;
     ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                               text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
-                                                      answerFormat:nameAnswerFormat];
+                                                      answerFormat:givenNameAnswerFormat];
     givenNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
+    ORKTextAnswerFormat *familyNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    familyNameAnswerFormat.multipleLines = NO;
+    familyNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    familyNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    familyNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    familyNameAnswerFormat.textContentType = UITextContentTypeFamilyName;
     ORKFormItem *familyNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_FamilyNameIdentifier
                                                              text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
-                                                     answerFormat:nameAnswerFormat];
+                                                     answerFormat:familyNameAnswerFormat];
     familyNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
     givenNameFormItem.optional = NO;

--- a/ResearchKit/Onboarding/ORKLoginStep.m
+++ b/ResearchKit/Onboarding/ORKLoginStep.m
@@ -79,6 +79,7 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -93,9 +94,11 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
         answerFormat.secureTextEntry = YES;
+        answerFormat.allowPasswordAutofill = YES;
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+@import UIKit;
 #import <ResearchKit/ORKFormStep.h>
 
 
@@ -143,6 +143,15 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
  By default, there is no invalid message.
  */
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
+
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ The `passcodeRules` should match the `passcodeValidationRegularExpression` or else a passcode
+ may be generated that fails validation.
+ */
+@property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules API_AVAILABLE(ios(12.0));
 
 /**
  The regular expression used to validate the phone number form item.

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -54,6 +54,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -69,9 +70,11 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
         answerFormat.secureTextEntry = YES;
+        answerFormat.allowPasswordAutofill = YES;
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
@@ -88,7 +91,10 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
                                                 text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil)
                                                 errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
         item.placeholder = ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_PLACEHOLDER", nil);
-        
+        if (@available(iOS 12.0, *)) {
+            ORKTextAnswerFormat *answerFormat = (ORKTextAnswerFormat *)item.answerFormat;
+            answerFormat.textContentType = UITextContentTypeNewPassword;
+        }
         [formItems addObject:item];
     }
     
@@ -101,6 +107,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeGivenName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeGivenName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierGivenName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
@@ -114,6 +121,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeFamilyName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeFamilyName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierFamilyName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
@@ -283,6 +291,14 @@ passcodeValidationRegularExpression:nil
 
 - (void)setPasscodeInvalidMessage:(NSString *)passcodeInvalidMessage {
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
+}
+
+- (UITextInputPasswordRules *)passcodeRules {
+    return [self passwordAnswerFormat].passwordRules;
+}
+
+- (void)setPasscodeRules:(UITextInputPasswordRules *)passcodeRules {
+    [self passwordAnswerFormat].passwordRules = passcodeRules;
 }
 
 - (NSRegularExpression *)phoneNumberValidationRegularExpression {


### PR DESCRIPTION
Closes https://github.com/CareEvolution/RKStudio-Participant/issues/1023 (and https://github.com/CareEvolution/ResearchKit/pull/9).

This PR looks to add the functionality added in [Eric DeLabar's PR on base ResearchKit](https://github.com/ResearchKit/ResearchKit/pull/1188) which incorporates some of the improvements in password management that arrived in iOS 12.

A new property on `ORK[1]TextAnswerFormat` named `allowPasswordAutoFill` is used to provide a switch for the autofill-avoidant behavior added in [Kevin's fix for secure text fields in surveys](https://github.com/CareEvolution/ResearchKit/pull/61).

This will allow us to selectively allow password autofill and management for myFHR which still uses the `ORK1RegistrationStep` and `ORK1LoginStep`. (Note that this does not attempt to convert the myFHR login/registration screens to the newer style supported by AoU and MDH at this time.)

While this feature was added both to RK1 and RK2, I did not attempt to update the minimum version for the ResearchKit (RK2) framework at this time, hence, the `if (@available` statements in RK2 here.

## Testing

### Password Functionality

For the login/appropriate domain matching, it's messy if you like me have numerous saved passwords for the careevolution.com domain. I made a simple dummy test login in iOS's Password database (Settings > Passwords) using a unique domain for each app (mydatahelps.org = MDH, myfhr.careevolution.com = myFHR, platform.joinallofus.org = AoU). I was able to confirm that I only saw the right test login for each app (except myFHR which matches on the wildcard *.careevolution.com so it showed in all 3 apps).

- MyDataHelps (basically regression testing)
  - ensure text answers marked "Sensitive" (`secureTextEntry = true`) fields in surveys  (QuestionStep and FormItems) continue to NOT suggest/show passwords nor ask to save them at survey completion.
  - login shows saved passwords for appropriate domains:
     - `mydatahelps.org`
     - `caev.io`
     - `mdhorg.ce.dev`
     - `*.careevolution.com`
- MyFHR
  - login should now appropriately suggest saved passwords if available
  - new account creation should be pretty friction-free if autofill passwords is enabled - when filling out the fields, it will suggest name, address, and a secure password (assuming Settings has this enabled - Settings > Passwords > AutoFill Passwords)
  - login shows passwords for appropriate domains:
    - `myfhr.careevolution.com`
    - `myfhr.careevolution.dev`
    - `caev.io`
- All Of Us (should not be otherwise affected)
  - login shows saved passwords for appropriate domains:
    - `platform.joinallofus.org`
    - `platformaou.ce.dev`
    - `caev.io`
    - `*.careevolution.com`

Since testing RK2 is not-trivial, I did a search and replace in RKStudio-Participant for much of the login screens from `ORK1` -> `ORK` and can confirm the behavior seen in RK1 applies to RK2. Here's a screenshot for giggles on what the myFHR screen would look like in RK2.

|Login|Registration|
|---|---|
|![IMG_528F937D558A-1](https://user-images.githubusercontent.com/1008462/171950639-21076c52-9786-4b5c-8c34-219e8e5e3ac0.jpeg)|![IMG_094B2722BBB5-1](https://user-images.githubusercontent.com/1008462/171950662-fac3c870-7142-4790-90c0-f41ee36d766b.jpeg)|

### ContextType

This [survey JSON](https://gist.github.com/eschramm/da7cd4c544b23f29d18efde2439eac32#file-allfilecontexttypesformstep-json) has all the types as FormItems to see how suggestions look for the various types.

