### PR TITLE
Round weight for USC to match what picker allows

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -2918,6 +2918,11 @@ static NSString *const kSecureTextEntryEscapeString = @"*";
         if (self.useMetricSystem) {
             answerString = [NSString stringWithFormat:@"%@ %@", [formatter stringFromNumber:answer], ORK1LocalizedString(@"MEASURING_UNIT_KG", nil)];
         } else {
+            if (self.numericPrecision == ORK1NumericPrecisionHigh) {
+                formatter.maximumFractionDigits = 1;
+            } else {
+                formatter.maximumFractionDigits = 0;
+            }
             double pounds = ORK1KilogramsToPounds(((NSNumber *)answer).doubleValue);
             NSString *poundsString = [formatter stringFromNumber:@(pounds)];
             answerString = [NSString stringWithFormat:@"%@ %@", poundsString, ORK1LocalizedString(@"MEASURING_UNIT_LB", nil)];


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/RKStudio-Participant/issues/1124. Also tested Low/High precision for Height and Weight for USC and Metric to see that display matches precision - Weight-USC was the only case affected.