### PR TITLE
Fix 'ResearchKit' message handling

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -46,11 +46,15 @@ ORK1_CLASS_AVAILABLE
 @property (nonatomic, strong, readonly) WKWebView *webView;
 
 /// The set of all WebKit Javascript bridge message names that should be passed to the ``scriptMessageHandler``.
+///
+/// This is in addition to WebKit messages named "ResearchKit", which are handled by this view controller, setting the ``result`` and triggering ``goForward`` to navigate to the next step.
 @property (nonatomic, readonly) NSSet<NSString *> *scriptMessageNames;
 
 /// The delegate object that will receive any script messages identified by ``scriptMessageNames``.
 ///
-/// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+/// This is initially `nil`. If ``scriptMessageNames`` is non-empty, any incoming script messages, including the "ResearchKit" message, are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+///
+/// If ``scriptMessageNames`` is empty, "ResearchKit" messages are processed immediately without needing to set `scriptMessageHandler`. This allows automatically-constructed ORK1WebViewStepViewController instances to work with no additional configuration.
 ///
 /// See ``WKScriptMessageHandler`` for more information.
 @property (nonatomic, strong, nullable) id<WKScriptMessageHandler> scriptMessageHandler;

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -169,8 +169,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
     }
 }
 
+- (BOOL)shouldProcessScriptMessages {
+    // scriptMessageNames is empty: no need for scriptMessageHandler; immediately process any ResearchKit message.
+    // scriptMessageNames is non-empty: wait until scriptMessageHandler is set.
+    return self.scriptMessageNames.count == 0
+        || self.scriptMessageHandler != nil;
+}
+
 - (void)processQueuedScriptMessages {
-    if (!self.scriptMessageHandler) { return; }
+    if (![self shouldProcessScriptMessages]) { return; }
     for (WKScriptMessage *message in self.scriptMessageQueue) {
         BOOL stop = [self processScriptMessage:message];
         if (stop) {
@@ -182,14 +189,14 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    if (self.scriptMessageHandler) {
+    if ([self shouldProcessScriptMessages]) {
         [self processScriptMessage:message];
     } else {
         [self.scriptMessageQueue addObject:message];
     }
 }
 
-/// Returns YES if the view controller should stop processing any other messages. Assumes that the handler is ready to process the message.
+/// Returns YES if the view controller should stop processing any other messages. Assumes that `shouldProcessScriptMessages` is true.
 /// - Parameter message: The message to process.
 - (BOOL)processScriptMessage:(WKScriptMessage *)message {
     if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {

--- a/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
@@ -33,8 +33,9 @@
 @import WebKit;
 #import "ORK1WebViewStepViewController.h"
 
-@interface ORK1WebViewStepViewControllerTests : XCTestCase
-
+@interface ORK1WebViewStepViewControllerTests : XCTestCase <ORK1StepViewControllerDelegate>
+@property (nonatomic, strong) NSMutableArray<NSString *> *events;
+- (NSString *)webViewResult:(ORK1StepViewController *)stepViewController;
 @end
 
 @interface MockScriptMessage: WKScriptMessage
@@ -84,10 +85,26 @@
 
 @implementation ORK1WebViewStepViewControllerTests
 
+- (void)setUp {
+    self.events = [NSMutableArray array];
+}
+
 - (ORK1WebViewStep *)webViewStep {
     ORK1WebViewStep *step = [[ORK1WebViewStep alloc] initWithIdentifier:@"step"];
     step.html = @"<html><body></body></html>";
     return step;
+}
+
+- (void)testNoScriptMessageHandler {
+    ORK1WebViewStep *webViewStep = [self webViewStep];
+    ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep];
+    viewController.delegate = self;
+    
+    XCTAssertNil(viewController.scriptMessageHandler, @"setup nil scriptMessageHandler");
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result1"];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageResearchKit];
+    
+    XCTAssertEqualObjects(self.events.firstObject, @"goForward:result1", @"ResearchKit message: sets result and triggers goForward");
 }
 
 - (void)testMessageQueue {
@@ -100,7 +117,7 @@
     WKScriptMessage *messageA2 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
     WKScriptMessage *messageB = [[MockScriptMessage alloc] initWithName:@"MessageB" body:nil];
     WKScriptMessage *messageC = [[MockScriptMessage alloc] initWithName:@"MessageC" body:nil];
-    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result"];
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result2"];
     
     // Send some messages before setting a handler; they should be enqueued for later processing.
     [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA1];
@@ -127,6 +144,31 @@
         XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didFinishWithNavigationDirection:forward");
     }
     [handler.events removeAllObjects];
+    XCTAssertEqualObjects([self webViewResult:viewController], @"result2", @"Stores correct result");
 }
+
+#pragma mark - Test helpers
+
+- (NSString *)webViewResult:(ORK1StepViewController *)stepViewController {
+    if ([stepViewController.result.results.firstObject isKindOfClass:[ORK1WebViewStepResult class]]) {
+        ORK1WebViewStepResult *result = (ORK1WebViewStepResult *)stepViewController.result.results.firstObject;
+        return result.result ?: @"(nil)";
+    } else {
+        return @"(not present)";
+    }
+}
+
+- (void)stepViewController:(ORK1StepViewController *)stepViewController didFinishWithNavigationDirection:(ORK1StepViewControllerNavigationDirection)direction {
+    switch (direction) {
+        case ORK1StepViewControllerNavigationDirectionForward:
+            [self.events addObject:[NSString stringWithFormat:@"goForward:%@", [self webViewResult:stepViewController]]];
+        case ORK1StepViewControllerNavigationDirectionReverse:
+            [self.events addObject:[NSString stringWithFormat:@"goBackward:%@", [self webViewResult:stepViewController]]];
+    }
+}
+
+- (void)stepViewControllerResultDidChange:(ORK1StepViewController *)stepViewController { }
+- (void)stepViewControllerDidFail:(ORK1StepViewController *)stepViewController withError:(NSError *)error { }
+- (void)stepViewController:(ORK1StepViewController *)stepViewController recorder:(ORK1Recorder *)recorder didFailWithError:(NSError *)error { }
 
 @end

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -45,11 +45,15 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, strong, readonly) WKWebView *webView;
 
 /// The set of all WebKit Javascript bridge message names that should be passed to the ``scriptMessageHandler``.
+///
+/// This is in addition to WebKit messages named "ResearchKit", which are handled by this view controller, setting the ``result`` and triggering ``goForward`` to navigate to the next step.
 @property (nonatomic, readonly) NSSet<NSString *> *scriptMessageNames;
 
 /// The delegate object that will receive any script messages identified by ``scriptMessageNames``.
 ///
-/// This is initially `nil`, and any incoming script messages are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+/// This is initially `nil`. If ``scriptMessageNames`` is non-empty, any incoming script messages, including the "ResearchKit" message, are stored in a queue until you set `scriptMessageHandler` to a non-nil value; at that time any queued messages will immediately be sent to the `scriptMessageHandler`.
+///
+/// If ``scriptMessageNames`` is empty, "ResearchKit" messages are processed immediately without needing to set `scriptMessageHandler`. This allows automatically-constructed ORKWebViewStepViewController instances to work with no additional configuration.
 ///
 /// See ``WKScriptMessageHandler`` for more information.
 @property (nonatomic, strong, nullable) id<WKScriptMessageHandler> scriptMessageHandler;

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -264,8 +264,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
     }
 }
 
+- (BOOL)shouldProcessScriptMessages {
+    // scriptMessageNames is empty: no need for scriptMessageHandler; immediately process any ResearchKit message.
+    // scriptMessageNames is non-empty: wait until scriptMessageHandler is set.
+    return self.scriptMessageNames.count == 0
+        || self.scriptMessageHandler != nil;
+}
+
 - (void)processQueuedScriptMessages {
-    if (!self.scriptMessageHandler) { return; }
+    if (![self shouldProcessScriptMessages]) { return; }
     for (WKScriptMessage *message in self.scriptMessageQueue) {
         BOOL stop = [self processScriptMessage:message];
         if (stop) {
@@ -277,14 +284,14 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    if (self.scriptMessageHandler) {
+    if ([self shouldProcessScriptMessages]) {
         [self processScriptMessage:message];
     } else {
         [self.scriptMessageQueue addObject:message];
     }
 }
 
-/// Returns YES if the view controller should stop processing any other messages. Assumes that the handler is ready to process the message.
+/// Returns YES if the view controller should stop processing any other messages. Assumes that `shouldProcessScriptMessages` is true.
 /// - Parameter message: The message to process.
 - (BOOL)processScriptMessage:(WKScriptMessage *)message {
     if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {

--- a/ResearchKitTests/ORKWebViewStepViewControllerTests.m
+++ b/ResearchKitTests/ORKWebViewStepViewControllerTests.m
@@ -33,8 +33,9 @@
 @import WebKit;
 #import "ORKWebViewStepViewController.h"
 
-@interface ORKWebViewStepViewControllerTests : XCTestCase
-
+@interface ORKWebViewStepViewControllerTests : XCTestCase <ORKStepViewControllerDelegate>
+@property (nonatomic, strong) NSMutableArray<NSString *> *events;
+- (NSString *)webViewResult:(ORKStepViewController *)stepViewController;
 @end
 
 @interface MockScriptMessage: WKScriptMessage
@@ -84,10 +85,26 @@
 
 @implementation ORKWebViewStepViewControllerTests
 
+- (void)setUp {
+    self.events = [NSMutableArray array];
+}
+
 - (ORKWebViewStep *)webViewStep {
     ORKWebViewStep *step = [[ORKWebViewStep alloc] initWithIdentifier:@"step"];
     step.html = @"<html><body></body></html>";
     return step;
+}
+
+- (void)testNoScriptMessageHandler {
+    ORKWebViewStep *webViewStep = [self webViewStep];
+    ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep];
+    viewController.delegate = self;
+    
+    XCTAssertNil(viewController.scriptMessageHandler, @"setup nil scriptMessageHandler");
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result1"];
+    [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageResearchKit];
+    
+    XCTAssertEqualObjects(self.events.firstObject, @"goForward:result1", @"ResearchKit message: sets result and triggers goForward");
 }
 
 - (void)testMessageQueue {
@@ -100,7 +117,7 @@
     WKScriptMessage *messageA2 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];
     WKScriptMessage *messageB = [[MockScriptMessage alloc] initWithName:@"MessageB" body:nil];
     WKScriptMessage *messageC = [[MockScriptMessage alloc] initWithName:@"MessageC" body:nil];
-    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result"];
+    WKScriptMessage *messageResearchKit = [[MockScriptMessage alloc] initWithName:@"ResearchKit" body:@"result2"];
     
     // Send some messages before setting a handler; they should be enqueued for later processing.
     [viewController userContentController:viewController.webView.configuration.userContentController didReceiveScriptMessage:messageA1];
@@ -127,6 +144,31 @@
         XCTAssertEqualObjects([handler.events objectAtIndex:1], @"didFinishWithNavigationDirection:forward");
     }
     [handler.events removeAllObjects];
+    XCTAssertEqualObjects([self webViewResult:viewController], @"result2", @"Stores correct result");
 }
+
+#pragma mark - Test helpers
+
+- (NSString *)webViewResult:(ORKStepViewController *)stepViewController {
+    if ([stepViewController.result.results.firstObject isKindOfClass:[ORKWebViewStepResult class]]) {
+        ORKWebViewStepResult *result = (ORKWebViewStepResult *)stepViewController.result.results.firstObject;
+        return result.result ?: @"(nil)";
+    } else {
+        return @"(not present)";
+    }
+}
+
+- (void)stepViewController:(ORKStepViewController *)stepViewController didFinishWithNavigationDirection:(ORKStepViewControllerNavigationDirection)direction {
+    switch (direction) {
+        case ORKStepViewControllerNavigationDirectionForward:
+            [self.events addObject:[NSString stringWithFormat:@"goForward:%@", [self webViewResult:stepViewController]]];
+        case ORKStepViewControllerNavigationDirectionReverse:
+            [self.events addObject:[NSString stringWithFormat:@"goBackward:%@", [self webViewResult:stepViewController]]];
+    }
+}
+
+- (void)stepViewControllerResultDidChange:(ORKStepViewController *)stepViewController { }
+- (void)stepViewControllerDidFail:(ORKStepViewController *)stepViewController withError:(NSError *)error { }
+- (void)stepViewController:(ORKStepViewController *)stepViewController recorder:(ORKRecorder *)recorder didFailWithError:(NSError *)error { }
 
 @end


### PR DESCRIPTION
See https://github.com/CareEvolution/CEVResearchKit/issues/278

With the ORK[1]WebViewStepViewController changes, `"ResearchKit"` webkit messages no longer work out-of-the-box without manually constructing the view controller with its new custom init method. This PR fixes that regression so that "ResearchKit" messages work for automatically-constructed WebViewStepViewControllers.

## Testing

N/A. All changes here affect only unit tests/UI tests, and have full test coverage.

