### PR TITLE
Improve saveOnArrival documentation

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -248,8 +248,13 @@ The default value of this property is 'nil'.
 @property (nonatomic, copy, nullable) NSDictionary *userInfo;
 
 /**
- When YES, upon loading this step, the ORK1TaskViewController will instruct
- the delegate to save the task results.
+ If 'YES', this property serves as a flag to instruct the host of the ORK1TaskViewController
+ to collect and process the results of the task upon reaching this step. Furthermore, the
+ step UI will prevent backwards navigation (no back button) and cancellation (no Cancel
+ button) - i.e., this will become the final step presented to the user and the task's `result`
+ will be complete. Subsequent receipt of the `didFinishWithReason` call to the
+ ORK1TaskViewControllerDelegate at this point may serve solely to trigger dismissal or
+ error handling.
  
  The default value of this property is `NO`.
  */

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -251,10 +251,9 @@ The default value of this property is 'nil'.
  If 'YES', this property serves as a flag to instruct the host of the ORK1TaskViewController
  to collect and process the results of the task upon reaching this step. Furthermore, the
  step UI will prevent backwards navigation (no back button) and cancellation (no Cancel
- button) - i.e., this will become the final step presented to the user and the task's `result`
+ button) - i.e., this will become the final step presented to the user, and the task's `result`
  will be complete. Subsequent receipt of the `didFinishWithReason` call to the
- ORK1TaskViewControllerDelegate at this point may serve solely to trigger dismissal or
- error handling.
+ ORK1TaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
  
  The default value of this property is `NO`.
  */

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -205,8 +205,13 @@ The default value of this property is 'nil'.
 @property (nonatomic, copy, nullable) NSDictionary *userInfo;
 
 /**
- When YES, upon loading this step, the ORKTaskViewController will instruct
- the delegate to save the task results.
+ If 'YES', this property serves as a flag to instruct the host of the ORK1TaskViewController
+ to collect and process the results of the task upon reaching this step. Furthermore, the
+ step UI will prevent backwards navigation (no back button) and cancellation (no Cancel
+ button) - i.e., this will become the final step presented to the user and the task's `result`
+ will be complete. Subsequent receipt of the `didFinishWithReason` call to the
+ ORK1TaskViewControllerDelegate at this point may serve solely to trigger dismissal or
+ error handling.
  
  The default value of this property is `NO`.
  */

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -208,10 +208,9 @@ The default value of this property is 'nil'.
  If 'YES', this property serves as a flag to instruct the host of the ORK1TaskViewController
  to collect and process the results of the task upon reaching this step. Furthermore, the
  step UI will prevent backwards navigation (no back button) and cancellation (no Cancel
- button) - i.e., this will become the final step presented to the user and the task's `result`
+ button) - i.e., this will become the final step presented to the user, and the task's `result`
  will be complete. Subsequent receipt of the `didFinishWithReason` call to the
- ORK1TaskViewControllerDelegate at this point may serve solely to trigger dismissal or
- error handling.
+ ORK1TaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
  
  The default value of this property is `NO`.
  */


### PR DESCRIPTION
Addresses [comment on PR](https://github.com/CareEvolution/ResearchKit/pull/129#discussion_r1094983066) after merge pertaining to documentation of the `saveOnArrival` property and scope in relation to role/purpose of ResearchKit.