### PR TITLE
Rename passcodeViewControllerDidCancel

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.m
@@ -159,7 +159,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
         
         // Check to see if cancel button should be set or not.
         if (self.passcodeDelegate &&
-            [self.passcodeDelegate respondsToSelector:@selector(passcodeViewControllerDidCancel:)]) {
+            [self.passcodeDelegate respondsToSelector:@selector(passcodeStepViewControllerDidCancel:)]) {
             self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"BUTTON_CANCEL", nil)
                                                                                       style:UIBarButtonItemStylePlain
                                                                                      target:self
@@ -319,8 +319,8 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)cancelButtonAction {
     if (self.passcodeDelegate &&
-        [self.passcodeDelegate respondsToSelector:@selector(passcodeViewControllerDidCancel:)]) {
-        [self.passcodeDelegate passcodeViewControllerDidCancel:self];
+        [self.passcodeDelegate respondsToSelector:@selector(passcodeStepViewControllerDidCancel:)]) {
+        [self.passcodeDelegate passcodeStepViewControllerDidCancel:self];
     }
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.h
@@ -67,7 +67,7 @@ ORK1_AVAILABLE_DECL
  
  @param viewController      The `ORK1PasscodeStepViewController` object in which the passcode input is entered.
  */
-- (void)passcodeViewControllerDidCancel:(UIViewController *)viewController;
+- (void)passcodeStepViewControllerDidCancel:(UIViewController *)viewController;
 
 /** 
  Defaults to Localized "Forgot Passcode?" text

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -174,7 +174,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
         
         // Check to see if cancel button should be set or not.
         if (self.passcodeDelegate &&
-            [self.passcodeDelegate respondsToSelector:@selector(passcodeViewControllerDidCancel:)]) {
+            [self.passcodeDelegate respondsToSelector:@selector(passcodeStepViewControllerDidCancel:)]) {
             self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_CANCEL", nil)
                                                                                       style:UIBarButtonItemStylePlain
                                                                                      target:self
@@ -404,8 +404,8 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)cancelButtonAction {
     if (self.passcodeDelegate &&
-        [self.passcodeDelegate respondsToSelector:@selector(passcodeViewControllerDidCancel:)]) {
-        [self.passcodeDelegate passcodeViewControllerDidCancel:self];
+        [self.passcodeDelegate respondsToSelector:@selector(passcodeStepViewControllerDidCancel:)]) {
+        [self.passcodeDelegate passcodeStepViewControllerDidCancel:self];
     }
 }
 

--- a/ResearchKit/Common/ORKPasscodeViewController.h
+++ b/ResearchKit/Common/ORKPasscodeViewController.h
@@ -67,7 +67,7 @@ ORK_AVAILABLE_DECL
  
  @param viewController      The `ORKPasscodeStepViewController` object in which the passcode input is entered.
  */
-- (void)passcodeViewControllerDidCancel:(UIViewController *)viewController;
+- (void)passcodeStepViewControllerDidCancel:(UIViewController *)viewController;
 
 /** 
  Defaults to Localized "Forgot Passcode?" text

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -556,7 +556,7 @@ NSString *RemoveParenthesisAndCapitalizeString(NSString *string) {
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)passcodeViewControllerDidCancel:(UIViewController *)viewController {
+- (void)passcodeStepViewControllerDidCancel:(UIViewController *)viewController {
     NSLog(@"User tapped the cancel button.");
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }


### PR DESCRIPTION
Seeing a new warning when uploading release builds to App Store Connect:

> The app references non-public selectors in ......./Frameworks/
ResearchKit.framework/ResearchKit:passcodeViewControllerDidCancel:

The build is still processing, so it's not yet certain whether this will actually cause a problem with App Store submissions, but it's simple enough to rename this selector and avoid the warning altogether.

## Testing

No QA testing necessary.