### PR TITLE
Remove saveOnArrival stepResult from taskResult

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -254,6 +254,7 @@ The default value of this property is 'nil'.
  button) - i.e., this will become the final step presented to the user, and the task's `result`
  will be complete. Subsequent receipt of the `didFinishWithReason` call to the
  ORK1TaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
+ Note: this step will not show in the ORK1TaskResult.
  
  The default value of this property is `NO`.
  */

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -748,8 +748,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         id <NSCopying> key = [self uniqueManagedKey:identifier index:idx];
         ORK1Result *result = _managedResults[key];
         NSAssert2(result, @"Result should not be nil for identifier %@ with key %@", identifier, key);
-        if ([identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival) {
-        } else {
+        BOOL excludeFromResult = [identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival;
+        if (!excludeFromResult) {
             [results addObject:result];
         }
     }];

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -748,7 +748,10 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         id <NSCopying> key = [self uniqueManagedKey:identifier index:idx];
         ORK1Result *result = _managedResults[key];
         NSAssert2(result, @"Result should not be nil for identifier %@ with key %@", identifier, key);
-        [results addObject:result];
+        if ([identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival) {
+        } else {
+            [results addObject:result];
+        }
     }];
     
     return [results copy];

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -205,13 +205,13 @@ The default value of this property is 'nil'.
 @property (nonatomic, copy, nullable) NSDictionary *userInfo;
 
 /**
- If 'YES', this property serves as a flag to instruct the host of the ORK1TaskViewController
+ If 'YES', this property serves as a flag to instruct the host of the ORKTaskViewController
  to collect and process the results of the task upon reaching this step. Furthermore, the
  step UI will prevent backwards navigation (no back button) and cancellation (no Cancel
  button) - i.e., this will become the final step presented to the user, and the task's `result`
  will be complete. Subsequent receipt of the `didFinishWithReason` call to the
- ORK1TaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
- Note: this step will not show in the ORK1TaskResult.
+ ORKTaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
+ Note: this step will not show in the ORKTaskResult.
  
  The default value of this property is `NO`.
  */

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -211,6 +211,7 @@ The default value of this property is 'nil'.
  button) - i.e., this will become the final step presented to the user, and the task's `result`
  will be complete. Subsequent receipt of the `didFinishWithReason` call to the
  ORK1TaskViewControllerDelegate may serve solely to trigger dismissal or error handling.
+ Note: this step will not show in the ORK1TaskResult.
  
  The default value of this property is `NO`.
  */

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -818,8 +818,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         id <NSCopying> key = [self uniqueManagedKey:identifier index:idx];
         ORKResult *result = _managedResults[key];
         NSAssert2(result, @"Result should not be nil for identifier %@ with key %@", identifier, key);
-        if ([identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival) {
-        } else {
+        BOOL excludeFromResult = [identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival;
+        if (!excludeFromResult) {
             [results addObject:result];
         }
     }];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -818,7 +818,10 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         id <NSCopying> key = [self uniqueManagedKey:identifier index:idx];
         ORKResult *result = _managedResults[key];
         NSAssert2(result, @"Result should not be nil for identifier %@ with key %@", identifier, key);
-        [results addObject:result];
+        if ([identifier isEqualToString:self.currentStepViewController.step.identifier] && self.currentStepViewController.step.saveOnArrival) {
+        } else {
+            [results addObject:result];
+        }
     }];
     
     return [results copy];


### PR DESCRIPTION
Per a [discussion on Slack](https://careevolution.slack.com/archives/C5Z45KQN5/p1675879026298459?thread_ts=1675789039.740919&cid=C5Z45KQN5) it was decided that we will NOT submit any data for the saveOnArrival step itself.


## Testing
Testing for this can be done by following the instructions for https://github.com/CareEvolution/MyDataHelps-iOS/pull/1152 and then looking at the result in MDHD. You should notice that there is no data for the saveOnArrival step itself - so if you select the InstructionStep, you should notice that there are only two steps in the result and not the final InstructionStep which is the saveOnArrival step.