### PR TITLE
Store original step result in WebViewStepViewControllers

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -66,10 +66,12 @@ ORK1_CLASS_AVAILABLE
 /// The `scriptMessageHandler` is initialized as `nil`. Any incoming script messages received while `scriptMessageHandler` is nil will be enqueued for later processing. Interactivity can thus be delayed until this view controller is ready to display, for example by waiting to set a `scriptMessageHandler` until this view controller's `viewWillAppear` lifecycle event.
 /// - Parameters:
 ///   - step: Must be an `ORK1WebViewStep`.
+///   - result: The previous step result for this step, if any. The view controller will use this as the source of its `result` value until any user interaction updates the result.
 ///   - scriptMessageNames: A set of custom WebKit message names to declare as supported. See ``scriptMessageHandler``.
 ///   - remoteURLCachePolicy: Cache policy for loading URL-based web view steps.
 ///   - remoteURLTimeoutInterval: Timeout interval for loading URL-based web view steps.
 - (instancetype)initWithStep:(ORK1Step *)step
+                      result:(nullable ORK1Result *)result
           scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
         remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
     remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval;

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -56,15 +56,21 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 @implementation ORK1WebViewStepViewController {
     NSString *_result;
+    NSString *_originalResult;
 }
 
 #pragma mark Public Interface
 
 - (instancetype)initWithStep:(ORK1Step *)step {
-    return [self initWithStep:step scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    return [self initWithStep:step result:nil scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+}
+
+- (instancetype)initWithStep:(ORK1Step *)step result:(ORK1Result *)result {
+    return [self initWithStep:step result:result scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
 }
 
 - (instancetype)initWithStep:(ORK1Step *)step
+                      result:(ORK1Result *)result
           scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
         remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
     remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval {
@@ -73,6 +79,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
         NSParameterAssert([step isKindOfClass:[ORK1WebViewStep class]]);
         
         _result = nil;
+        _originalResult = nil;
+        if ([result isKindOfClass:[ORK1StepResult class]]) {
+            ORK1StepResult *stepResult = (ORK1StepResult *)result;
+            if ([stepResult.results.firstObject isKindOfClass:[ORK1WebViewStepResult class]]) {
+                ORK1WebViewStepResult *webResult = (ORK1WebViewStepResult *)stepResult.results.firstObject;
+                _originalResult = webResult.result;
+            }
+        }
+        
         _scriptMessageHandler = nil;
         _scriptMessageQueue = [NSMutableArray array];
         _scriptMessageNames = [scriptMessageNames copy];
@@ -158,7 +173,7 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 - (void)loadWebContent {
     [self.scriptMessageQueue removeAllObjects];
-    _result = nil;
+    _result = _originalResult;
     
     ORK1WebViewStep *webViewStep = [self webViewStep];
     if (webViewStep.url) {

--- a/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
+++ b/ORK1Kit/ORK1KitTests/ORK1WebViewStepViewControllerTests.m
@@ -95,6 +95,23 @@
     return step;
 }
 
+- (void)testUsesOriginalResult {
+    ORK1WebViewStep *webViewStep = [self webViewStep];
+    ORK1WebViewStepResult *childResult = [[ORK1WebViewStepResult alloc] initWithIdentifier:webViewStep.identifier];
+    childResult.result = @"original";
+    childResult.endDate = [NSDate date];
+    ORK1StepResult *originalResult = [[ORK1StepResult alloc] initWithStepIdentifier:webViewStep.identifier results:[NSArray arrayWithObject:childResult]];
+    ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep result:originalResult];
+    
+    ORK1StepResult *result = viewController.result;
+    XCTAssertEqualObjects(result.identifier, webViewStep.identifier);
+    XCTAssertEqual(result.results.count, 1);
+    if ([result.results.firstObject isKindOfClass: [ORK1WebViewStepResult class]]) {
+        ORK1WebViewStepResult *innerResult = (ORK1WebViewStepResult *)result.results.firstObject;
+        XCTAssertEqualObjects(innerResult.result, childResult.result);
+    }
+}
+
 - (void)testNoScriptMessageHandler {
     ORK1WebViewStep *webViewStep = [self webViewStep];
     ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep];
@@ -110,7 +127,7 @@
 - (void)testMessageQueue {
     ORK1WebViewStep *webViewStep = [self webViewStep];
     TestScriptHandler *handler = [[TestScriptHandler alloc] init];
-    ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    ORK1WebViewStepViewController *viewController = [[ORK1WebViewStepViewController alloc] initWithStep:webViewStep result:nil scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
     viewController.delegate = handler;
     
     WKScriptMessage *messageA1 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -65,10 +65,12 @@ ORK_CLASS_AVAILABLE
 /// The `scriptMessageHandler` is initialized as `nil`. Any incoming script messages received while `scriptMessageHandler` is nil will be enqueued for later processing. Interactivity can thus be delayed until this view controller is ready to display, for example by waiting to set a `scriptMessageHandler` until this view controller's `viewWillAppear` lifecycle event.
 /// - Parameters:
 ///   - step: Must be an `ORKWebViewStep`.
+///   - result: The previous step result for this step, if any. The view controller will use this as the source of its `result` value until any user interaction updates the result.   
 ///   - scriptMessageNames: A set of custom WebKit message names to declare as supported. See ``scriptMessageHandler``.
 ///   - remoteURLCachePolicy: Cache policy for loading URL-based web view steps.
 ///   - remoteURLTimeoutInterval: Timeout interval for loading URL-based web view steps.
 - (instancetype)initWithStep:(ORKStep *)step
+                      result:(nullable ORKResult *)result
           scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
         remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
     remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval;

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -63,6 +63,7 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 @implementation ORKWebViewStepViewController {
     NSString *_result;
+    NSString *_originalResult;
     ORKNavigationContainerView *_navigationFooterView;
     NSArray<NSLayoutConstraint *> *_constraints;
 }
@@ -70,10 +71,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 #pragma mark Public Interface
 
 - (instancetype)initWithStep:(ORKStep *)step {
-    return [self initWithStep:step scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    return [self initWithStep:step result:nil scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+}
+
+- (instancetype)initWithStep:(ORKStep *)step result:(ORKResult *)result {
+    return [self initWithStep:step result:result scriptMessageNames:[NSSet set] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
 }
 
 - (instancetype)initWithStep:(ORKStep *)step
+                      result:(ORKResult *)result
           scriptMessageNames:(NSSet<NSString *> *)scriptMessageNames
         remoteURLCachePolicy:(NSURLRequestCachePolicy)remoteURLCachePolicy
     remoteURLTimeoutInterval:(NSTimeInterval)remoteURLTimeoutInterval {
@@ -82,6 +88,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
         NSParameterAssert([step isKindOfClass:[ORKWebViewStep class]]);
         
         _result = nil;
+        _originalResult = nil;
+        if ([result isKindOfClass:[ORKStepResult class]]) {
+            ORKStepResult *stepResult = (ORKStepResult *)result;
+            if ([stepResult.results.firstObject isKindOfClass:[ORKWebViewStepResult class]]) {
+                ORKWebViewStepResult *webResult = (ORKWebViewStepResult *)stepResult.results.firstObject;
+                _originalResult = webResult.result;
+            }
+        }
+        
         _scriptMessageHandler = nil;
         _scriptMessageQueue = [NSMutableArray array];
         _scriptMessageNames = [scriptMessageNames copy];
@@ -253,7 +268,7 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 
 - (void)loadWebContent {
     [self.scriptMessageQueue removeAllObjects];
-    _result = nil;
+    _result = _originalResult;
     
     ORKWebViewStep *webViewStep = [self webViewStep];
     if (webViewStep.url) {

--- a/ResearchKitTests/ORKWebViewStepViewControllerTests.m
+++ b/ResearchKitTests/ORKWebViewStepViewControllerTests.m
@@ -95,6 +95,23 @@
     return step;
 }
 
+- (void)testUsesOriginalResult {
+    ORKWebViewStep *webViewStep = [self webViewStep];
+    ORKWebViewStepResult *childResult = [[ORKWebViewStepResult alloc] initWithIdentifier:webViewStep.identifier];
+    childResult.result = @"original";
+    childResult.endDate = [NSDate date];
+    ORKStepResult *originalResult = [[ORKStepResult alloc] initWithStepIdentifier:webViewStep.identifier results:[NSArray arrayWithObject:childResult]];
+    ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep result:originalResult];
+    
+    ORKStepResult *result = viewController.result;
+    XCTAssertEqualObjects(result.identifier, webViewStep.identifier);
+    XCTAssertEqual(result.results.count, 1);
+    if ([result.results.firstObject isKindOfClass: [ORKWebViewStepResult class]]) {
+        ORKWebViewStepResult *innerResult = (ORKWebViewStepResult *)result.results.firstObject;
+        XCTAssertEqualObjects(innerResult.result, childResult.result);
+    }
+}
+
 - (void)testNoScriptMessageHandler {
     ORKWebViewStep *webViewStep = [self webViewStep];
     ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep];
@@ -110,7 +127,7 @@
 - (void)testMessageQueue {
     ORKWebViewStep *webViewStep = [self webViewStep];
     TestScriptHandler *handler = [[TestScriptHandler alloc] init];
-    ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
+    ORKWebViewStepViewController *viewController = [[ORKWebViewStepViewController alloc] initWithStep:webViewStep result:nil scriptMessageNames:[NSSet setWithObjects:@"MessageA", @"MessageB", nil] remoteURLCachePolicy:NSURLRequestUseProtocolCachePolicy remoteURLTimeoutInterval:30];
     viewController.delegate = handler;
     
     WKScriptMessage *messageA1 = [[MockScriptMessage alloc] initWithName:@"MessageA" body:nil];


### PR DESCRIPTION
See https://github.com/CareEvolution/MyDataHelps-iOS/issues/1162

WebViewStepControllers have always reset their result to nil each time they're displayed. Thus they ignore any previously entered result when navigating backward. This PR modifies the initializers for WebViewStepControllers to accept the previously stored step result for that step. Note that the view controllers can't actually set `_result` to the previous value in the initializer, since their web content can be loaded and reloaded at any time, which should revert their state—so the original result is restored during `loadWebContent`.

If initialized with no previous result, there is no change in behavior.

## Testing

See the associated MDH PR for testing info.