### PR TITLE
Support "url" property in WebViewSteps

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStep.h
@@ -62,6 +62,15 @@ ORK1_CLASS_AVAILABLE
                                   baseURL:(nullable NSURL *)baseURL;
 
 /**
+ Returns a new web view step that includes the specified identifier and will display the resource at the specified URL.
+ 
+ @param identifier    The identifier of the step (a step identifier should be unique within the task).
+ @param url    The URL of an external resource to display.
+ */
++ (instancetype)webViewStepWithIdentifier:(NSString *)identifier
+                                      url:(NSURL *)url;
+
+/**
  Embedded html used for displaying the webview.
  */
 @property (nonatomic, copy, nullable) NSString *html;
@@ -70,6 +79,11 @@ ORK1_CLASS_AVAILABLE
  Base URL for embedded html.
  */
 @property (nonatomic, copy, nullable) NSURL *baseURL;
+
+/**
+ The URL of an external resource to display.
+ */
+@property (nonatomic, copy, nullable) NSURL *url;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStep.m
@@ -44,15 +44,25 @@
     ORK1WebViewStep *step = [[ORK1WebViewStep alloc] initWithIdentifier:identifier];
     step.html = html;
     step.baseURL = baseURL;
+    step.url = nil;
+    return step;
+}
+
++ (instancetype)webViewStepWithIdentifier:(NSString *)identifier
+                                      url:(NSURL *)url {
+    ORK1WebViewStep *step = [[ORK1WebViewStep alloc] initWithIdentifier:identifier];
+    step.html = nil;
+    step.baseURL = nil;
+    step.url = url;
     return step;
 }
 
 - (void)validateParameters {
     [super validateParameters];
     
-    if (self.html == nil) {
+    if (self.html == nil && self.url == nil) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"WebViewStep requires html property."
+                                       reason:@"WebViewStep requires html or url property."
                                      userInfo:nil];
     }
 }
@@ -62,6 +72,7 @@
     if (self) {
         ORK1_DECODE_OBJ_CLASS(aDecoder, html, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, baseURL, NSURL);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, url, NSURL);
     }
     return self;
 }
@@ -70,6 +81,7 @@
     [super encodeWithCoder:aCoder];
     ORK1_ENCODE_OBJ(aCoder, html);
     ORK1_ENCODE_OBJ(aCoder, baseURL);
+    ORK1_ENCODE_OBJ(aCoder, url);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -80,6 +92,7 @@
     ORK1WebViewStep *step = [super copyWithZone:zone];
     step.html = self.html;
     step.baseURL = self.baseURL;
+    step.url = self.url;
     return step;
 }
 
@@ -88,8 +101,9 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            [self.html isEqual:castObject.html] &&
-            [self.baseURL isEqual:castObject.baseURL]);
+            ORK1EqualObjects(self.html, castObject.html) &&
+            ORK1EqualObjects(self.baseURL, castObject.baseURL) &&
+            ORK1EqualObjects(self.url, castObject.url));
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -66,7 +66,13 @@ ORK1_CLASS_AVAILABLE
  */
 ORK1_CLASS_AVAILABLE
 @interface ORK1WebViewStepViewController : ORK1StepViewController<WKScriptMessageHandler, WKNavigationDelegate>
+
+// Guaranteed to be non-nil after this view controller's init.
 @property (nonatomic, strong, readonly) WKWebView *webView;
+
+// Set these properties before the first viewWillAppear event, or in the `stepViewControllerWillAppear` delegate method.
+
+@property (nonatomic) BOOL reloadContentOnFirstAppearance;
 @property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
 @property (nonatomic, strong) NSArray<NSString *> *scriptMessageNames;
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -35,11 +35,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ORK1WebViewStep;
+
 ORK1_CLASS_AVAILABLE
+/// Caches at most exactly one instance of a WKWebView.
+///
+/// Intended for offscreen loading of web content before there is a view controller to contain the web view, so that the content is ready to immediately render once it is time to display on-screen.
 @interface ORK1WebViewPreloader : NSObject
+
+/// A singleton instance.
 + (instancetype)shared;
-- (void)preload:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL forKey:(NSString *)key;
-- (WKWebView *)webViewForKey:(NSString *)key baseURL:(nullable NSURL *)baseURL;
+
+@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
+@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
+
+/// Creates and stores a web view, and immediately begins loading content in the view as specified by the `webViewStep`. Replaces any previously stored web view.
+/// - Parameters:
+///   - webViewStep: Defines the content to load in the web view.
+///   - key: A unique identifier for the web view.
+- (void)preload:(ORK1WebViewStep *)webViewStep forKey:(NSString *)key;
+
 @end
 
 /**

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -119,6 +119,7 @@
         };
         
         _webView = [[ORK1WebViewPreloader shared] preloadedWebViewForKey:step.identifier];
+        BOOL preloaded = (_webView != nil);
         if (!_webView) {
             _webView = [[ORK1WebViewPreloader shared] makeWebView:nil];
         }
@@ -129,7 +130,9 @@
         _webView.navigationDelegate = self;
         
         _result = nil;
-        [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        if (!preloaded) {
+            [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        }
         
         [self.view addSubview:_webView];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
@@ -139,6 +142,16 @@
 
 - (ORK1WebViewStep *)webViewStep {
     return (ORK1WebViewStep *)self.step;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    BOOL firstAppearance = !self.hasBeenPresented;
+    [super viewWillAppear:animated];
+    
+    if (firstAppearance && self.reloadContentOnFirstAppearance) {
+        _result = nil;
+        [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -50,25 +50,28 @@
     if ((self = [super init])) {
         _cache = [[NSCache alloc] init];
         _cache.countLimit = 1;
+        self.remoteURLCachePolicy = NSURLRequestUseProtocolCachePolicy;
+        self.remoteURLTimeoutInterval = 30;
     }
     return self;
 }
 
-- (void)preload:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL forKey:(nonnull NSString *)key {
-    WKWebView *webView = [self newWebView:htmlString baseURL:baseURL];
-    [_cache setObject:webView forKey:key];
-}
-
-- (WKWebView *)webViewForKey:(NSString *)key baseURL:(nullable NSURL *)baseURL {
+- (nullable WKWebView *)preloadedWebViewForKey:(NSString *)key {
     WKWebView *webView = [_cache objectForKey:key];
     [_cache removeObjectForKey:key];
-    if (webView == nil) {
-        webView = [self newWebView:nil baseURL:baseURL];
-    }
     return webView;
 }
 
-- (WKWebView *)newWebView:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL {
+- (void)loadContentForStep:(nullable ORK1WebViewStep *)webViewStep withWebView:(WKWebView *)webView {
+    if (webViewStep.url) {
+        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
+        [webView loadRequest:request];
+    } else if (webViewStep.html) {
+        [webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
+    }
+}
+
+- (WKWebView *)makeWebView:(nullable ORK1WebViewStep *)webViewStep {
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
     config.allowsInlineMediaPlayback = true;
     if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
@@ -78,10 +81,13 @@
     config.userContentController = controller;
     
     WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
-    if (htmlString) {
-        [webView loadHTMLString:htmlString baseURL:baseURL];
-    }
+    [self loadContentForStep:webViewStep withWebView:webView];
     return webView;
+}
+
+- (void)preload:(ORK1WebViewStep *)webViewStep forKey:(NSString *)key {
+    WKWebView *webView = [self makeWebView:webViewStep];
+    [_cache setObject:webView forKey:key];
 }
 
 @end
@@ -112,12 +118,19 @@
             [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
         };
         
-        _webView = [[ORK1WebViewPreloader shared] webViewForKey:step.identifier baseURL:[self webViewStep].baseURL];
+        _webView = [[ORK1WebViewPreloader shared] preloadedWebViewForKey:step.identifier];
+        if (!_webView) {
+            _webView = [[ORK1WebViewPreloader shared] makeWebView:nil];
+        }
+        
         [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
         _webView.frame = self.view.bounds;
         _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _webView.navigationDelegate = self;
-        [_webView loadHTMLString:[self webViewStep].html baseURL:[self webViewStep].baseURL];
+        
+        _result = nil;
+        [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        
         [self.view addSubview:_webView];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
@@ -126,11 +139,6 @@
 
 - (ORK1WebViewStep *)webViewStep {
     return (ORK1WebViewStep *)self.step;
-}
-
-- (void)stepDidChange {
-    _result = nil;
-    [_webView loadHTMLString:[self webViewStep].html baseURL:[self webViewStep].baseURL];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/ResearchKit/Common/ORKWebViewStep.h
+++ b/ResearchKit/Common/ORKWebViewStep.h
@@ -62,6 +62,15 @@ ORK_CLASS_AVAILABLE
                                   baseURL:(nullable NSURL *)baseURL;
 
 /**
+ Returns a new web view step that includes the specified identifier and will display the resource at the specified URL.
+ 
+ @param identifier    The identifier of the step (a step identifier should be unique within the task).
+ @param url    The URL of an external resource to display.
+ */
++ (instancetype)webViewStepWithIdentifier:(NSString *)identifier
+                                      url:(NSURL *)url;
+
+/**
  Embedded html used for displaying the webview.
  */
 @property (nonatomic, copy, nullable) NSString *html;
@@ -70,6 +79,11 @@ ORK_CLASS_AVAILABLE
  Base URL for embedded html.
  */
 @property (nonatomic, copy, nullable) NSURL *baseURL;
+
+/**
+ The URL of an external resource to display.
+ */
+@property (nonatomic, copy, nullable) NSURL *url;
 
 @end
 

--- a/ResearchKit/Common/ORKWebViewStep.m
+++ b/ResearchKit/Common/ORKWebViewStep.m
@@ -47,12 +47,21 @@
     return step;
 }
 
++ (instancetype)webViewStepWithIdentifier:(NSString *)identifier
+                                      url:(NSURL *)url {
+    ORKWebViewStep *step = [[ORKWebViewStep alloc] initWithIdentifier:identifier];
+    step.html = nil;
+    step.baseURL = nil;
+    step.url = url;
+    return step;
+}
+
 - (void)validateParameters {
     [super validateParameters];
     
-    if (self.html == nil) {
+    if (self.html == nil && self.url == nil) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                       reason:@"WebViewStep requires html property."
+                                       reason:@"WebViewStep requires html or url property."
                                      userInfo:nil];
     }
 }
@@ -62,6 +71,7 @@
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, html, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, baseURL, NSURL);
+        ORK_DECODE_OBJ_CLASS(aDecoder, url, NSURL);
     }
     return self;
 }
@@ -70,6 +80,7 @@
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, html);
     ORK_ENCODE_OBJ(aCoder, baseURL);
+    ORK_ENCODE_OBJ(aCoder, url);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -80,6 +91,7 @@
     ORKWebViewStep *step = [super copyWithZone:zone];
     step.html = self.html;
     step.baseURL = self.baseURL;
+    step.url = self.url;
     return step;
 }
 
@@ -88,8 +100,9 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            [self.html isEqual:castObject.html] &&
-            [self.baseURL isEqual:castObject.baseURL]);
+            ORKEqualObjects(self.html, castObject.html) &&
+            ORKEqualObjects(self.baseURL, castObject.baseURL) &&
+            ORKEqualObjects(self.url, castObject.url));
 }
 
 @end

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -65,7 +65,13 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKWebViewStepViewController : ORKStepViewController<WKScriptMessageHandler, WKNavigationDelegate>
+
+// Guaranteed to be non-nil after this view controller's init.
 @property (nonatomic, strong, readonly) WKWebView *webView;
+
+// Set these properties before the first viewWillAppear event, or in the `stepViewControllerWillAppear` delegate method.
+
+@property (nonatomic) BOOL reloadContentOnFirstAppearance;
 @property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
 @property (nonatomic, strong) NSArray<NSString *> *scriptMessageNames;
 @end

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -34,11 +34,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ORKWebViewStep;
+
 ORK_CLASS_AVAILABLE
+/// Caches at most exactly one instance of a WKWebView.
+///
+/// Intended for offscreen loading of web content before there is a view controller to contain the web view, so that the content is ready to immediately render once it is time to display on-screen.
 @interface ORKWebViewPreloader : NSObject
+
+/// A singleton instance.
 + (instancetype)shared;
-- (void)preload:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL forKey:(NSString *)key;
-- (WKWebView *)webViewForKey:(NSString *)key baseURL:(nullable NSURL *)baseURL;
+
+@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
+@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
+
+/// Creates and stores a web view, and immediately begins loading content in the view as specified by the `webViewStep`. Replaces any previously stored web view.
+/// - Parameters:
+///   - webViewStep: Defines the content to load in the web view.
+///   - key: A unique identifier for the web view.
+- (void)preload:(ORKWebViewStep *)webViewStep forKey:(NSString *)key;
+
 @end
 
 /**

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -132,6 +132,7 @@
         };
         
         _webView = [[ORKWebViewPreloader shared] preloadedWebViewForKey:step.identifier];
+        BOOL preloaded = (_webView != nil);
         if (!_webView) {
             _webView = [[ORKWebViewPreloader shared] makeWebView:nil];
         }
@@ -142,7 +143,9 @@
         _webView.navigationDelegate = self;
         
         _result = nil;
-        [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        if (!preloaded) {
+            [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        }
         
         [self.view addSubview:_webView];
         [self setupNavigationFooterView];
@@ -153,14 +156,20 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    BOOL firstAppearance = !self.hasBeenPresented;
+    [super viewWillAppear:animated];
+    
     /*
      CEVHACK - This fixes a bug that affects RK2 where the cancel button did nothing - because the view cycle is different than
      other subclasses of ORKStepViewController. Setting the cancelButtonItem on the _navigationFooterView needs to happen AFTER
      the super class ORKStepViewController has had a chance to create it.
      */
-    
-    [super viewWillAppear:animated];
     _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+    
+    if (firstAppearance && self.reloadContentOnFirstAppearance) {
+        _result = nil;
+        [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+    }
 }
 
 - (void)setupNavigationFooterView {

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -57,25 +57,28 @@
     if ((self = [super init])) {
         _cache = [[NSCache alloc] init];
         _cache.countLimit = 1;
+        self.remoteURLCachePolicy = NSURLRequestUseProtocolCachePolicy;
+        self.remoteURLTimeoutInterval = 30;
     }
     return self;
 }
 
-- (void)preload:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL forKey:(nonnull NSString *)key {
-    WKWebView *webView = [self newWebView:htmlString baseURL:baseURL];
-    [_cache setObject:webView forKey:key];
-}
-
-- (WKWebView *)webViewForKey:(NSString *)key baseURL:(nullable NSURL *)baseURL {
+- (nullable WKWebView *)preloadedWebViewForKey:(NSString *)key {
     WKWebView *webView = [_cache objectForKey:key];
     [_cache removeObjectForKey:key];
-    if (webView == nil) {
-        webView = [self newWebView:nil baseURL:baseURL];
-    }
     return webView;
 }
 
-- (WKWebView *)newWebView:(NSString *)htmlString baseURL:(nullable NSURL *)baseURL {
+- (void)loadContentForStep:(nullable ORKWebViewStep *)webViewStep withWebView:(WKWebView *)webView {
+    if (webViewStep.url) {
+        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
+        [webView loadRequest:request];
+    } else if (webViewStep.html) {
+        [webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
+    }
+}
+
+- (WKWebView *)makeWebView:(nullable ORKWebViewStep *)webViewStep {
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
     config.allowsInlineMediaPlayback = true;
     if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
@@ -85,10 +88,13 @@
     config.userContentController = controller;
     
     WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
-    if (htmlString) {
-        [webView loadHTMLString:htmlString baseURL:baseURL];
-    }
+    [self loadContentForStep:webViewStep withWebView:webView];
     return webView;
+}
+
+- (void)preload:(ORKWebViewStep *)webViewStep forKey:(NSString *)key {
+    WKWebView *webView = [self makeWebView:webViewStep];
+    [_cache setObject:webView forKey:key];
 }
 
 @end
@@ -116,11 +122,6 @@
     return (ORKWebViewStep *)self.step;
 }
 
-- (void)stepDidChange {
-    _result = nil;
-    [_webView loadHTMLString:[self webViewStep].html baseURL:[self webViewStep].baseURL];
-}
-
 - (instancetype)initWithStep:(ORKStep *)step {
     self = [super initWithStep:step];
     if (self) {
@@ -130,12 +131,19 @@
             [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
         };
         
-        _webView = [[ORKWebViewPreloader shared] webViewForKey:step.identifier baseURL:[self webViewStep].baseURL];
+        _webView = [[ORKWebViewPreloader shared] preloadedWebViewForKey:step.identifier];
+        if (!_webView) {
+            _webView = [[ORKWebViewPreloader shared] makeWebView:nil];
+        }
+        
         [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
         _webView.frame = self.view.bounds;
         _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _webView.navigationDelegate = self;
-        [_webView loadHTMLString:[self webViewStep].html baseURL:[self webViewStep].baseURL];
+        
+        _result = nil;
+        [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        
         [self.view addSubview:_webView];
         [self setupNavigationFooterView];
         [self setupConstraints];
@@ -226,11 +234,6 @@
                                                    constant:0.0]
                      ];
     [NSLayoutConstraint activateConstraints:_constraints];
-}
-
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self stepDidChange];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
Adds a `url` property to ORK[1]WebViewStep, as an alternative to the `html` property, to display content from an external resource in a web view step.

ORK[1]WebViewStepViewController and ORK[1]WebViewPreloader are updated to load content from the external URL when provided. Some related refactoring and interface changes:

- The Preloader has public properties for customizing the cache and timeout behavior for external URL loading.
- The `webViewForKey` getter method in the Preloader is no longer public, now returns nil if there is no cached web view, and has an internally-accessible method to construct an empty web view when needed.
- Previously, the view controller always reloads the web view's content: it assumes any preloaded web view may have outdated content that must be reloaded. Now, the app using ResearchKit can control this behavior via the `reloadContentOnFirstAppearance` property to make the behavior more explicit.

## Testing

See related PRs
