### PR TITLE
WebViewStep updates and refactoring

### DIFF
--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		959A2C0E1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 959A2C0C1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m */; };
 		95E11E551D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 95E11E531D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h */; };
 		95E11E561D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95E11E541D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m */; };
+		AC6BDFA22967193E0030A1CB /* ORK1WebViewStepViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AC6BDFA12967193E0030A1CB /* ORK1WebViewStepViewControllerTests.m */; };
 		AC9069B425080B5500910AB7 /* ORK1DocumentSelectionStep.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069B225080B5500910AB7 /* ORK1DocumentSelectionStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC9069B525080B5500910AB7 /* ORK1DocumentSelectionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */; };
 		AC9069B82508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1060,6 +1061,7 @@
 		959A2C0C1D68C91400841B04 /* ORK1ShoulderRangeOfMotionStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ShoulderRangeOfMotionStep.m; sourceTree = "<group>"; };
 		95E11E531D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORK1ShoulderRangeOfMotionStepViewController.h; sourceTree = "<group>"; };
 		95E11E541D73396300BF865B /* ORK1ShoulderRangeOfMotionStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORK1ShoulderRangeOfMotionStepViewController.m; sourceTree = "<group>"; };
+		AC6BDFA12967193E0030A1CB /* ORK1WebViewStepViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1WebViewStepViewControllerTests.m; sourceTree = "<group>"; };
 		AC9069B225080B5500910AB7 /* ORK1DocumentSelectionStep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentSelectionStep.h; sourceTree = "<group>"; };
 		AC9069B325080B5500910AB7 /* ORK1DocumentSelectionStep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORK1DocumentSelectionStep.m; sourceTree = "<group>"; };
 		AC9069B62508149C00910AB7 /* ORK1DocumentSelectionStepViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORK1DocumentSelectionStepViewController.h; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 				2EBFE11F1AE1B74100CB8254 /* ORK1VoiceEngineTests.m */,
 				DA5D7F4F28C940FE00C5E50C /* ORK1KitTests-Bridging-Header.h */,
 				DA5D7F5028C940FE00C5E50C /* ORK1SkinSwiftTests.swift */,
+				AC6BDFA12967193E0030A1CB /* ORK1WebViewStepViewControllerTests.m */,
 			);
 			path = ORK1KitTests;
 			sourceTree = "<group>";
@@ -3164,6 +3167,7 @@
 				BCAD50E81B0201EE0034806A /* ORK1TaskTests.m in Sources */,
 				86CC8EBB1AC09383001CCD89 /* ORK1TextChoiceCellGroupTests.m in Sources */,
 				FA7A9D2B1B082688005A2BEA /* ORK1ConsentDocumentTests.m in Sources */,
+				AC6BDFA22967193E0030A1CB /* ORK1WebViewStepViewControllerTests.m in Sources */,
 				FA7A9D371B09365F005A2BEA /* ORK1ConsentSectionFormatterTests.m in Sources */,
 				86D348021AC161B0006DB02B /* ORK1RecorderTests.m in Sources */,
 				86CC8EB61AC09383001CCD89 /* ORK1DataLoggerManagerTests.m in Sources */,

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -65,6 +65,8 @@ ORK1_CLASS_AVAILABLE
 + (void)setFallbackTaskViewController:(nullable ORK1TaskViewController *)taskViewController;
 - (nonnull instancetype)initWithType:(CEVRK1ThemeType)type;
 
+@property (nonatomic, strong, nonnull) NSDictionary *properties;
+
 @property (nonatomic, strong) UIColor * _Nullable tintColor;
 
 @property (nonatomic, strong, nullable) CEVRK1TextStyle *titleStyle;

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -52,6 +52,11 @@
 
 + (CEVRK1Theme *)themeByOverridingTheme:(nullable CEVRK1Theme *)theme withTheme:(nullable CEVRK1Theme *)theme2 {
     CEVRK1Theme *merged = [[CEVRK1Theme alloc] init];
+    
+    NSMutableDictionary *mergedProperties = [theme.properties mutableCopy];
+    [mergedProperties addEntriesFromDictionary:theme2.properties];
+    merged.properties = mergedProperties;
+    
     merged.tintColor = theme2.tintColor ?: theme.tintColor;
     
     merged.titleStyle = [CEVRK1Theme textStyleByOverridingTextStyle:theme.titleStyle withTextStyle:theme2.titleStyle];
@@ -137,6 +142,14 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
         return self;
     }
     return nil;
+}
+
+- (NSDictionary *)properties {
+    if (_properties) {
+        return _properties;
+    } else {
+        return [[NSDictionary alloc] init];
+    }
 }
 
 - (NSMutableDictionary *)textAttributesForView:(UIView *)view {

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017, CareEvolution, Inc.
+ Copyright (c) 2017, CareEvolution, LLC.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -35,46 +35,46 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ORK1WebViewStep;
-
-ORK1_CLASS_AVAILABLE
-/// Caches at most exactly one instance of a WKWebView.
-///
-/// Intended for offscreen loading of web content before there is a view controller to contain the web view, so that the content is ready to immediately render once it is time to display on-screen.
-@interface ORK1WebViewPreloader : NSObject
-
-/// A singleton instance.
-+ (instancetype)shared;
-
-@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
-@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
-
-/// Creates and stores a web view, and immediately begins loading content in the view as specified by the `webViewStep`. Replaces any previously stored web view.
-/// - Parameters:
-///   - webViewStep: Defines the content to load in the web view.
-///   - key: A unique identifier for the web view.
-- (void)preload:(ORK1WebViewStep *)webViewStep forKey:(NSString *)key;
-
-@end
-
 /**
  The `ORK1WebViewStepViewController` class is a step view controller subclass
  used to manage a web view step (`ORK1WebViewStep`).
- 
- You should not need to instantiate a web view step view controller directly. Instead, include
- a web view step in a task, and present a task view controller for that task.
  */
 ORK1_CLASS_AVAILABLE
 @interface ORK1WebViewStepViewController : ORK1StepViewController<WKScriptMessageHandler, WKNavigationDelegate>
 
-// Guaranteed to be non-nil after this view controller's init.
+/// Guaranteed to be non-nil after this view controller is initialized.
 @property (nonatomic, strong, readonly) WKWebView *webView;
 
-// Set these properties before the first viewWillAppear event, or in the `stepViewControllerWillAppear` delegate method.
+/// The set of all WebKit Javascript bridge message names that should be passed to the ``scriptMessageHandler``.
+@property (nonatomic, readonly) NSSet<NSString *> *scriptMessageNames;
 
-@property (nonatomic) BOOL reloadContentOnFirstAppearance;
+/// The delegate object that will receive any script messages identified by ``scriptMessageNames``.
+///
+/// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+///
+/// See ``WKScriptMessageHandler`` for more information.
 @property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
-@property (nonatomic, strong) NSArray<NSString *> *scriptMessageNames;
+
+/// Creates a web view and immediately begins loading content in the web view as specified by the step definition.
+///
+/// Use this initializer to pre-load a web view step offscreen so it can be ready to render immediately when it is time to present the step.
+///
+/// The `scriptMessageHandler` is initialized as `nil`. Any incoming script messages received while `scriptMessageHandler` is nil will be enqueued for later processing. Interactivity can thus be delayed until this view controller is ready to display, for example by waiting to set a `scriptMessageHandler` until this view controller's `viewWillAppear` lifecycle event.
+/// - Parameters:
+///   - step: Must be an `ORK1WebViewStep`.
+///   - scriptMessageNames: A set of custom WebKit message names to declare as supported. See ``scriptMessageHandler``.
+///   - remoteURLCachePolicy: Cache policy for loading URL-based web view steps.
+///   - remoteURLTimeoutInterval: Timeout interval for loading URL-based web view steps.
+- (instancetype)initWithStep:(ORK1Step *)step
+          scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
+        remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
+    remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval;
+
+/// Immediately reloads the content specified by this view controller's web view step.
+///
+/// Use this to prepare a view controller previously loaded offscreen with the latest step content. This discards any enqueued WebKit script messages.
+- (void)reloadWebContent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017, CareEvolution, Inc.
+ Copyright (c) 2017, CareEvolution, LLC.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -33,108 +33,56 @@
 #import <ORK1Kit/ORK1Result.h>
 @import SafariServices;
 
-@implementation ORK1WebViewPreloader {
-    NSCache *_cache;
-}
+static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
-+ (instancetype)shared {
-    static ORK1WebViewPreloader *shared;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        shared = [[ORK1WebViewPreloader alloc] init];
-    });
-    return shared;
-}
-
-- (instancetype)init {
-    if ((self = [super init])) {
-        _cache = [[NSCache alloc] init];
-        _cache.countLimit = 1;
-        self.remoteURLCachePolicy = NSURLRequestUseProtocolCachePolicy;
-        self.remoteURLTimeoutInterval = 30;
-    }
-    return self;
-}
-
-- (nullable WKWebView *)preloadedWebViewForKey:(NSString *)key {
-    WKWebView *webView = [_cache objectForKey:key];
-    [_cache removeObjectForKey:key];
-    return webView;
-}
-
-- (void)loadContentForStep:(nullable ORK1WebViewStep *)webViewStep withWebView:(WKWebView *)webView {
-    if (webViewStep.url) {
-        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
-        [webView loadRequest:request];
-    } else if (webViewStep.html) {
-        [webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
-    }
-}
-
-- (WKWebView *)makeWebView:(nullable ORK1WebViewStep *)webViewStep {
-    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    config.allowsInlineMediaPlayback = true;
-    if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
-        config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    }
-    WKUserContentController *controller = [[WKUserContentController alloc] init];
-    config.userContentController = controller;
-    
-    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
-    [self loadContentForStep:webViewStep withWebView:webView];
-    return webView;
-}
-
-- (void)preload:(ORK1WebViewStep *)webViewStep forKey:(NSString *)key {
-    WKWebView *webView = [self makeWebView:webViewStep];
-    [_cache setObject:webView forKey:key];
-}
-
-@end
-
-@interface ORK1ScriptMessageHandlerImpl: NSObject <WKScriptMessageHandler>
-@property (nonatomic, copy, nullable) void (^didReceiveScriptMessageFunc)(WKUserContentController *, WKScriptMessage *);
-@end
-
-@implementation ORK1ScriptMessageHandlerImpl
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
-    if (self.didReceiveScriptMessageFunc != nil) {
-        self.didReceiveScriptMessageFunc(userContentController, message);
-    }
-}
+@interface ORK1WebViewStepViewController ()
+@property (nonatomic, strong) NSMutableArray *scriptMessageQueue;
+@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
+@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
 @end
 
 @implementation ORK1WebViewStepViewController {
     NSString *_result;
-    ORK1ScriptMessageHandlerImpl *_scriptMessageHandlerImpl;
 }
 
+#pragma mark Public Interface
+
 - (instancetype)initWithStep:(ORK1Step *)step {
+    return [self initWithStep:step scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+}
+
+- (instancetype)initWithStep:(ORK1Step *)step
+          scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
+        remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
+    remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval {
     self = [super initWithStep:step];
     if (self) {
-        __weak typeof(self) weakSelf = self;
-        _scriptMessageHandlerImpl = [[ORK1ScriptMessageHandlerImpl alloc] init];
-        _scriptMessageHandlerImpl.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
-            [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
-        };
-        
-        _webView = [[ORK1WebViewPreloader shared] preloadedWebViewForKey:step.identifier];
-        BOOL preloaded = (_webView != nil);
-        if (!_webView) {
-            _webView = [[ORK1WebViewPreloader shared] makeWebView:nil];
-        }
-        
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
-        _webView.frame = self.view.bounds;
-        _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        _webView.navigationDelegate = self;
+        NSParameterAssert([step isKindOfClass:[ORK1WebViewStep class]]);
         
         _result = nil;
-        if (!preloaded) {
-            [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+        _scriptMessageHandler = nil;
+        _scriptMessageQueue = [NSMutableArray array];
+        _scriptMessageNames = [scriptMessageNames copy];
+        _remoteURLCachePolicy = remoteURLCachePolicy;
+        _remoteURLTimeoutInterval = remoteURLTimeoutInterval;
+        
+        WKUserContentController *controller = [[WKUserContentController alloc] init];
+        [controller addScriptMessageHandler:self name:ResearchKitCompleteStepMessageName];
+        for (NSString *name in scriptMessageNames) {
+            [controller addScriptMessageHandler:self name:name];
         }
         
-        [self.view addSubview:_webView];
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.allowsInlineMediaPlayback = true;
+        if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
+            config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+        }
+        config.userContentController = controller;
+        _webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
+        _webView.navigationDelegate = self;
+        
+        [self loadWebContent];
+        
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
     return self;
@@ -144,14 +92,35 @@
     return (ORK1WebViewStep *)self.step;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    BOOL firstAppearance = !self.hasBeenPresented;
-    [super viewWillAppear:animated];
-    
-    if (firstAppearance && self.reloadContentOnFirstAppearance) {
-        _result = nil;
-        [[ORK1WebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
+- (void)setScriptMessageHandler:(id<WKScriptMessageHandler>)scriptMessageHandler {
+    _scriptMessageHandler = scriptMessageHandler;
+    [self processQueuedScriptMessages];
+}
+
+- (void)reloadWebContent {
+    [self loadWebContent];
+}
+
+#pragma mark - ResearchKit
+
+- (ORK1StepResult *)result {
+    ORK1StepResult *parentResult = [super result];
+    if (parentResult) {
+        ORK1WebViewStepResult *childResult = [[ORK1WebViewStepResult alloc] initWithIdentifier:self.step.identifier];
+        childResult.result = _result;
+        childResult.endDate = parentResult.endDate;
+        parentResult.results = @[childResult];
     }
+    return parentResult;
+}
+
+#pragma mark - View Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    _webView.frame = self.view.bounds;
+    _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:_webView];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -165,27 +134,55 @@
     [_webView evaluateJavaScript:script completionHandler:nil];
 }
 
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
-{
-    if ([self.scriptMessageNames containsObject:message.name]) {
-        [self.scriptMessageHandler userContentController:userContentController didReceiveScriptMessage:message];
-        return;
-    }
-    if ([message.body isKindOfClass:[NSString class]]){
-        _result = (NSString *)message.body;
-        [self goForward];
+#pragma mark - Web Content Handling
+
+- (void)loadWebContent {
+    [self.scriptMessageQueue removeAllObjects];
+    _result = nil;
+    
+    ORK1WebViewStep *webViewStep = [self webViewStep];
+    if (webViewStep.url) {
+        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
+        [_webView loadRequest:request];
+    } else if ([self webViewStep].html) {
+        [_webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
     }
 }
 
-- (ORK1StepResult *)result {
-    ORK1StepResult *parentResult = [super result];
-    if (parentResult) {
-        ORK1WebViewStepResult *childResult = [[ORK1WebViewStepResult alloc] initWithIdentifier:self.step.identifier];
-        childResult.result = _result;
-        childResult.endDate = parentResult.endDate;
-        parentResult.results = @[childResult];
+- (void)processQueuedScriptMessages {
+    if (!self.scriptMessageHandler) { return; }
+    for (WKScriptMessage *message in self.scriptMessageQueue) {
+        BOOL stop = [self processScriptMessage:message];
+        if (stop) {
+            break;
+        }
     }
-    return parentResult;
+    [self.scriptMessageQueue removeAllObjects];
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    if (self.scriptMessageHandler) {
+        [self processScriptMessage:message];
+    } else {
+        [self.scriptMessageQueue addObject:message];
+    }
+}
+
+/// Returns YES if the view controller should stop processing any other messages. Assumes that the handler is ready to process the message.
+/// - Parameter message: The message to process.
+- (BOOL)processScriptMessage:(WKScriptMessage *)message {
+    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {
+        _result = (NSString *)message.body;
+        [self goForward];
+        return YES;
+    }
+    
+    if ([self.scriptMessageNames containsObject:message.name]) {
+        [self.scriptMessageHandler userContentController:self.webView.configuration.userContentController didReceiveScriptMessage:message];
+        return NO;
+    }
+    return NO;
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
@@ -210,13 +207,6 @@
         }
     }
     decisionHandler(WKNavigationActionPolicyAllow);
-}
-
-- (void)setScriptMessageNames:(NSArray<NSString *> *)scriptMessageNames {
-    _scriptMessageNames = scriptMessageNames;
-    for (NSString *i in scriptMessageNames) {
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:i];
-    }
 }
 
 @end

--- a/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
@@ -1,0 +1,132 @@
+/*
+ Copyright (c) 2023, CareEvolution, LLC.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+@import ORK1Kit.Private;
+@import WebKit;
+#import "ORK1WebViewStepViewController.h"
+
+@interface ORK1WebViewStepViewControllerTests : XCTestCase
+
+@end
+
+@interface MockScriptMessage: WKScriptMessage
+@property (nonatomic, strong) NSString *nameOverride;
+@property (nonatomic, strong) NSString *bodyOverride;
+- (instancetype)initWithName:(NSString *)name body:(NSString *)body;
+@end
+
+@implementation MockScriptMessage
+- (instancetype)initWithName:(NSString *)name body:(NSString *)body {
+    if (self = [super init]) {
+        _nameOverride = name;
+        _bodyOverride = body;
+    }
+    return self;
+}
+
+- (NSString *)name {
+    return _nameOverride;
+}
+- (id)body {
+    return _bodyOverride;
+}
+@end
+
+@interface TestScriptHandler: NSObject <WKScriptMessageHandler, ORK1StepViewControllerDelegate>
+@property (nonatomic, strong) NSMutableArray<NSString *> *events;
+@end
+
+@implementation TestScriptHandler
+- (instancetype)init {
+    if (self = [super init]) {
+        _events = [NSMutableArray array];
+    }
+    return self;
+}
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    [_events addObject:[NSString stringWithFormat:@"didReceiveScriptMessage:%@", message.name]];
+}
+- (void)stepViewController:(ORK1StepViewController *)stepViewController didFinishWithNavigationDirection:(ORK1StepViewControllerNavigationDirection)direction {
+    [_events addObject:[NSString stringWithFormat:@"didFinishWithNavigationDirection:%@", direction == ORK1StepViewControllerNavigationDirectionForward ? @"forward" : @"reverse"]];
+}
+- (void)stepViewControllerResultDidChange:(ORK1StepViewController *)stepViewController { }
+- (void)stepViewControllerDidFail:(ORK1StepViewController *)stepViewController withError:(NSError *)error { }
+- (void)stepViewController:(ORK1StepViewController *)stepViewController recorder:(ORK1Recorder *)recorder didFailWithError:(NSError *)error { }
+@end
+
+@implementation ORK1WebViewStepViewControllerTests
+
+- (ORK1WebViewStep *)webViewStep {
+    ORK1WebViewStep *step = [[ORK1WebViewStep alloc] initWithIdentifier:@"step"];
+    step.html = @"<html><body></body></html>";
+    return step;
+}
+
+- (void)testMessageQueue {
+    ORK1WebViewStep *webViewStep = [self webViewStep];
+    TestScriptHandler *handler = [[TestScriptHandler alloc] init];
+    ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    viewController.delegate = handler;
+    
+    WKScriptMessage *messageA1 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
+    WKScriptMessage *messageA2 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
+    WKScriptMessage *messageB = [[MockScriptMessage alloc] initWithName:@"MessageB" body:nil];
+    WKScriptMessage *messageC = [[MockScriptMessage alloc] initWithName:@"MessageC" body:nil];
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result"];
+    
+    // Send some messages before setting a handler; they should be enqueued for later processing.
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA1];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageB];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageC];
+    
+    viewController.scriptMessageHandler = handler;
+    
+    XCTAssertEqual(handler.events.count, 2, @"Two queued messages processed after setting the script handler, one unsupported message ignored");
+    if (handler.events.count == 2) {
+        XCTAssertEqualObjects([handler.events objectAtIndex:0], @"didReceiveScriptMessage:MessageA");
+        XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didReceiveScriptMessage:MessageB");
+    }
+    [handler.events removeAllObjects];
+    
+    // Send some messages after setting a handler; they should be processed immediately.
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageC];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA2];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageResearchKit];
+    
+    XCTAssertEqual(handler.events.count, 2, @"One message processed immediately, one unsupported message ignored, ResearchKit (goForward) message not passed to handler.");
+    if (handler.events.count == 2) {
+        XCTAssertEqualObjects([handler.events objectAtIndex:0], @"didReceiveScriptMessage:MessageA");
+        XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didFinishWithNavigationDirection:forward");
+    }
+    [handler.events removeAllObjects];
+}
+
+@end

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		959A2C0E1D68C91400841B04 /* ORKShoulderRangeOfMotionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 959A2C0C1D68C91400841B04 /* ORKShoulderRangeOfMotionStep.m */; };
 		95E11E551D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 95E11E531D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.h */; };
 		95E11E561D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95E11E541D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.m */; };
+		AC6BDFA4296726F30030A1CB /* ORKWebViewStepViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AC6BDFA3296726F30030A1CB /* ORKWebViewStepViewControllerTests.m */; };
 		B11C54991A9EEF8800265E61 /* ORKConsentSharingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C54961A9EEF8800265E61 /* ORKConsentSharingStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B11C549B1A9EEF8800265E61 /* ORKConsentSharingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = B11C54971A9EEF8800265E61 /* ORKConsentSharingStep.m */; };
 		B11C549F1A9EF4A700265E61 /* ORKConsentSharingStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B11C549C1A9EF4A700265E61 /* ORKConsentSharingStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1269,6 +1270,7 @@
 		959A2C0C1D68C91400841B04 /* ORKShoulderRangeOfMotionStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKShoulderRangeOfMotionStep.m; sourceTree = "<group>"; };
 		95E11E531D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKShoulderRangeOfMotionStepViewController.h; sourceTree = "<group>"; };
 		95E11E541D73396300BF865B /* ORKShoulderRangeOfMotionStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKShoulderRangeOfMotionStepViewController.m; sourceTree = "<group>"; };
+		AC6BDFA3296726F30030A1CB /* ORKWebViewStepViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORKWebViewStepViewControllerTests.m; sourceTree = "<group>"; };
 		B11C54961A9EEF8800265E61 /* ORKConsentSharingStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSharingStep.h; sourceTree = "<group>"; };
 		B11C54971A9EEF8800265E61 /* ORKConsentSharingStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSharingStep.m; sourceTree = "<group>"; };
 		B11C549C1A9EF4A700265E61 /* ORKConsentSharingStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSharingStepViewController.h; sourceTree = "<group>"; };
@@ -2135,6 +2137,7 @@
 				86CC8EB01AC09383001CCD89 /* ORKTextChoiceCellGroupTests.m */,
 				2EBFE11C1AE1B32D00CB8254 /* ORKUIViewAccessibilityTests.m */,
 				2EBFE11F1AE1B74100CB8254 /* ORKVoiceEngineTests.m */,
+				AC6BDFA3296726F30030A1CB /* ORKWebViewStepViewControllerTests.m */,
 			);
 			path = ResearchKitTests;
 			sourceTree = "<group>";
@@ -3702,6 +3705,7 @@
 				BCB96C131B19C0EC002A0B96 /* ORKStepTests.m in Sources */,
 				86CC8EB51AC09383001CCD89 /* ORKConsentTests.m in Sources */,
 				2EBFE11D1AE1B32D00CB8254 /* ORKUIViewAccessibilityTests.m in Sources */,
+				AC6BDFA4296726F30030A1CB /* ORKWebViewStepViewControllerTests.m in Sources */,
 				86CC8EB41AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m in Sources */,
 				2EBFE1201AE1B74100CB8254 /* ORKVoiceEngineTests.m in Sources */,
 				BCAD50E81B0201EE0034806A /* ORKTaskTests.m in Sources */,

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1618,7 +1618,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder {
     
     /*
-     NOTE: this is manually (vs using ORK1_ENCODE_xxx) due to the conditional
+     NOTE: this is manually (vs using ORK_ENCODE_xxx) due to the conditional
      encoding of "stepIdentifier" (_ORKStepIdentifierRestoreKey)
      */
     

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017, CareEvolution, Inc.
+ Copyright (c) 2017, CareEvolution, LLC.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -34,46 +34,46 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ORKWebViewStep;
-
-ORK_CLASS_AVAILABLE
-/// Caches at most exactly one instance of a WKWebView.
-///
-/// Intended for offscreen loading of web content before there is a view controller to contain the web view, so that the content is ready to immediately render once it is time to display on-screen.
-@interface ORKWebViewPreloader : NSObject
-
-/// A singleton instance.
-+ (instancetype)shared;
-
-@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
-@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
-
-/// Creates and stores a web view, and immediately begins loading content in the view as specified by the `webViewStep`. Replaces any previously stored web view.
-/// - Parameters:
-///   - webViewStep: Defines the content to load in the web view.
-///   - key: A unique identifier for the web view.
-- (void)preload:(ORKWebViewStep *)webViewStep forKey:(NSString *)key;
-
-@end
-
 /**
  The `ORKWebViewStepViewController` class is a step view controller subclass
  used to manage a web view step (`ORKWebViewStep`).
- 
- You should not need to instantiate a web view step view controller directly. Instead, include
- a web view step in a task, and present a task view controller for that task.
  */
 ORK_CLASS_AVAILABLE
 @interface ORKWebViewStepViewController : ORKStepViewController<WKScriptMessageHandler, WKNavigationDelegate>
 
-// Guaranteed to be non-nil after this view controller's init.
+/// Guaranteed to be non-nil after this view controller is initialized.
 @property (nonatomic, strong, readonly) WKWebView *webView;
 
-// Set these properties before the first viewWillAppear event, or in the `stepViewControllerWillAppear` delegate method.
+/// The set of all WebKit Javascript bridge message names that should be passed to the ``scriptMessageHandler``.
+@property (nonatomic, readonly) NSSet<NSString *> *scriptMessageNames;
 
-@property (nonatomic) BOOL reloadContentOnFirstAppearance;
+/// The delegate object that will receive any script messages identified by ``scriptMessageNames``.
+///
+/// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+///
+/// See ``WKScriptMessageHandler`` for more information.
 @property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
-@property (nonatomic, strong) NSArray<NSString *> *scriptMessageNames;
+
+/// Creates a web view and immediately begins loading content in the web view as specified by the step definition.
+///
+/// Use this initializer to pre-load a web view step offscreen so it can be ready to render immediately when it is time to present the step.
+///
+/// The `scriptMessageHandler` is initialized as `nil`. Any incoming script messages received while `scriptMessageHandler` is nil will be enqueued for later processing. Interactivity can thus be delayed until this view controller is ready to display, for example by waiting to set a `scriptMessageHandler` until this view controller's `viewWillAppear` lifecycle event.
+/// - Parameters:
+///   - step: Must be an `ORKWebViewStep`.
+///   - scriptMessageNames: A set of custom WebKit message names to declare as supported. See ``scriptMessageHandler``.
+///   - remoteURLCachePolicy: Cache policy for loading URL-based web view steps.
+///   - remoteURLTimeoutInterval: Timeout interval for loading URL-based web view steps.
+- (instancetype)initWithStep:(ORKStep *)step
+          scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
+        remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
+    remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval;
+
+/// Immediately reloads the content specified by this view controller's web view step.
+///
+/// Use this to prepare a view controller previously loaded offscreen with the latest step content. This discards any enqueued WebKit script messages.
+- (void)reloadWebContent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2017, CareEvolution, Inc.
+ Copyright (c) 2017, CareEvolution, LLC.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -40,123 +40,101 @@
 #import <ResearchKit/ORKResult.h>
 @import SafariServices;
 
-@implementation ORKWebViewPreloader {
-    NSCache *_cache;
-}
+static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
-+ (instancetype)shared {
-    static ORKWebViewPreloader *shared;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        shared = [[ORKWebViewPreloader alloc] init];
-    });
-    return shared;
-}
-
-- (instancetype)init {
-    if ((self = [super init])) {
-        _cache = [[NSCache alloc] init];
-        _cache.countLimit = 1;
-        self.remoteURLCachePolicy = NSURLRequestUseProtocolCachePolicy;
-        self.remoteURLTimeoutInterval = 30;
-    }
-    return self;
-}
-
-- (nullable WKWebView *)preloadedWebViewForKey:(NSString *)key {
-    WKWebView *webView = [_cache objectForKey:key];
-    [_cache removeObjectForKey:key];
-    return webView;
-}
-
-- (void)loadContentForStep:(nullable ORKWebViewStep *)webViewStep withWebView:(WKWebView *)webView {
-    if (webViewStep.url) {
-        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
-        [webView loadRequest:request];
-    } else if (webViewStep.html) {
-        [webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
-    }
-}
-
-- (WKWebView *)makeWebView:(nullable ORKWebViewStep *)webViewStep {
-    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    config.allowsInlineMediaPlayback = true;
-    if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
-        config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    }
-    WKUserContentController *controller = [[WKUserContentController alloc] init];
-    config.userContentController = controller;
-    
-    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
-    [self loadContentForStep:webViewStep withWebView:webView];
-    return webView;
-}
-
-- (void)preload:(ORKWebViewStep *)webViewStep forKey:(NSString *)key {
-    WKWebView *webView = [self makeWebView:webViewStep];
-    [_cache setObject:webView forKey:key];
-}
-
-@end
-
-@interface ORKScriptMessageHandlerImpl: NSObject <WKScriptMessageHandler>
-@property (nonatomic, copy, nullable) void (^didReceiveScriptMessageFunc)(WKUserContentController *, WKScriptMessage *);
-@end
-
-@implementation ORKScriptMessageHandlerImpl
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
-    if (self.didReceiveScriptMessageFunc != nil) {
-        self.didReceiveScriptMessageFunc(userContentController, message);
-    }
-}
+@interface ORKWebViewStepViewController ()
+@property (nonatomic, strong) NSMutableArray *scriptMessageQueue;
+@property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
+@property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
 @end
 
 @implementation ORKWebViewStepViewController {
     NSString *_result;
     ORKNavigationContainerView *_navigationFooterView;
     NSArray<NSLayoutConstraint *> *_constraints;
-    ORKScriptMessageHandlerImpl *_scriptMessageHandlerImpl;
+}
+
+#pragma mark Public Interface
+
+- (instancetype)initWithStep:(ORKStep *)step {
+    return [self initWithStep:step scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+}
+
+- (instancetype)initWithStep:(ORKStep *)step
+          scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
+        remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
+    remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval {
+    self = [super initWithStep:step];
+    if (self) {
+        NSParameterAssert([step isKindOfClass:[ORKWebViewStep class]]);
+        
+        _result = nil;
+        _scriptMessageHandler = nil;
+        _scriptMessageQueue = [NSMutableArray array];
+        _scriptMessageNames = [scriptMessageNames copy];
+        _remoteURLCachePolicy = remoteURLCachePolicy;
+        _remoteURLTimeoutInterval = remoteURLTimeoutInterval;
+        
+        WKUserContentController *controller = [[WKUserContentController alloc] init];
+        [controller addScriptMessageHandler:self name:ResearchKitCompleteStepMessageName];
+        for (NSString *name in scriptMessageNames) {
+            [controller addScriptMessageHandler:self name:name];
+        }
+        
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.allowsInlineMediaPlayback = true;
+        if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
+            config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+        }
+        config.userContentController = controller;
+        _webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
+        _webView.navigationDelegate = self;
+        
+        [self loadWebContent];
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    }
+    return self;
 }
 
 - (ORKWebViewStep *)webViewStep {
     return (ORKWebViewStep *)self.step;
 }
 
-- (instancetype)initWithStep:(ORKStep *)step {
-    self = [super initWithStep:step];
-    if (self) {
-        __weak typeof(self) weakSelf = self;
-        _scriptMessageHandlerImpl = [[ORKScriptMessageHandlerImpl alloc] init];
-        _scriptMessageHandlerImpl.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
-            [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
-        };
-        
-        _webView = [[ORKWebViewPreloader shared] preloadedWebViewForKey:step.identifier];
-        BOOL preloaded = (_webView != nil);
-        if (!_webView) {
-            _webView = [[ORKWebViewPreloader shared] makeWebView:nil];
-        }
-        
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:@"ResearchKit"];
-        _webView.frame = self.view.bounds;
-        _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        _webView.navigationDelegate = self;
-        
-        _result = nil;
-        if (!preloaded) {
-            [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
-        }
-        
-        [self.view addSubview:_webView];
-        [self setupNavigationFooterView];
-        [self setupConstraints];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseAudio) name:UIApplicationDidEnterBackgroundNotification object:nil];
+- (void)setScriptMessageHandler:(id<WKScriptMessageHandler>)scriptMessageHandler {
+    _scriptMessageHandler = scriptMessageHandler;
+    [self processQueuedScriptMessages];
+}
+
+- (void)reloadWebContent {
+    [self loadWebContent];
+}
+
+#pragma mark - ResearchKit
+
+- (ORKStepResult *)result {
+    ORKStepResult *parentResult = [super result];
+    if (parentResult) {
+        ORKWebViewStepResult *childResult = [[ORKWebViewStepResult alloc] initWithIdentifier:self.step.identifier];
+        childResult.result = _result;
+        childResult.endDate = parentResult.endDate;
+        parentResult.results = [parentResult.results arrayByAddingObject:childResult] ? : @[childResult];
     }
-    return self;
+    return parentResult;
+}
+
+#pragma mark - View Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    _webView.frame = self.view.bounds;
+    _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:_webView];
+    [self setupNavigationFooterView];
+    [self setupConstraints];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    BOOL firstAppearance = !self.hasBeenPresented;
     [super viewWillAppear:animated];
     
     /*
@@ -165,11 +143,11 @@
      the super class ORKStepViewController has had a chance to create it.
      */
     _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
-    
-    if (firstAppearance && self.reloadContentOnFirstAppearance) {
-        _result = nil;
-        [[ORKWebViewPreloader shared] loadContentForStep:[self webViewStep] withWebView:_webView];
-    }
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [self pauseAudio];
+    [super viewDidDisappear:animated];
 }
 
 - (void)setupNavigationFooterView {
@@ -245,38 +223,61 @@
     [NSLayoutConstraint activateConstraints:_constraints];
 }
 
-- (void)viewDidDisappear:(BOOL)animated {
-    [self pauseAudio];
-    [super viewDidDisappear:animated];
-}
-
 - (void)pauseAudio {
     // https://stackoverflow.com/a/44829559
     NSString *script = @"var vids = document.getElementsByTagName('video'); var i; for (i of vids) { i.pause(); }";
     [_webView evaluateJavaScript:script completionHandler:nil];
 }
 
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
-{
-    if ([self.scriptMessageNames containsObject:message.name]) {
-        [self.scriptMessageHandler userContentController:userContentController didReceiveScriptMessage:message];
-        return;
-    }
-    if ([message.body isKindOfClass:[NSString class]]){
-        _result = (NSString *)message.body;
-        [self goForward];
+#pragma mark - Web Content Handling
+
+- (void)loadWebContent {
+    [self.scriptMessageQueue removeAllObjects];
+    _result = nil;
+    
+    ORKWebViewStep *webViewStep = [self webViewStep];
+    if (webViewStep.url) {
+        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:webViewStep.url cachePolicy:self.remoteURLCachePolicy timeoutInterval:self.remoteURLTimeoutInterval];
+        [_webView loadRequest:request];
+    } else if ([self webViewStep].html) {
+        [_webView loadHTMLString:webViewStep.html baseURL:webViewStep.baseURL];
     }
 }
 
-- (ORKStepResult *)result {
-    ORKStepResult *parentResult = [super result];
-    if (parentResult) {
-        ORKWebViewStepResult *childResult = [[ORKWebViewStepResult alloc] initWithIdentifier:self.step.identifier];
-        childResult.result = _result;
-        childResult.endDate = parentResult.endDate;
-        parentResult.results = [parentResult.results arrayByAddingObject:childResult] ? : @[childResult];
+- (void)processQueuedScriptMessages {
+    if (!self.scriptMessageHandler) { return; }
+    for (WKScriptMessage *message in self.scriptMessageQueue) {
+        BOOL stop = [self processScriptMessage:message];
+        if (stop) {
+            break;
+        }
     }
-    return parentResult;
+    [self.scriptMessageQueue removeAllObjects];
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    if (self.scriptMessageHandler) {
+        [self processScriptMessage:message];
+    } else {
+        [self.scriptMessageQueue addObject:message];
+    }
+}
+
+/// Returns YES if the view controller should stop processing any other messages. Assumes that the handler is ready to process the message.
+/// - Parameter message: The message to process.
+- (BOOL)processScriptMessage:(WKScriptMessage *)message {
+    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {
+        _result = (NSString *)message.body;
+        [self goForward];
+        return YES;
+    }
+    
+    if ([self.scriptMessageNames containsObject:message.name]) {
+        [self.scriptMessageHandler userContentController:self.webView.configuration.userContentController didReceiveScriptMessage:message];
+        return NO;
+    }
+    return NO;
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
@@ -302,13 +303,6 @@
         }
     }
     decisionHandler(WKNavigationActionPolicyAllow);
-}
-
-- (void)setScriptMessageNames:(NSArray<NSString *> *)scriptMessageNames {
-    _scriptMessageNames = scriptMessageNames;
-    for (NSString *i in scriptMessageNames) {
-        [_webView.configuration.userContentController addScriptMessageHandler:_scriptMessageHandlerImpl name:i];
-    }
 }
 
 @end

--- a/ResearchKitTests/ORKWebViewStepViewControllerTests.m
+++ b/ResearchKitTests/ORKWebViewStepViewControllerTests.m
@@ -1,0 +1,132 @@
+/*
+ Copyright (c) 2023, CareEvolution, LLC.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+@import ResearchKit.Private;
+@import WebKit;
+#import "ORKWebViewStepViewController.h"
+
+@interface ORKWebViewStepViewControllerTests : XCTestCase
+
+@end
+
+@interface MockScriptMessage: WKScriptMessage
+@property (nonatomic, strong) NSString *nameOverride;
+@property (nonatomic, strong) NSString *bodyOverride;
+- (instancetype)initWithName:(NSString *)name body:(NSString *)body;
+@end
+
+@implementation MockScriptMessage
+- (instancetype)initWithName:(NSString *)name body:(NSString *)body {
+    if (self = [super init]) {
+        _nameOverride = name;
+        _bodyOverride = body;
+    }
+    return self;
+}
+
+- (NSString *)name {
+    return _nameOverride;
+}
+- (id)body {
+    return _bodyOverride;
+}
+@end
+
+@interface TestScriptHandler: NSObject <WKScriptMessageHandler, ORKStepViewControllerDelegate>
+@property (nonatomic, strong) NSMutableArray<NSString *> *events;
+@end
+
+@implementation TestScriptHandler
+- (instancetype)init {
+    if (self = [super init]) {
+        _events = [NSMutableArray array];
+    }
+    return self;
+}
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    [_events addObject:[NSString stringWithFormat:@"didReceiveScriptMessage:%@", message.name]];
+}
+- (void)stepViewController:(ORKStepViewController *)stepViewController didFinishWithNavigationDirection:(ORKStepViewControllerNavigationDirection)direction {
+    [_events addObject:[NSString stringWithFormat:@"didFinishWithNavigationDirection:%@", direction == ORKStepViewControllerNavigationDirectionForward ? @"forward" : @"reverse"]];
+}
+- (void)stepViewControllerResultDidChange:(ORKStepViewController *)stepViewController { }
+- (void)stepViewControllerDidFail:(ORKStepViewController *)stepViewController withError:(NSError *)error { }
+- (void)stepViewController:(ORKStepViewController *)stepViewController recorder:(ORKRecorder *)recorder didFailWithError:(NSError *)error { }
+@end
+
+@implementation ORKWebViewStepViewControllerTests
+
+- (ORKWebViewStep *)webViewStep {
+    ORKWebViewStep *step = [[ORKWebViewStep alloc] initWithIdentifier:@"step"];
+    step.html = @"<html><body></body></html>";
+    return step;
+}
+
+- (void)testMessageQueue {
+    ORKWebViewStep *webViewStep = [self webViewStep];
+    TestScriptHandler *handler = [[TestScriptHandler alloc] init];
+    ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    viewController.delegate = handler;
+    
+    WKScriptMessage *messageA1 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
+    WKScriptMessage *messageA2 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
+    WKScriptMessage *messageB = [[MockScriptMessage alloc] initWithName:@"MessageB" body:nil];
+    WKScriptMessage *messageC = [[MockScriptMessage alloc] initWithName:@"MessageC" body:nil];
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result"];
+    
+    // Send some messages before setting a handler; they should be enqueued for later processing.
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA1];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageB];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageC];
+    
+    viewController.scriptMessageHandler = handler;
+    
+    XCTAssertEqual(handler.events.count, 2, @"Two queued messages processed after setting the script handler, one unsupported message ignored");
+    if (handler.events.count == 2) {
+        XCTAssertEqualObjects([handler.events objectAtIndex:0], @"didReceiveScriptMessage:MessageA");
+        XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didReceiveScriptMessage:MessageB");
+    }
+    [handler.events removeAllObjects];
+    
+    // Send some messages after setting a handler; they should be processed immediately.
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageC];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA2];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageResearchKit];
+    
+    XCTAssertEqual(handler.events.count, 2, @"One message processed immediately, one unsupported message ignored, ResearchKit (goForward) message not passed to handler.");
+    if (handler.events.count == 2) {
+        XCTAssertEqualObjects([handler.events objectAtIndex:0], @"didReceiveScriptMessage:MessageA");
+        XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didFinishWithNavigationDirection:forward");
+    }
+    [handler.events removeAllObjects];
+}
+
+@end


### PR DESCRIPTION
See https://github.com/CareEvolution/RKStudio-Participant/issues/1141

Minor change: adds a `properties` dictionary to CEVRK1Theme. It's the best way I could think of to expose the original style configuration data to JS clients without a lot of boilerplate code.

Major change: refactors WebViewStepViewControllers with the following goals in mind:

- Allows the `scriptMessageNames` set to be configured in the view controller's init:
    - This allows the app to decide when it's ready to process incoming JS messages, by setting `scriptMessageHandler` at the appropriate time. Incoming messages are stored in a queue until `scriptMessageHandler` is set to a non-nil value.
    - Makes it possible to preload WebViewSteps configured with external URLs, without having to reload the web content after the scriptMessageNames/before the view is presented. The app can wait until (for example) the viewWillAppear event to process any messages.
- Moves responsibility of preloading to the app that's using ResearchKit. Preloading is now simply a matter of constructing and caching the WebViewStepViewControllers themselves, instead preloading the WKWebView (and thus exposing more of the internals of the view controller to the app).
- General cleanup of tech debt to account for the various functionality changes since these were originally written.

## Testing

See related PRs.
