### PR TITLE
Add saveOnArrival support

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
@@ -165,7 +165,9 @@
         _specialEndSurveyStepIdentifier = nil;
     }
     
-    if (![nextStepIdentifier isEqualToString:ORK1NullStepIdentifier]) { // If ORK1NullStepIdentifier, return nil to end task
+    if (!ignoreSaveOnArrival && step.saveOnArrival) {
+        nextStep = nil;
+    } else if (![nextStepIdentifier isEqualToString:ORK1NullStepIdentifier]) { // If ORK1NullStepIdentifier, return nil to end task
         if (nextStepIdentifier) {
             nextStep = [self stepWithIdentifier:nextStepIdentifier];
             
@@ -180,10 +182,6 @@
         if ([skipNavigationRule stepShouldSkipWithTaskResult:result]) {
             return [self stepAfterStep:nextStep withResult:result ignoreSaveOnArrival:YES];
         }
-    }
-    
-    if (!ignoreSaveOnArrival && step.saveOnArrival) {
-        nextStep = nil;
     }
     
     if (nextStep != nil) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.m
@@ -150,6 +150,10 @@
 }
 
 - (ORK1Step *)stepAfterStep:(ORK1Step *)step withResult:(ORK1TaskResult *)result {
+    return [self stepAfterStep:step withResult:result ignoreSaveOnArrival:NO];
+}
+
+- (ORK1Step *)stepAfterStep:(ORK1Step *)step withResult:(ORK1TaskResult *)result ignoreSaveOnArrival:(BOOL)ignoreSaveOnArrival {
     ORK1Step *nextStep = nil;
     ORK1StepNavigationRule *navigationRule = _stepNavigationRules[step.identifier];
     NSString *nextStepIdentifier = [navigationRule identifierForDestinationStepWithTaskResult:result];
@@ -174,8 +178,12 @@
         
         ORK1SkipStepNavigationRule *skipNavigationRule = _skipStepNavigationRules[nextStep.identifier];
         if ([skipNavigationRule stepShouldSkipWithTaskResult:result]) {
-            return [self stepAfterStep:nextStep withResult:result];
+            return [self stepAfterStep:nextStep withResult:result ignoreSaveOnArrival:YES];
         }
+    }
+    
+    if (!ignoreSaveOnArrival && step.saveOnArrival) {
+        nextStep = nil;
     }
     
     if (nextStep != nil) {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -247,6 +247,15 @@ The default value of this property is 'nil'.
  */
 @property (nonatomic, copy, nullable) NSDictionary *userInfo;
 
+/**
+ When YES, upon loading this step, the ORK1TaskViewController will instruct
+ the delegate to save the task results.
+ 
+ The default value of this property is `NO`.
+ */
+
+@property (nonatomic, assign) BOOL saveOnArrival;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.m
@@ -96,6 +96,7 @@
     step.excludeFromProgressCalculation = _excludeFromProgressCalculation;
     step.nextButtonText = _nextButtonText;
     step.userInfo = _userInfo;
+    step.saveOnArrival = _saveOnArrival;
     return step;
 }
 
@@ -114,12 +115,13 @@
             && (self.useSurveyMode == castObject.useSurveyMode)
             && (self.excludeFromProgressCalculation == castObject.excludeFromProgressCalculation)
             && ORK1EqualObjects(self.nextButtonText, castObject.nextButtonText)
-            && ORK1EqualObjects(self.userInfo, castObject.userInfo));
+            && ORK1EqualObjects(self.userInfo, castObject.userInfo)
+            && (self.saveOnArrival == castObject.saveOnArrival));
 }
 
 - (NSUInteger)hash {
     // Ignore the task reference - it's not part of the content of the step.
-    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash;
+    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xf : 0x1);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -139,6 +141,7 @@
         ORK1_DECODE_BOOL(aDecoder, excludeFromProgressCalculation);
         ORK1_DECODE_OBJ_CLASS(aDecoder, nextButtonText, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, userInfo, NSDictionary);
+        ORK1_DECODE_BOOL(aDecoder, saveOnArrival);
     }
     return self;
 }
@@ -153,6 +156,7 @@
     ORK1_ENCODE_BOOL(aCoder, excludeFromProgressCalculation);
     ORK1_ENCODE_OBJ(aCoder, nextButtonText);
     ORK1_ENCODE_OBJ(aCoder, userInfo);
+    ORK1_ENCODE_BOOL(aCoder, saveOnArrival);
     if ([_task isKindOfClass:[ORK1OrderedTask class]]) {
         ORK1_ENCODE_OBJ(aCoder, task);
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.m
@@ -121,7 +121,7 @@
 
 - (NSUInteger)hash {
     // Ignore the task reference - it's not part of the content of the step.
-    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xf : 0x1);
+    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xe : 0x1);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m
@@ -108,7 +108,7 @@
 }
 
 - (void)setupButtons {
-    if (self.hasPreviousStep == YES) {
+    if (self.hasPreviousStep == YES && !self.step.saveOnArrival) {
         [self ork_setBackButtonItem: _internalBackButtonItem];
     } else {
         [self ork_setBackButtonItem:nil];

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1600,7 +1600,7 @@ static NSString *const _ORK1PresentedDate = @"presentedDate";
         if (stepViewController) {
             stepViewController.delegate = self;
             
-            if (stepViewController.cancelButtonItem == nil) {
+            if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
                 stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
             }
             

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1202,7 +1202,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [self setManagedResult:stepViewController.result forKey:step.identifier];
     
     
-    if (stepViewController.cancelButtonItem == nil) {
+    if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
         stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
     }
     

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -145,6 +145,10 @@
 }
 
 - (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
+    return [self stepAfterStep:step withResult:result ignoreSaveOnArrival:NO];
+}
+
+- (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result ignoreSaveOnArrival:(BOOL)ignoreSaveOnArrival {
     ORKStep *nextStep = nil;
     ORKStepNavigationRule *navigationRule = _stepNavigationRules[step.identifier];
     NSString *nextStepIdentifier = [navigationRule identifierForDestinationStepWithTaskResult:result];
@@ -169,8 +173,12 @@
         
         ORKSkipStepNavigationRule *skipNavigationRule = _skipStepNavigationRules[nextStep.identifier];
         if ([skipNavigationRule stepShouldSkipWithTaskResult:result]) {
-            return [self stepAfterStep:nextStep withResult:result];
+            return [self stepAfterStep:nextStep withResult:result ignoreSaveOnArrival:YES];
         }
+    }
+    
+    if (!ignoreSaveOnArrival && step.saveOnArrival) {
+        nextStep = nil;
     }
     
     if (nextStep != nil) {

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -160,7 +160,9 @@
         _specialEndSurveyStepIdentifier = nil;
     }
     
-    if (![nextStepIdentifier isEqualToString:ORKNullStepIdentifier]) { // If ORKNullStepIdentifier, return nil to end task
+    if (!ignoreSaveOnArrival && step.saveOnArrival) {
+        nextStep = nil;
+    } else if (![nextStepIdentifier isEqualToString:ORKNullStepIdentifier]) { // If ORKNullStepIdentifier, return nil to end task
         if (nextStepIdentifier) {
             nextStep = [self stepWithIdentifier:nextStepIdentifier];
             
@@ -175,10 +177,6 @@
         if ([skipNavigationRule stepShouldSkipWithTaskResult:result]) {
             return [self stepAfterStep:nextStep withResult:result ignoreSaveOnArrival:YES];
         }
-    }
-    
-    if (!ignoreSaveOnArrival && step.saveOnArrival) {
-        nextStep = nil;
     }
     
     if (nextStep != nil) {

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -205,6 +205,15 @@ The default value of this property is 'nil'.
 @property (nonatomic, copy, nullable) NSDictionary *userInfo;
 
 /**
+ When YES, upon loading this step, the ORKTaskViewController will instruct
+ the delegate to save the task results.
+ 
+ The default value of this property is `NO`.
+ */
+
+@property (nonatomic, assign) BOOL saveOnArrival;
+
+/**
  Checks the parameters of the step and throws exceptions on invalid parameters.
  
  This method is called when there is a need to validate the step's parameters, which is typically

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -96,6 +96,7 @@
     step.excludeFromProgressCalculation = _excludeFromProgressCalculation;
     step.nextButtonText = _nextButtonText;
     step.userInfo = _userInfo;
+    step.saveOnArrival = _saveOnArrival;
     return step;
 }
 
@@ -114,12 +115,13 @@
             && (self.useSurveyMode == castObject.useSurveyMode)
             && (self.excludeFromProgressCalculation == castObject.excludeFromProgressCalculation)
             && ORKEqualObjects(self.nextButtonText, castObject.nextButtonText)
-            && ORKEqualObjects(self.userInfo, castObject.userInfo));
+            && ORKEqualObjects(self.userInfo, castObject.userInfo)
+            && (self.saveOnArrival == castObject.saveOnArrival));
 }
 
 - (NSUInteger)hash {
     // Ignore the task reference - it's not part of the content of the step.
-    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash;
+    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xf : 0x1);;
 }
 
 + (BOOL)supportsSecureCoding {
@@ -139,6 +141,7 @@
         ORK_DECODE_BOOL(aDecoder, excludeFromProgressCalculation);
         ORK_DECODE_OBJ_CLASS(aDecoder, nextButtonText, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, userInfo, NSDictionary);
+        ORK_DECODE_BOOL(aDecoder, saveOnArrival);
     }
     return self;
 }
@@ -153,6 +156,7 @@
     ORK_ENCODE_BOOL(aCoder, excludeFromProgressCalculation);
     ORK_ENCODE_OBJ(aCoder, nextButtonText);
     ORK_ENCODE_OBJ(aCoder, userInfo);
+    ORK_ENCODE_BOOL(aCoder, saveOnArrival);
     if ([_task isKindOfClass:[ORKOrderedTask class]]) {
         ORK_ENCODE_OBJ(aCoder, task);
     }

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -121,7 +121,7 @@
 
 - (NSUInteger)hash {
     // Ignore the task reference - it's not part of the content of the step.
-    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xf : 0x1);;
+    return _identifier.hash ^ _title.hash ^ _text.hash ^ (_optional ? 0xf : 0x0) ^ _nextButtonText.hash ^ _userInfo.hash ^ (_saveOnArrival ? 0xe : 0x1);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -258,7 +258,7 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
 }
 
 - (void)setupButtons {
-    if (self.hasPreviousStep == YES) {
+    if (self.hasPreviousStep == YES && !self.step.saveOnArrival) {
         [self ork_setBackButtonItem: _internalBackButtonItem];
     } else {
         [self ork_setBackButtonItem:nil];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1287,7 +1287,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [self setManagedResult:stepViewController.result forKey:step.identifier];
     
     
-    if (stepViewController.cancelButtonItem == nil) {
+    if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
         stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
     }
     

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1704,7 +1704,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
         if (stepViewController) {
             stepViewController.delegate = self;
             
-            if (stepViewController.cancelButtonItem == nil) {
+            if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
                 stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
             }
             


### PR DESCRIPTION
Supports https://github.com/CareEvolution/MyDataHelps-iOS/issues/1086. At the ResearchKit level, this PR serves to simply:
- add a BOOL for `saveOnArrival` to the ORK[1]Step
- remove the back button to prevent backwards navigation on a step with `saveOnArrival == YES`
- remove the cancel button on a step with `saveOnArrival == YES`
- prevent navigation beyond a step with `saveOnArrival == YES` - essentially this must be the last step of a survey

### Testing
No testing necessarily needed at this level, see https://github.com/CareEvolution/MyDataHelps-iOS/pull/1152.