### PR TITLE
WebViewStepViewController bug fixes

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -53,7 +53,7 @@ ORK1_CLASS_AVAILABLE
 /// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
 ///
 /// See ``WKScriptMessageHandler`` for more information.
-@property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
+@property (nonatomic, strong, nullable) id<WKScriptMessageHandler> scriptMessageHandler;
 
 /// Creates a web view and immediately begins loading content in the web view as specified by the step definition.
 ///

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -35,8 +35,21 @@
 
 static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
+@interface ORK1WeakScriptMessageHandler: NSObject <WKScriptMessageHandler>
+@property (nonatomic, copy, nullable) void (^didReceiveScriptMessageFunc)(WKUserContentController *, WKScriptMessage *);
+@end
+
+@implementation ORK1WeakScriptMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    if (self.didReceiveScriptMessageFunc != nil) {
+        self.didReceiveScriptMessageFunc(userContentController, message);
+    }
+}
+@end
+
 @interface ORK1WebViewStepViewController ()
 @property (nonatomic, strong) NSMutableArray *scriptMessageQueue;
+@property (nonatomic, strong) ORK1WeakScriptMessageHandler *scriptMessageHandlerWrapper;
 @property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
 @property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
 @end
@@ -66,10 +79,17 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
         _remoteURLCachePolicy = remoteURLCachePolicy;
         _remoteURLTimeoutInterval = remoteURLTimeoutInterval;
         
+        // WKWebView maintains a strong reference to its scriptMessageHandlers, making retain cycles possible. This wrapper facilitates breaking such retain cycles.
+        __weak typeof(self) weakSelf = self;
+        _scriptMessageHandlerWrapper = [[ORK1WeakScriptMessageHandler alloc] init];
+        _scriptMessageHandlerWrapper.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
+            [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
+        };
+        
         WKUserContentController *controller = [[WKUserContentController alloc] init];
-        [controller addScriptMessageHandler:self name:ResearchKitCompleteStepMessageName];
+        [controller addScriptMessageHandler:_scriptMessageHandlerWrapper name:ResearchKitCompleteStepMessageName];
         for (NSString *name in scriptMessageNames) {
-            [controller addScriptMessageHandler:self name:name];
+            [controller addScriptMessageHandler:_scriptMessageHandlerWrapper name:name];
         }
         
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -52,7 +52,7 @@ ORK_CLASS_AVAILABLE
 /// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
 ///
 /// See ``WKScriptMessageHandler`` for more information.
-@property (nonatomic, strong) id<WKScriptMessageHandler> scriptMessageHandler;
+@property (nonatomic, strong, nullable) id<WKScriptMessageHandler> scriptMessageHandler;
 
 /// Creates a web view and immediately begins loading content in the web view as specified by the step definition.
 ///

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -42,8 +42,21 @@
 
 static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
+@interface ORKWeakScriptMessageHandler: NSObject <WKScriptMessageHandler>
+@property (nonatomic, copy, nullable) void (^didReceiveScriptMessageFunc)(WKUserContentController *, WKScriptMessage *);
+@end
+
+@implementation ORKWeakScriptMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    if (self.didReceiveScriptMessageFunc != nil) {
+        self.didReceiveScriptMessageFunc(userContentController, message);
+    }
+}
+@end
+
 @interface ORKWebViewStepViewController ()
 @property (nonatomic, strong) NSMutableArray *scriptMessageQueue;
+@property (nonatomic, strong) ORKWeakScriptMessageHandler *scriptMessageHandlerWrapper;
 @property (nonatomic) NSURLRequestCachePolicy remoteURLCachePolicy;
 @property (nonatomic) NSTimeInterval remoteURLTimeoutInterval;
 @end
@@ -75,10 +88,17 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
         _remoteURLCachePolicy = remoteURLCachePolicy;
         _remoteURLTimeoutInterval = remoteURLTimeoutInterval;
         
+        // WKWebView maintains a strong reference to its scriptMessageHandlers, making retain cycles possible. This wrapper facilitates breaking such retain cycles.
+        __weak typeof(self) weakSelf = self;
+        _scriptMessageHandlerWrapper = [[ORKWeakScriptMessageHandler alloc] init];
+        _scriptMessageHandlerWrapper.didReceiveScriptMessageFunc = ^(WKUserContentController *userContentController, WKScriptMessage *scriptMessage) {
+            [weakSelf userContentController:userContentController didReceiveScriptMessage:scriptMessage];
+        };
+        
         WKUserContentController *controller = [[WKUserContentController alloc] init];
-        [controller addScriptMessageHandler:self name:ResearchKitCompleteStepMessageName];
+        [controller addScriptMessageHandler:_scriptMessageHandlerWrapper name:ResearchKitCompleteStepMessageName];
         for (NSString *name in scriptMessageNames) {
-            [controller addScriptMessageHandler:self name:name];
+            [controller addScriptMessageHandler:_scriptMessageHandlerWrapper name:name];
         }
         
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];


### PR DESCRIPTION
Follow-up to #125 

- Marks `scriptMessageHandler` as nullable.
- Fixes a retain cycle introduced in the last PR that prevents WebViewStepViewControllers from deallocing. I had thought that [`ORK1ScriptMessageHandlerImpl`](https://github.com/CareEvolution/ResearchKit/pull/125/files#diff-d45c2e0c0b2e263f0e882b9e34b9b7861864c8a598e6bcde397cd8bbb11857feL95) was a useless wrapper and removed it, but turns out it's necessary because WKWebView keeps a strong reference to its scriptMessageHandlers. This wrapper helps to break the retain cycle caused by those strong references. (The alternative is calling `removeAllScriptMessageHandlers` on `userContentController` but that requires explicitly and reliably performing that task at exactly the right moment in the task view controller lifecycle).

## Testing

This is a bug fix for https://github.com/CareEvolution/RKStudio-Participant/pull/1145, so just test this as part of that PR.

I've already thoroughly tested the retain cycle fix described above.