### PR TITLE
Secure decoding fixes

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Internal.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Internal.h
@@ -81,9 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
 #define ORK1_ENCODE_URL_BOOKMARK(c, x) [c encodeObject:ORK1BookmarkDataFromURL(_ ## x) forKey:@ORK1_STRINGIFY(x)]
 
 #define ORK1_DECODE_OBJ_CLASS(d,x,cl)  _ ## x = (cl *)[d decodeObjectOfClass:[cl class] forKey:@ORK1_STRINGIFY(x)]
-#define ORK1_DECODE_OBJ_ARRAY(d,x,cl)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],nil] forKey:@ORK1_STRINGIFY(x)]
+#define ORK1_DECODE_OBJ_ARRAY(d,x,cl)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],[NSString class],nil] forKey:@ORK1_STRINGIFY(x)]
+#define ORK1_DECODE_OBJ_ARRAY2(d,x,cl,cl2)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],[cl2 class],[NSString class],nil] forKey:@ORK1_STRINGIFY(x)]
 #define ORK1_DECODE_OBJ_MUTABLE_ORDERED_SET(d,x,cl)  _ ## x = [(NSOrderedSet *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSOrderedSet class],[cl class],nil] forKey:@ORK1_STRINGIFY(x)] mutableCopy]
 #define ORK1_DECODE_OBJ_MUTABLE_DICTIONARY(d,x,kcl,cl)  _ ## x = [(NSDictionary *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class],[kcl class],[cl class],nil] forKey:@ORK1_STRINGIFY(x)] mutableCopy]
+#define ORK1_DECODE_OBJ_MUTABLE_ARRAY(d,x,cl)  _ ## x = [(NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],nil] forKey:@ORK1_STRINGIFY(x)] mutableCopy]
 
 #define ORK1_ENCODE_COND_OBJ(c,x)  [c encodeConditionalObject:_ ## x forKey:@ORK1_STRINGIFY(x)]
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.m
@@ -1473,7 +1473,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK1_DECODE_OBJ_ARRAY(aDecoder, choiceAnswers, NSObject);
+        ORK1_DECODE_OBJ_ARRAY2(aDecoder, choiceAnswers, ORK1TextChoice, ORK1ImageChoice);
     }
     return self;
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1512,6 +1512,12 @@ static NSString *const _ORK1StepIdentifierRestoreKey = @"stepIdentifier";
 static NSString *const _ORK1PresentedDate = @"presentedDate";
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder {
+    
+    /*
+     NOTE: this is manually (vs using ORK1_ENCODE_xxx) due to the conditional
+     encoding of "stepIdentifier" (_ORK1StepIdentifierRestoreKey)
+     */
+    
     [super encodeRestorableStateWithCoder:coder];
     
     [coder encodeObject:_taskRunUUID forKey:_ORK1TaskRunUUIDRestoreKey];
@@ -1539,9 +1545,10 @@ static NSString *const _ORK1PresentedDate = @"presentedDate";
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder {
     [super decodeRestorableStateWithCoder:coder];
     
-    _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORK1TaskRunUUIDRestoreKey];
-    self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORK1ShowsProgressInNavigationBarRestoreKey];
+    ORK1_DECODE_OBJ_CLASS(coder, taskRunUUID, NSUUID);
+    ORK1_DECODE_BOOL(coder, showsProgressInNavigationBar);
     
+    // manually decoded due to two-step encode/decode of bookmark data <--> URL
     _outputDirectory = ORK1URLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORK1OutputDirectoryRestoreKey]);
     [self ensureDirectoryExists:_outputDirectory];
     
@@ -1549,10 +1556,10 @@ static NSString *const _ORK1PresentedDate = @"presentedDate";
     if (_task) {
         
         // Recover partially entered results, even if we may not be able to jump to the desired step.
-        _managedResults = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:_ORK1ManagedResultsRestoreKey];
-        _managedStepIdentifiers = [coder decodeObjectOfClass:[NSMutableArray class] forKey:_ORK1ManagedStepIdentifiersRestoreKey];
+        ORK1_DECODE_OBJ_MUTABLE_DICTIONARY(coder, managedResults, NSString, ORK1Result);
+        ORK1_DECODE_OBJ_MUTABLE_ARRAY(coder, managedStepIdentifiers, NSString);
+        ORK1_DECODE_OBJ_CLASS(coder, restoredTaskIdentifier, NSString);
         
-        _restoredTaskIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORK1TaskIdentifierRestoreKey];
         if (_restoredTaskIdentifier) {
             if (![_task.identifier isEqualToString:_restoredTaskIdentifier]) {
                 @throw [NSException exceptionWithName:NSInternalInconsistencyException
@@ -1562,12 +1569,13 @@ static NSString *const _ORK1PresentedDate = @"presentedDate";
         }
         
         if ([_task respondsToSelector:@selector(stepWithIdentifier:)]) {
-            _hasSetProgressLabel = [coder decodeBoolForKey:_ORK1HasSetProgressLabelRestoreKey];
-            _requestedHealthTypesForRead = [coder decodeObjectOfClass:[NSSet class] forKey:_ORK1RequestedHealthTypesForReadRestoreKey];
-            _requestedHealthTypesForWrite = [coder decodeObjectOfClass:[NSSet class] forKey:_ORK1RequestedHealthTypesForWriteRestoreKey];
-            _presentedDate = [coder decodeObjectOfClass:[NSDate class] forKey:_ORK1PresentedDate];
-            _lastBeginningInstructionStepIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORK1LastBeginningInstructionStepIdentifierKey];
+            ORK1_DECODE_BOOL(coder, hasSetProgressLabel);
+            ORK1_DECODE_OBJ_CLASS(coder, requestedHealthTypesForRead, NSSet);
+            ORK1_DECODE_OBJ_CLASS(coder, requestedHealthTypesForWrite, NSSet);
+            ORK1_DECODE_OBJ_CLASS(coder, presentedDate, NSDate);
+            ORK1_DECODE_OBJ_CLASS(coder, lastBeginningInstructionStepIdentifier, NSString);
             
+            // manually decoded due to mapping into custom ivar
             _restoredStepIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORK1StepIdentifierRestoreKey];
         } else {
             ORK1_Log_Warning(@"Not restoring current step of task %@ because it does not implement -stepWithIdentifier:", _task.identifier);

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -81,9 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
 #define ORK_ENCODE_URL_BOOKMARK(c, x) [c encodeObject:ORKBookmarkDataFromURL(_ ## x) forKey:@ORK_STRINGIFY(x)]
 
 #define ORK_DECODE_OBJ_CLASS(d,x,cl)  _ ## x = (cl *)[d decodeObjectOfClass:[cl class] forKey:@ORK_STRINGIFY(x)]
-#define ORK_DECODE_OBJ_ARRAY(d,x,cl)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],nil] forKey:@ORK_STRINGIFY(x)]
+#define ORK_DECODE_OBJ_ARRAY(d,x,cl)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],[NSString class],nil] forKey:@ORK_STRINGIFY(x)]
+#define ORK_DECODE_OBJ_ARRAY2(d,x,cl,cl2)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],[cl2 class],[NSString class],nil] forKey:@ORK_STRINGIFY(x)]
 #define ORK_DECODE_OBJ_MUTABLE_ORDERED_SET(d,x,cl)  _ ## x = [(NSOrderedSet *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSOrderedSet class],[cl class],nil] forKey:@ORK_STRINGIFY(x)] mutableCopy]
 #define ORK_DECODE_OBJ_MUTABLE_DICTIONARY(d,x,kcl,cl)  _ ## x = [(NSDictionary *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class],[kcl class],[cl class],nil] forKey:@ORK_STRINGIFY(x)] mutableCopy]
+#define ORK_DECODE_OBJ_MUTABLE_ARRAY(d,x,cl)  _ ## x = [(NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],nil] forKey:@ORK_STRINGIFY(x)] mutableCopy]
 
 #define ORK_ENCODE_COND_OBJ(c,x)  [c encodeConditionalObject:_ ## x forKey:@ORK_STRINGIFY(x)]
 

--- a/ResearchKit/Common/ORKQuestionResult.m
+++ b/ResearchKit/Common/ORKQuestionResult.m
@@ -204,7 +204,7 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK_DECODE_OBJ_ARRAY(aDecoder, choiceAnswers, NSObject);
+        ORK_DECODE_OBJ_ARRAY2(aDecoder, choiceAnswers, ORKTextChoice, ORKImageChoice);
     }
     return self;
 }

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1616,6 +1616,12 @@ static NSString *const _ORKStepIdentifierRestoreKey = @"stepIdentifier";
 static NSString *const _ORKPresentedDate = @"presentedDate";
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder {
+    
+    /*
+     NOTE: this is manually (vs using ORK1_ENCODE_xxx) due to the conditional
+     encoding of "stepIdentifier" (_ORKStepIdentifierRestoreKey)
+     */
+    
     [super encodeRestorableStateWithCoder:coder];
     
     [coder encodeObject:_taskRunUUID forKey:_ORKTaskRunUUIDRestoreKey];
@@ -1643,9 +1649,10 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder {
     [super decodeRestorableStateWithCoder:coder];
     
-    _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORKTaskRunUUIDRestoreKey];
-    self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
+    ORK_DECODE_OBJ_CLASS(coder, taskRunUUID, NSUUID);
+    ORK_DECODE_BOOL(coder, showsProgressInNavigationBar);
     
+    // manually decoded due to two-step encode/decode of bookmark data <--> URL
     _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
     [self ensureDirectoryExists:_outputDirectory];
     
@@ -1653,10 +1660,10 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     if (_task) {
         
         // Recover partially entered results, even if we may not be able to jump to the desired step.
-        _managedResults = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:_ORKManagedResultsRestoreKey];
-        _managedStepIdentifiers = [coder decodeObjectOfClass:[NSMutableArray class] forKey:_ORKManagedStepIdentifiersRestoreKey];
+        ORK_DECODE_OBJ_MUTABLE_DICTIONARY(coder, managedResults, NSString, ORKResult);
+        ORK_DECODE_OBJ_MUTABLE_ARRAY(coder, managedStepIdentifiers, NSString);
+        ORK_DECODE_OBJ_CLASS(coder, restoredTaskIdentifier, NSString);
         
-        _restoredTaskIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORKTaskIdentifierRestoreKey];
         if (_restoredTaskIdentifier) {
             if (![_task.identifier isEqualToString:_restoredTaskIdentifier]) {
                 @throw [NSException exceptionWithName:NSInternalInconsistencyException
@@ -1666,12 +1673,13 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
         }
         
         if ([_task respondsToSelector:@selector(stepWithIdentifier:)]) {
-            _hasSetProgressLabel = [coder decodeBoolForKey:_ORKHasSetProgressLabelRestoreKey];
-            _requestedHealthTypesForRead = [coder decodeObjectOfClass:[NSSet class] forKey:_ORKRequestedHealthTypesForReadRestoreKey];
-            _requestedHealthTypesForWrite = [coder decodeObjectOfClass:[NSSet class] forKey:_ORKRequestedHealthTypesForWriteRestoreKey];
-            _presentedDate = [coder decodeObjectOfClass:[NSDate class] forKey:_ORKPresentedDate];
-            _lastBeginningInstructionStepIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORKLastBeginningInstructionStepIdentifierKey];
+            ORK_DECODE_BOOL(coder, hasSetProgressLabel);
+            ORK_DECODE_OBJ_CLASS(coder, requestedHealthTypesForRead, NSSet);
+            ORK_DECODE_OBJ_CLASS(coder, requestedHealthTypesForWrite, NSSet);
+            ORK_DECODE_OBJ_CLASS(coder, presentedDate, NSDate);
+            ORK_DECODE_OBJ_CLASS(coder, lastBeginningInstructionStepIdentifier, NSString);
             
+            // manually decoded due to mapping into custom ivar
             _restoredStepIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORKStepIdentifierRestoreKey];
         } else {
             ORK_Log_Warning(@"Not restoring current step of task %@ because it does not implement -stepWithIdentifier:", _task.identifier);


### PR DESCRIPTION
The changes in https://github.com/CareEvolution/ResearchKit/pull/119 broke saving/restoring tasks due to an exception being thrown and swallowed due to not all needed classes being explicitly included in the calls to the secure decoder.

This PR attempt to use the macros defined in `ORK[1]Helpers_Internal` to perform the decoding. However, these macros assume the local private ivar has an underscore of the passed string so there are a few cases where this won't work reliably. A warning showed in the console when decoding an object with a base class of NSObject stating that this essentially defeats the purpose of secure decoding since it can decode anything that inherits from NSObject and will become an error in the future. In an audit of all macros using NSObject, I found one I could reliably improve because only 2 classes could be in that array. The others appear to resolve `id` types, basically due to the loose typing of the result which can be an array, a value, among other things. I started a trace of the data types and have come up with:
- NSNumber
- NSTimeInterval
- ORK1Location
- ORK1NullAnswerValue
- NSDateComponents
- NSDate
- NSString
- NSDecimalNumber
I'm a little leery to make these replacements now, but in case that warning does become an error before we have this resolved, this serves as a reference.

To also assist with the current changes and the future if we do replace those NSObjects, a robust set of tests have been added to CEVResearchKit in https://github.com/CareEvolution/CEVResearchKit/pull/273.