### PR TITLE
Add image to QuestionStep and FormStep, support imageAltText on any step containing image

### DIFF
--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
@@ -199,6 +199,11 @@ The default value of this property is `NO`.
 @property (nonatomic, strong, nullable) UIImage *image;
 
 /**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
+/**
  An array of recorder configurations that define the parameters for recorders to be
  run during a step to collect sensor or other data.
  

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.m
@@ -103,6 +103,7 @@
     step.finishedSpokenInstruction = self.finishedSpokenInstruction;
     step.recorderConfigurations = [self.recorderConfigurations copy];
     step.image = self.image;
+    step.imageAltText = self.imageAltText;
     return step;
 }
 
@@ -123,6 +124,7 @@
         ORK1_DECODE_OBJ_CLASS(aDecoder, spokenInstruction, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, finishedSpokenInstruction, NSString);
         ORK1_DECODE_IMAGE(aDecoder, image);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK1_DECODE_OBJ_ARRAY(aDecoder, recorderConfigurations, ORK1RecorderConfiguration);
     }
     return self;
@@ -142,6 +144,7 @@
     ORK1_ENCODE_BOOL(aCoder, shouldUseNextAsSkipButton);
     ORK1_ENCODE_BOOL(aCoder, shouldContinueOnFinish);
     ORK1_ENCODE_IMAGE(aCoder, image);
+    ORK1_ENCODE_OBJ(aCoder, imageAltText);
     ORK1_ENCODE_OBJ(aCoder, spokenInstruction);
     ORK1_ENCODE_OBJ(aCoder, finishedSpokenInstruction);
     ORK1_ENCODE_OBJ(aCoder, recorderConfigurations);
@@ -156,6 +159,7 @@
             ORK1EqualObjects(self.finishedSpokenInstruction, castObject.finishedSpokenInstruction) &&
             ORK1EqualObjects(self.recorderConfigurations, castObject.recorderConfigurations) &&
             ORK1EqualObjects(self.image, castObject.image) &&
+            ORK1EqualObjects(self.imageAltText, castObject.imageAltText) &&
             (self.stepDuration == castObject.stepDuration) &&
             (self.shouldShowDefaultTimer == castObject.shouldShowDefaultTimer) &&
             (self.shouldStartTimerAutomatically == castObject.shouldStartTimerAutomatically) &&

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessContentView.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessContentView.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) double distanceInMeters;
 
 @property (nonatomic, strong, nullable) UIImage *image;
+@property (nonatomic, strong, nullable) NSString *imageAccessibilityLabel;
 
 @property (nonatomic, assign) NSTimeInterval timeLeft;
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessContentView.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessContentView.m
@@ -269,6 +269,11 @@
     }
 }
 
+- (void)setImageAccessibilityLabel:(NSString *)imageAccessibilityLabel {
+    _imageView.accessibilityLabel = imageAccessibilityLabel;
+    _imageView.isAccessibilityElement = YES;
+}
+
 - (void)setHasDistance:(BOOL)hasDistance {
     _hasDistance = hasDistance;
     [self distanceView].enabled = _hasDistance;

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStepViewController.m
@@ -83,6 +83,7 @@
     // Do any additional setup after loading the view.
     _contentView = [ORK1FitnessContentView new];
     _contentView.image = self.fitnessStep.image;
+    _contentView.imageAccessibilityLabel = self.fitnessStep.imageAltText;
     _contentView.timeLeft = self.fitnessStep.stepDuration;
     self.activeStepView.activeCustomView = _contentView;
     self.activeStepView.stepViewFillsAvailableSpace = YES;

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkContentView.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkContentView.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ORK1TimedWalkContentView : ORK1ActiveStepCustomView
 
 @property (nonatomic, strong, nullable) UIImage *image;
+@property (nonatomic, strong, nullable) NSString *imageAccessibilityLabel;
 
 @end
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkContentView.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkContentView.m
@@ -91,6 +91,11 @@
     }
 }
 
+- (void)setImageAccessibilityLabel:(NSString *)imageAccessibilityLabel {
+    _imageView.accessibilityLabel = imageAccessibilityLabel;
+    _imageView.isAccessibilityElement = YES;
+}
+
 - (void)updateConstraints {
     [NSLayoutConstraint deactivateConstraints:self.constraints];
     

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.m
@@ -82,6 +82,7 @@
     
     self.timedWalkContentView = [ORK1TimedWalkContentView new];
     self.timedWalkContentView.image = [self timedWalkStep].image;
+    self.timedWalkContentView.imageAccessibilityLabel = [self timedWalkStep].imageAltText;
     self.activeStepView.activeCustomView = self.timedWalkContentView;
     self.activeStepView.stepViewFillsAvailableSpace = YES;
     self.activeStepView.continueSkipContainer.continueEnabled = YES;

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStep.h
@@ -94,6 +94,20 @@ ORK1_CLASS_AVAILABLE
  */
 @property (nonatomic, copy, nullable) NSArray<ORK1FormItem *> *formItems;
 
+/**
+ An image that provides visual context for the instruction.
+ 
+ The image is displayed with aspect fit. Depending on the device, the screen area
+ available for this image can vary. For exact
+ metrics, see `ORK1ScreenMetricIllustrationHeight`.
+ */
+@property (nonatomic, copy, nullable) UIImage *image;
+
+/**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
 @end
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStep.m
@@ -93,6 +93,8 @@
     ORK1FormStep *step = [super copyWithZone:zone];
     step.formItems = ORK1ArrayCopyObjects(_formItems);
     step.footnote = self.footnote;
+    step.image = self.image;
+    step.imageAltText = self.imageAltText;
     return step;
 }
 
@@ -102,11 +104,13 @@
     __typeof(self) castObject = object;
     return isParentSame &&
         ORK1EqualObjects(self.formItems, castObject.formItems) &&
-        ORK1EqualObjects(self.footnote, castObject.footnote);
+        ORK1EqualObjects(self.footnote, castObject.footnote) &&
+        ORK1EqualObjects(self.image, castObject.image) &&
+        ORK1EqualObjects(self.imageAltText, castObject.imageAltText);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.formItems.hash ^ self.footnote.hash;
+    return super.hash ^ self.formItems.hash ^ self.footnote.hash ^ self.image.hash ^ self.imageAltText.hash;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -114,6 +118,8 @@
     if (self) {
         ORK1_DECODE_OBJ_ARRAY(aDecoder, formItems, ORK1FormItem);
         ORK1_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
+        ORK1_DECODE_IMAGE(aDecoder, image);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
     }
     return self;
 }
@@ -122,6 +128,8 @@
     [super encodeWithCoder:aCoder];
     ORK1_ENCODE_OBJ(aCoder, formItems);
     ORK1_ENCODE_OBJ(aCoder, footnote);
+    ORK1_ENCODE_IMAGE(aCoder, image);
+    ORK1_ENCODE_OBJ(aCoder, imageAltText);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.m
@@ -556,6 +556,8 @@
         
         _tableContainer = [[ORK1TableContainerView alloc] initWithFrame:self.view.bounds];
         _tableContainer.delegate = self;
+        _tableContainer.image = [self formStep].image;
+        _tableContainer.imageAltText = [self formStep].imageAltText;
         [self.view addSubview:_tableContainer];
         _tableContainer.tapOffView = self.view;
         

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.h
@@ -73,6 +73,11 @@ ORK1_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) UIImage *image;
 
 /**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
+/**
  An image that provides visual context for the instruction that will allow for showing
  a two-part composite image where the `image` is tinted and the `auxiliaryImage` is 
  shown with light grey.

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.m
@@ -57,6 +57,7 @@
         ORK1_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
         ORK1_DECODE_IMAGE(aDecoder, image);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK1_DECODE_IMAGE(aDecoder, auxiliaryImage);
         ORK1_DECODE_IMAGE(aDecoder, iconImage);
     }
@@ -68,6 +69,7 @@
     ORK1_ENCODE_OBJ(aCoder, detailText);
     ORK1_ENCODE_OBJ(aCoder, footnote);
     ORK1_ENCODE_IMAGE(aCoder, image);
+    ORK1_ENCODE_OBJ(aCoder, imageAltText);
     ORK1_ENCODE_IMAGE(aCoder, auxiliaryImage);
     ORK1_ENCODE_IMAGE(aCoder, iconImage);
 }
@@ -81,6 +83,7 @@
     step.detailText = self.detailText;
     step.footnote = self.footnote;
     step.image = self.image;
+    step.imageAltText = self.imageAltText;
     step.auxiliaryImage = self.auxiliaryImage;
     step.iconImage = self.iconImage;
     return step;
@@ -94,6 +97,7 @@
         ORK1EqualObjects(self.detailText, castObject.detailText) &&
         ORK1EqualObjects(self.footnote, castObject.footnote) &&
         ORK1EqualObjects(self.image, castObject.image) &&
+        ORK1EqualObjects(self.imageAltText, castObject.imageAltText) &&
         ORK1EqualObjects(self.auxiliaryImage, castObject.auxiliaryImage) &&
         ORK1EqualObjects(self.iconImage, castObject.iconImage);
 }

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
@@ -137,7 +137,7 @@
         [NSLayoutConstraint activateConstraints:constraints];
         
         _instructionImageView.isAccessibilityElement = YES;
-        if (_instructionStep.imageAltText) {
+        if (_instructionStep.imageAltText.length > 0) {
             _instructionImageView.accessibilityLabel = _instructionStep.imageAltText;
         } else {
             _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORK1LocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepView.m
@@ -137,7 +137,11 @@
         [NSLayoutConstraint activateConstraints:constraints];
         
         _instructionImageView.isAccessibilityElement = YES;
-        _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORK1LocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];
+        if (_instructionStep.imageAltText) {
+            _instructionImageView.accessibilityLabel = _instructionStep.imageAltText;
+        } else {
+            _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORK1LocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];
+        }
     } else {
         _instructionImageView.isAccessibilityElement = NO;
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.h
@@ -115,6 +115,20 @@ ORK1_CLASS_AVAILABLE
  */
 @property (nonatomic, copy, nullable) NSString *footnote;
 
+/**
+ An image that provides visual context for the instruction.
+ 
+ The image is displayed with aspect fit. Depending on the device, the screen area
+ available for this image can vary. For exact
+ metrics, see `ORK1ScreenMetricIllustrationHeight`.
+ */
+@property (nonatomic, copy, nullable) UIImage *image;
+
+/**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.m
@@ -103,6 +103,8 @@
     questionStep.answerFormat = [self.answerFormat copy];
     questionStep.placeholder = [self.placeholder copy];
     questionStep.footnote = [self.footnote copy];
+    questionStep.image = [self.image copy];
+    questionStep.imageAltText = [self.imageAltText copy];
     return questionStep;
 }
 
@@ -113,11 +115,13 @@
     return isParentSame &&
     ORK1EqualObjects(self.answerFormat, castObject.answerFormat) &&
     ORK1EqualObjects(self.placeholder, castObject.placeholder) &&
-    ORK1EqualObjects(self.footnote, castObject.footnote);
+    ORK1EqualObjects(self.footnote, castObject.footnote) &&
+    ORK1EqualObjects(self.image, castObject.image) &&
+    ORK1EqualObjects(self.imageAltText, castObject.imageAltText);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.answerFormat.hash ^ self.footnote.hash;
+    return super.hash ^ self.answerFormat.hash ^ self.footnote.hash ^ self.image.hash ^ self.imageAltText.hash;
 }
 
 - (ORK1QuestionType)questionType {
@@ -135,6 +139,8 @@
         ORK1_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORK1AnswerFormat);
         ORK1_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK1_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
+        ORK1_DECODE_IMAGE(aDecoder, image);
+        ORK1_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
     }
     return self;
 }
@@ -145,6 +151,8 @@
     ORK1_ENCODE_OBJ(aCoder, answerFormat);
     ORK1_ENCODE_OBJ(aCoder, placeholder);
     ORK1_ENCODE_OBJ(aCoder, footnote);
+    ORK1_ENCODE_IMAGE(aCoder, image);
+    ORK1_ENCODE_OBJ(aCoder, imageAltText);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
@@ -39,12 +39,50 @@
 #import "ORK1QuestionStep_Internal.h"
 
 
-@implementation ORK1QuestionStepView
+@implementation ORK1QuestionStepView {
+    UIImageView *_imageView;
+}
 
 - (void)setQuestionCustomView:(ORK1QuestionStepCustomView *)questionCustomView {
     _questionCustomView = questionCustomView;
     questionCustomView.translatesAutoresizingMaskIntoConstraints = NO;
-    self.stepView = _questionCustomView;
+    UIStackView *baseView = [[UIStackView alloc] init];
+    baseView.axis = UILayoutConstraintAxisVertical;
+    baseView.spacing = 10;
+    baseView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    if (_questionStep.image) {
+        _imageView = [[UIImageView alloc] initWithImage:_questionStep.image];
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        if (_questionStep.imageAltText) {
+            _imageView.accessibilityLabel = _questionStep.imageAltText;
+            _imageView.isAccessibilityElement = YES;
+        }
+        [baseView addArrangedSubview:_imageView];
+        
+        CGSize imageSize = _questionStep.image.size;
+        if (imageSize.width > 0 && imageSize.height > 0) {
+            NSMutableArray *constraints = [NSMutableArray new];
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                attribute:NSLayoutAttributeHeight
+                                                                relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                   toItem:_imageView
+                                                                attribute:NSLayoutAttributeWidth
+                                                               multiplier:imageSize.height / imageSize.width
+                                                                 constant:0.0]];
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                           attribute:NSLayoutAttributeHeight
+                                                                           relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                              toItem:nil
+                                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                                          multiplier:1.0
+                                                                            constant:300.0]];
+            [NSLayoutConstraint activateConstraints:constraints];
+        }
+    }
+    
+    [baseView addArrangedSubview:questionCustomView];
+    self.stepView = baseView;
 }
 
 - (void)setQuestionStep:(ORK1QuestionStep *)step {
@@ -85,6 +123,9 @@
     }
     if (self.questionCustomView) {
         [elements addObject:self.questionCustomView];
+    }
+    if (_imageView) {
+        [elements addObject:_imageView];
     }
     if (self.continueSkipContainer.continueButton != nil) {
         [elements addObject:self.continueSkipContainer.continueButton];

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
@@ -54,7 +54,7 @@
     if (_questionStep.image) {
         _imageView = [[UIImageView alloc] initWithImage:_questionStep.image];
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
-        if (_questionStep.imageAltText) {
+        if (_questionStep.imageAltText.length > 0) {
             _imageView.accessibilityLabel = _questionStep.imageAltText;
             _imageView.isAccessibilityElement = YES;
         }

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepView.m
@@ -121,11 +121,11 @@
     if (self.headerView.learnMoreButton != nil) {
         [elements addObject:self.headerView.learnMoreButton];
     }
-    if (self.questionCustomView) {
-        [elements addObject:self.questionCustomView];
-    }
     if (_imageView) {
         [elements addObject:_imageView];
+    }
+    if (self.questionCustomView) {
+        [elements addObject:self.questionCustomView];
     }
     if (self.continueSkipContainer.continueButton != nil) {
         [elements addObject:self.continueSkipContainer.continueButton];

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.m
@@ -162,6 +162,8 @@ typedef NS_ENUM(NSInteger, ORK1QuestionSection) {
             
             [self.view addSubview:_tableContainer];
             _tableContainer.tapOffView = self.view;
+            _tableContainer.image = [self questionStep].image;
+            _tableContainer.imageAltText = [self questionStep].imageAltText;
             
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UITableView *tableView;
 @property (nonatomic, strong, readonly) ORK1StepHeaderView *stepHeaderView;
 @property (nonatomic, strong, readonly) ORK1NavigationContainerView *continueSkipContainerView;
-@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong, nullable) UIImage *image;
 @property (nonatomic, copy) NSString *imageAltText;
 
 /*

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UITableView *tableView;
 @property (nonatomic, strong, readonly) ORK1StepHeaderView *stepHeaderView;
 @property (nonatomic, strong, readonly) ORK1NavigationContainerView *continueSkipContainerView;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, copy) NSString *imageAltText;
 
 /*
  If tap off events should be accepted from outside this view's bounds, provide

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -58,6 +58,7 @@
     CGFloat _preKeyboardBottomConstant;
     
     UIScrollView *_scrollView;
+    UIImageView *_imageView;
     
     UITapGestureRecognizer *_tapOffGestureRecognizer;
 }
@@ -131,16 +132,63 @@
     // make the contentSize to be correct after changing the frame
     [_tableView layoutIfNeeded];
     {
+        UIStackView *baseView = [[UIStackView alloc] init];
+        baseView.axis = UILayoutConstraintAxisVertical;
+        baseView.spacing = 10;
+        baseView.translatesAutoresizingMaskIntoConstraints = NO;
+        
         _stepHeaderView.frame = (CGRect){{0,0},{_tableView.bounds.size.width,30}};
-        _tableView.tableHeaderView = _stepHeaderView;
+        _tableView.tableHeaderView = baseView;
+        [baseView addArrangedSubview:_stepHeaderView];
+        
+        [_stepHeaderView.widthAnchor constraintEqualToConstant:_tableView.bounds.size.width].active = YES;
+        
         // Do the layout with the view in the hierarchy; otherwise it won't
         // get the right margins.
         [_stepHeaderView setNeedsLayout];
         [_stepHeaderView layoutIfNeeded];
-        CGSize headerSize = [_stepHeaderView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
-        _stepHeaderView.bounds = (CGRect){{0,0},headerSize};
+        
+        if (self.image) {
+            /*
+             Adding 20 points to the height setting the edge inset will ensure a 20-point padding from the image to the tableView.
+             Before arriving at this, attempted to add 20 to header view height in the baseView.bounds line below which works
+             initially, then if the table "recalculates" (e.g., upon selecting an option in a QuestionStep of type TextChoice)
+             the 20-point padding disappears, probably due to complex vertical constraint calculation for these views.
+             */
+            _imageView = [[UIImageView alloc] initWithImage:[self.image imageWithAlignmentRectInsets:UIEdgeInsetsMake(0, 0, -20, 0)]];
+            _imageView.contentMode = UIViewContentModeScaleAspectFit;
+            if (self.imageAltText) {
+                _imageView.accessibilityLabel = self.imageAltText;
+                _imageView.isAccessibilityElement = YES;
+            }
+            [baseView addArrangedSubview:_imageView];
+            
+            CGSize imageSize = self.image.size;
+            if (imageSize.width > 0 && imageSize.height > 0) {
+                NSMutableArray *constraints = [NSMutableArray new];
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                    attribute:NSLayoutAttributeHeight
+                                                                    relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                       toItem:_imageView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:imageSize.height / imageSize.width
+                                                                     constant:0.0]];
+                
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                               attribute:NSLayoutAttributeHeight
+                                                                               relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                                  toItem:nil
+                                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                                              multiplier:1.0
+                                                                                constant:300.0]];
+                [NSLayoutConstraint activateConstraints:constraints];
+            }
+        }
+        
+        CGSize headerSize = [baseView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+        baseView.bounds = (CGRect){{0,0}, headerSize};
         _tableView.tableHeaderView = nil;
-        _tableView.tableHeaderView = _stepHeaderView;
+        _tableView.tableHeaderView = baseView;
     }
     
     {
@@ -407,6 +455,28 @@
     
     _keyboardIsUp = NO;
     [self animateLayoutForKeyboardNotification:notification];
+}
+
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+    return NO;
+}
+
+- (NSArray *)accessibilityElements {
+    NSMutableArray *elements = [[NSMutableArray alloc] init];
+    
+    [elements addObject:_stepHeaderView];
+    if (_imageView) {
+        [elements addObject:_imageView];
+    }
+    // UITableViewCells are not accessibility elements by default - https://stackoverflow.com/questions/57365412/why-uitableviewcell-is-not-accessible-for-voiceover
+    for (UITableViewCell *cell in _tableView.visibleCells) {
+        [elements addObject:cell];
+    }
+    [elements addObject:_continueSkipContainerView];
+    
+    return elements;
 }
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -157,7 +157,7 @@
              */
             _imageView = [[UIImageView alloc] initWithImage:[self.image imageWithAlignmentRectInsets:UIEdgeInsetsMake(0, 0, -20, 0)]];
             _imageView.contentMode = UIViewContentModeScaleAspectFit;
-            if (self.imageAltText) {
+            if (self.imageAltText.length > 0) {
                 _imageView.accessibilityLabel = self.imageAltText;
                 _imageView.isAccessibilityElement = YES;
             }

--- a/ResearchKit/ActiveTasks/ORKActiveStep.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.h
@@ -199,6 +199,11 @@ The default value of this property is `NO`.
 @property (nonatomic, strong, nullable) UIImage *image;
 
 /**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
+/**
  An array of recorder configurations that define the parameters for recorders to be
  run during a step to collect sensor or other data.
  

--- a/ResearchKit/ActiveTasks/ORKActiveStep.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.m
@@ -103,6 +103,7 @@
     step.finishedSpokenInstruction = self.finishedSpokenInstruction;
     step.recorderConfigurations = [self.recorderConfigurations copy];
     step.image = self.image;
+    step.imageAltText = self.imageAltText;
     step.isPractice = self.isPractice;
     return step;
 }
@@ -124,6 +125,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, spokenInstruction, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, finishedSpokenInstruction, NSString);
         ORK_DECODE_IMAGE(aDecoder, image);
+        ORK_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK_DECODE_OBJ_ARRAY(aDecoder, recorderConfigurations, ORKRecorderConfiguration);
         ORK_DECODE_BOOL(aDecoder, isPractice);
     }
@@ -144,6 +146,7 @@
     ORK_ENCODE_BOOL(aCoder, shouldUseNextAsSkipButton);
     ORK_ENCODE_BOOL(aCoder, shouldContinueOnFinish);
     ORK_ENCODE_IMAGE(aCoder, image);
+    ORK_ENCODE_OBJ(aCoder, imageAltText);
     ORK_ENCODE_OBJ(aCoder, spokenInstruction);
     ORK_ENCODE_OBJ(aCoder, finishedSpokenInstruction);
     ORK_ENCODE_OBJ(aCoder, recorderConfigurations);
@@ -159,6 +162,7 @@
             ORKEqualObjects(self.finishedSpokenInstruction, castObject.finishedSpokenInstruction) &&
             ORKEqualObjects(self.recorderConfigurations, castObject.recorderConfigurations) &&
             ORKEqualObjects(self.image, castObject.image) &&
+            ORKEqualObjects(self.imageAltText, castObject.imageAltText) &&
             (self.stepDuration == castObject.stepDuration) &&
             (self.shouldShowDefaultTimer == castObject.shouldShowDefaultTimer) &&
             (self.shouldStartTimerAutomatically == castObject.shouldStartTimerAutomatically) &&

--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.h
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) double distanceInMeters;
 
 @property (nonatomic, strong, nullable) UIImage *image;
+@property (nonatomic, strong, nullable) NSString *imageAccessibilityLabel;
 
 @property (nonatomic, assign) NSTimeInterval timeLeft;
 

--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -269,6 +269,11 @@
     }
 }
 
+- (void)setImageAccessibilityLabel:(NSString *)imageAccessibilityLabel {
+    _imageView.accessibilityLabel = imageAccessibilityLabel;
+    _imageView.isAccessibilityElement = YES;
+}
+
 - (void)setHasDistance:(BOOL)hasDistance {
     _hasDistance = hasDistance;
     [self distanceView].enabled = _hasDistance;

--- a/ResearchKit/ActiveTasks/ORKFitnessStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessStepViewController.m
@@ -83,6 +83,7 @@
     // Do any additional setup after loading the view.
     _contentView = [ORKFitnessContentView new];
     _contentView.image = self.fitnessStep.image;
+    _contentView.imageAccessibilityLabel = self.fitnessStep.imageAltText;
     _contentView.timeLeft = self.fitnessStep.stepDuration;
     self.activeStepView.activeCustomView = _contentView;
     self.activeStepView.stepViewFillsAvailableSpace = YES;

--- a/ResearchKit/ActiveTasks/ORKTimedWalkContentView.h
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkContentView.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ORKTimedWalkContentView : ORKActiveStepCustomView
 
 @property (nonatomic, strong, nullable) UIImage *image;
+@property (nonatomic, strong, nullable) NSString *imageAccessibilityLabel;
 
 @end
 

--- a/ResearchKit/ActiveTasks/ORKTimedWalkContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkContentView.m
@@ -91,6 +91,11 @@
     }
 }
 
+- (void)setImageAccessibilityLabel:(NSString *)imageAccessibilityLabel {
+    _imageView.accessibilityLabel = imageAccessibilityLabel;
+    _imageView.isAccessibilityElement = YES;
+}
+
 - (void)updateConstraints {
     [NSLayoutConstraint deactivateConstraints:self.constraints];
     

--- a/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.m
@@ -83,6 +83,7 @@
     
     self.timedWalkContentView = [ORKTimedWalkContentView new];
     self.timedWalkContentView.image = [self timedWalkStep].image;
+    self.timedWalkContentView.imageAccessibilityLabel = [self timedWalkStep].imageAltText;
     self.activeStepView.activeCustomView = self.timedWalkContentView;
     self.activeStepView.stepViewFillsAvailableSpace = YES;
     self.navigationFooterView.continueEnabled = YES;

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+@import UIKit;
 #import <ResearchKit/ORKStep.h>
 
 
@@ -98,6 +98,21 @@ ORK_CLASS_AVAILABLE
  The property to present the form with all the items in a card view. Default to YES;
  */
 @property (nonatomic) BOOL useCardView;
+
+/**
+ An image that provides visual context for the instruction.
+ 
+ The image is displayed with aspect fit. Depending on the device, the screen area
+ available for this image can vary. For exact
+ metrics, see `ORKScreenMetricIllustrationHeight`.
+ */
+@property (nonatomic, copy, nullable) UIImage *image;
+
+/**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
 
 @end
 

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -95,6 +95,8 @@
     ORKFormStep *step = [super copyWithZone:zone];
     step.formItems = ORKArrayCopyObjects(_formItems);
     step.footnote = self.footnote;
+    step.image = self.image;
+    step.imageAltText = self.imageAltText;
     return step;
 }
 
@@ -104,11 +106,13 @@
     __typeof(self) castObject = object;
     return isParentSame &&
         ORKEqualObjects(self.formItems, castObject.formItems) &&
-        ORKEqualObjects(self.footnote, castObject.footnote);
+        ORKEqualObjects(self.footnote, castObject.footnote) &&
+        ORKEqualObjects(self.image, castObject.image) &&
+        ORKEqualObjects(self.imageAltText, castObject.imageAltText);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.formItems.hash ^ self.footnote.hash;
+    return super.hash ^ self.formItems.hash ^ self.footnote.hash ^ self.image.hash ^ self.imageAltText.hash;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -116,6 +120,8 @@
     if (self) {
         ORK_DECODE_OBJ_ARRAY(aDecoder, formItems, ORKFormItem);
         ORK_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
+        ORK_DECODE_IMAGE(aDecoder, image);
+        ORK_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
     }
     return self;
 }
@@ -124,6 +130,8 @@
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, formItems);
     ORK_ENCODE_OBJ(aCoder, footnote);
+    ORK_ENCODE_IMAGE(aCoder, image);
+    ORK_ENCODE_OBJ(aCoder, imageAltText);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -547,6 +547,8 @@
         
         _tableContainer = [ORKTableContainerView new];
         _tableContainer.delegate = self;
+        _tableContainer.image = [self formStep].image;
+        _tableContainer.imageAltText = [self formStep].imageAltText;
         [self.view addSubview:_tableContainer];
         _tableContainer.tapOffView = self.view;
         

--- a/ResearchKit/Common/ORKInstructionStep.h
+++ b/ResearchKit/Common/ORKInstructionStep.h
@@ -80,6 +80,11 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) UIImage *image;
 
 /**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
+
+/**
  An image that provides visual context for the instruction that will allow for showing
  a two-part composite image where the `image` is tinted and the `auxiliaryImage` is 
  shown with light grey.

--- a/ResearchKit/Common/ORKInstructionStep.m
+++ b/ResearchKit/Common/ORKInstructionStep.m
@@ -58,6 +58,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, attributedDetailText, NSAttributedString);
         ORK_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
         ORK_DECODE_IMAGE(aDecoder, image);
+        ORK_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK_DECODE_IMAGE(aDecoder, auxiliaryImage);
         ORK_DECODE_IMAGE(aDecoder, iconImage);
     }
@@ -69,6 +70,7 @@
     ORK_ENCODE_OBJ(aCoder, detailText);
     ORK_ENCODE_OBJ(aCoder, footnote);
     ORK_ENCODE_IMAGE(aCoder, image);
+    ORK_ENCODE_OBJ(aCoder, imageAltText);
     ORK_ENCODE_IMAGE(aCoder, auxiliaryImage);
     ORK_ENCODE_IMAGE(aCoder, iconImage);
 }
@@ -82,6 +84,7 @@
     step.detailText = self.detailText;
     step.footnote = self.footnote;
     step.image = self.image;
+    step.imageAltText = self.imageAltText;
     step.auxiliaryImage = self.auxiliaryImage;
     step.iconImage = self.iconImage;
     return step;
@@ -95,6 +98,7 @@
         ORKEqualObjects(self.detailText, castObject.detailText) &&
         ORKEqualObjects(self.footnote, castObject.footnote) &&
         ORKEqualObjects(self.image, castObject.image) &&
+        ORKEqualObjects(self.imageAltText, castObject.imageAltText) &&
         ORKEqualObjects(self.auxiliaryImage, castObject.auxiliaryImage) &&
         ORKEqualObjects(self.iconImage, castObject.iconImage);
 }

--- a/ResearchKit/Common/ORKInstructionStepView.m
+++ b/ResearchKit/Common/ORKInstructionStepView.m
@@ -136,7 +136,11 @@
         [NSLayoutConstraint activateConstraints:constraints];
         
         _instructionImageView.isAccessibilityElement = YES;
-        _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORKLocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];
+        if (_instructionStep.imageAltText) {
+            _instructionImageView.accessibilityLabel = _instructionStep.imageAltText;
+        } else {
+            _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORKLocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];
+        }
     } else {
         _instructionImageView.isAccessibilityElement = NO;
     }

--- a/ResearchKit/Common/ORKInstructionStepView.m
+++ b/ResearchKit/Common/ORKInstructionStepView.m
@@ -136,7 +136,7 @@
         [NSLayoutConstraint activateConstraints:constraints];
         
         _instructionImageView.isAccessibilityElement = YES;
-        if (_instructionStep.imageAltText) {
+        if (_instructionStep.imageAltText.length > 0) {
             _instructionImageView.accessibilityLabel = _instructionStep.imageAltText;
         } else {
             _instructionImageView.accessibilityLabel = [NSString stringWithFormat:ORKLocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), _instructionStep.title];

--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+@import UIKit;
 #import <ResearchKit/ORKStep.h>
 
 
@@ -116,6 +116,20 @@ ORK_CLASS_AVAILABLE
  A property to present the question with a card view. Default to YES;
  */
 @property (nonatomic) BOOL useCardView;
+
+/**
+ An image that provides visual context for the instruction.
+ 
+ The image is displayed with aspect fit. Depending on the device, the screen area
+ available for this image can vary. For exact
+ metrics, see `ORKScreenMetricIllustrationHeight`.
+ */
+@property (nonatomic, copy, nullable) UIImage *image;
+
+/**
+ Alternative text to show for an image - for accessibility.
+ */
+@property (nonatomic, copy, nullable) NSString *imageAltText;
 
 @end
 

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -85,6 +85,8 @@
     questionStep.answerFormat = [self.answerFormat copy];
     questionStep.placeholder = [self.placeholder copy];
     questionStep.footnote = [self.footnote copy];
+    questionStep.image = [self.image copy];
+    questionStep.imageAltText = [self.imageAltText copy];
     return questionStep;
 }
 
@@ -95,11 +97,13 @@
     return isParentSame &&
     ORKEqualObjects(self.answerFormat, castObject.answerFormat) &&
     ORKEqualObjects(self.placeholder, castObject.placeholder) &&
-    ORKEqualObjects(self.footnote, castObject.footnote);
+    ORKEqualObjects(self.footnote, castObject.footnote) &&
+    ORKEqualObjects(self.image, castObject.image) &&
+    ORKEqualObjects(self.imageAltText, castObject.imageAltText);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.answerFormat.hash ^ self.footnote.hash;
+    return super.hash ^ self.answerFormat.hash ^ self.footnote.hash ^ self.image.hash ^ self.imageAltText.hash;
 }
 
 - (void)setQuestion:(NSString *)question {
@@ -121,6 +125,8 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
+        ORK_DECODE_IMAGE(aDecoder, image);
+        ORK_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
     }
     return self;
 }
@@ -131,6 +137,8 @@
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, footnote);
+    ORK_ENCODE_IMAGE(aCoder, image);
+    ORK_ENCODE_OBJ(aCoder, imageAltText);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKQuestionStepView.m
+++ b/ResearchKit/Common/ORKQuestionStepView.m
@@ -123,11 +123,11 @@
     if (self.headerView.learnMoreButton != nil) {
         [elements addObject:self.headerView.learnMoreButton];
     }
-    if (self.questionCustomView) {
-        [elements addObject:self.questionCustomView];
-    }
     if (_imageView) {
         [elements addObject:_imageView];
+    }
+    if (self.questionCustomView) {
+        [elements addObject:self.questionCustomView];
     }
     return elements;
 }

--- a/ResearchKit/Common/ORKQuestionStepView.m
+++ b/ResearchKit/Common/ORKQuestionStepView.m
@@ -54,7 +54,7 @@
     if (_questionStep.image) {
         _imageView = [[UIImageView alloc] initWithImage:_questionStep.image];
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
-        if (_questionStep.imageAltText) {
+        if (_questionStep.imageAltText.length > 0) {
             _imageView.accessibilityLabel = _questionStep.imageAltText;
             _imageView.isAccessibilityElement = YES;
         }

--- a/ResearchKit/Common/ORKQuestionStepView.m
+++ b/ResearchKit/Common/ORKQuestionStepView.m
@@ -39,12 +39,49 @@
 #import "ORKQuestionStep_Internal.h"
 #import "ORKSkin.h"
 
-@implementation ORKQuestionStepView
+@implementation ORKQuestionStepView {
+    UIImageView *_imageView;
+}
 
 - (void)setQuestionCustomView:(ORKQuestionStepCustomView *)questionCustomView {
     _questionCustomView = questionCustomView;
     questionCustomView.translatesAutoresizingMaskIntoConstraints = NO;
-    self.stepView = _questionCustomView;
+    UIStackView *baseView = [[UIStackView alloc] init];
+    baseView.axis = UILayoutConstraintAxisVertical;
+    baseView.spacing = 10;
+    baseView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    if (_questionStep.image) {
+        _imageView = [[UIImageView alloc] initWithImage:_questionStep.image];
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        if (_questionStep.imageAltText) {
+            _imageView.accessibilityLabel = _questionStep.imageAltText;
+            _imageView.isAccessibilityElement = YES;
+        }
+        [baseView addArrangedSubview:_imageView];
+        
+        CGSize imageSize = _questionStep.image.size;
+        if (imageSize.width > 0 && imageSize.height > 0) {
+            NSMutableArray *constraints = [NSMutableArray new];
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                attribute:NSLayoutAttributeHeight
+                                                                relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                   toItem:_imageView
+                                                                attribute:NSLayoutAttributeWidth
+                                                               multiplier:imageSize.height / imageSize.width
+                                                                 constant:0.0]];
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                           attribute:NSLayoutAttributeHeight
+                                                                           relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                              toItem:nil
+                                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                                          multiplier:1.0
+                                                                            constant:300.0]];
+            [NSLayoutConstraint activateConstraints:constraints];
+        }
+    }
+    [baseView addArrangedSubview:_questionCustomView];
+    self.stepView = baseView;
 }
 
 - (void)setQuestionStep:(ORKQuestionStep *)step {
@@ -88,6 +125,9 @@
     }
     if (self.questionCustomView) {
         [elements addObject:self.questionCustomView];
+    }
+    if (_imageView) {
+        [elements addObject:_imageView];
     }
     return elements;
 }

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -177,6 +177,8 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             
             [self.view insertSubview:_tableContainer belowSubview:_navigationFooterView];
             _tableContainer.tapOffView = self.view;
+            _tableContainer.image = [self questionStep].image;
+            _tableContainer.imageAltText = [self questionStep].imageAltText;
             
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;

--- a/ResearchKit/Common/ORKTableContainerView.h
+++ b/ResearchKit/Common/ORKTableContainerView.h
@@ -53,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) UITableView *tableView;
 @property (nonatomic, strong, readonly) ORKStepHeaderView *stepHeaderView;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, copy) NSString *imageAltText;
 
 /*
  If tap off events should be accepted from outside this view's bounds, provide

--- a/ResearchKit/Common/ORKTableContainerView.h
+++ b/ResearchKit/Common/ORKTableContainerView.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) UITableView *tableView;
 @property (nonatomic, strong, readonly) ORKStepHeaderView *stepHeaderView;
-@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong, nullable) UIImage *image;
 @property (nonatomic, copy) NSString *imageAltText;
 
 /*

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -58,6 +58,7 @@ static const CGFloat CellBottomPadding = 20.0;
     BOOL _keyboardIsUp;
     
     UIScrollView *_scrollView;
+    UIImageView *_imageView;
     
     UITapGestureRecognizer *_tapOffGestureRecognizer;
 }
@@ -120,16 +121,63 @@ static const CGFloat CellBottomPadding = 20.0;
     // make the contentSize to be correct after changing the frame
     [_tableView layoutIfNeeded];
     {
+        UIStackView *baseView = [[UIStackView alloc] init];
+        baseView.axis = UILayoutConstraintAxisVertical;
+        baseView.spacing = 10;
+        baseView.translatesAutoresizingMaskIntoConstraints = NO;
+        
         _stepHeaderView.frame = (CGRect){{0,0},{_tableView.bounds.size.width,30}};
-        _tableView.tableHeaderView = _stepHeaderView;
+        _tableView.tableHeaderView = baseView;
+        [baseView addArrangedSubview:_stepHeaderView];
+        
+        [_stepHeaderView.widthAnchor constraintEqualToConstant:_tableView.bounds.size.width].active = YES;
+        
         // Do the layout with the view in the hierarchy; otherwise it won't
         // get the right margins.
         [_stepHeaderView setNeedsLayout];
         [_stepHeaderView layoutIfNeeded];
-        CGSize headerSize = [_stepHeaderView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
-        _stepHeaderView.bounds = (CGRect){{0,0},headerSize};
+        
+        if (self.image) {
+            /*
+             Adding 20 points to the height setting the edge inset will ensure a 20-point padding from the image to the tableView.
+             Before arriving at this, attempted to add 20 to header view height in the baseView.bounds line below which works
+             initially, then if the table "recalculates" (e.g., upon selecting an option in a QuestionStep of type TextChoice)
+             the 20-point padding disappears, probably due to complex vertical constraint calculation for these views.
+             */
+            _imageView = [[UIImageView alloc] initWithImage:[self.image imageWithAlignmentRectInsets:UIEdgeInsetsMake(0, 0, -20, 0)]];
+            _imageView.contentMode = UIViewContentModeScaleAspectFit;
+            if (self.imageAltText) {
+                _imageView.accessibilityLabel = self.imageAltText;
+                _imageView.isAccessibilityElement = YES;
+            }
+            [baseView addArrangedSubview:_imageView];
+            
+            CGSize imageSize = self.image.size;
+            if (imageSize.width > 0 && imageSize.height > 0) {
+                NSMutableArray *constraints = [NSMutableArray new];
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                    attribute:NSLayoutAttributeHeight
+                                                                    relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                       toItem:_imageView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:imageSize.height / imageSize.width
+                                                                     constant:0.0]];
+                
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:_imageView
+                                                                               attribute:NSLayoutAttributeHeight
+                                                                               relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                                  toItem:nil
+                                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                                              multiplier:1.0
+                                                                                constant:300.0]];
+                [NSLayoutConstraint activateConstraints:constraints];
+            }
+        }
+        
+        CGSize headerSize = [baseView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+        baseView.bounds = (CGRect){{0,0}, headerSize};
         _tableView.tableHeaderView = nil;
-        _tableView.tableHeaderView = _stepHeaderView;
+        _tableView.tableHeaderView = baseView;
     }
     
     {
@@ -346,6 +394,34 @@ static const CGFloat CellBottomPadding = 20.0;
     
     _keyboardIsUp = NO;
     [self animateLayoutForKeyboardNotification:notification];
+}
+
+#pragma mark - Accessibility
+
+/*
+ In RK2, the ORKQuestionStep.text is placed in a view of a UITableView section header 😳.
+ The section header view is not exposed to Accessibility currently.
+ TODO: add the section header into the Accessibility group/chain
+ */
+
+
+- (BOOL)isAccessibilityElement {
+    return NO;
+}
+
+- (NSArray *)accessibilityElements {
+    NSMutableArray *elements = [[NSMutableArray alloc] init];
+    
+    [elements addObject:_stepHeaderView];
+    if (_imageView) {
+        [elements addObject:_imageView];
+    }
+    // UITableViewCells are not accessibility elements by default - https://stackoverflow.com/questions/57365412/why-uitableviewcell-is-not-accessible-for-voiceover
+    for (UITableViewCell *cell in _tableView.visibleCells) {
+        [elements addObject:cell];
+    }
+    
+    return elements;
 }
 
 @end

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -146,7 +146,7 @@ static const CGFloat CellBottomPadding = 20.0;
              */
             _imageView = [[UIImageView alloc] initWithImage:[self.image imageWithAlignmentRectInsets:UIEdgeInsetsMake(0, 0, -20, 0)]];
             _imageView.contentMode = UIViewContentModeScaleAspectFit;
-            if (self.imageAltText) {
+            if (self.imageAltText.length > 0) {
                 _imageView.accessibilityLabel = self.imageAltText;
                 _imageView.isAccessibilityElement = YES;
             }


### PR DESCRIPTION
Closes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1158. Adds `image` to ORK[1]QuestionStep and ORK[1]FormStep and `imageAltText ` to all steps that support `image`.

The latter implies the use of Accessibility (a11y) to “read” a representation of the image as supplied in `imageAltText`. This required some of the significant lift in this PR as a11y was not working as expected on Question- and FormSteps.

Support for a11y here is defined as being able to tap on the image with Settings > Accessibility > Spoken Content turned on as well as being able to cycle the views on a screen and see them spoken in order (can be done with Apple’s Accessibility Inspector using Xcode and a simulator, or with Spoken Content on, two-finger swipe down on screen).

Due to low usage (only used by one study to my knowledge) and spending several hours struggling with it, this PR does NOT provide full a11y for ORKQuestionsStep (RK2) when a UITableView is used (e.g., TextChoices). The question `text` in RK2 is actually placed in a Section Header which is not a standard place for a11y when looking at UITableview hierarchy. It might be achieved by passing more data around or after a deep dive on subclassing aspects of UITableView.

### RK1
|QuestionStep|FormStep|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-03-06 at 14 48 10](https://user-images.githubusercontent.com/1008462/223227757-4ab9d4e7-673c-4907-8c44-0634caccece2.png)|![Simulator Screen Shot - iPhone 14 - 2023-03-06 at 14 48 33](https://user-images.githubusercontent.com/1008462/223227794-3c72fa84-fff5-4480-9cee-7a45444e578e.png)|

### RK2
|QuestionStep|FormStep|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-03-06 at 14 49 28](https://user-images.githubusercontent.com/1008462/223227901-402a101e-f654-474e-9439-2f256a3709d7.png)|![Simulator Screen Shot - iPhone 14 - 2023-03-06 at 14 48 56](https://user-images.githubusercontent.com/1008462/223227934-b1785de9-eb64-4bd9-850f-c4abe8d6e4c7.png)|

## Testing

Until [this server PR](https://github.com/CareEvolution/MyDataHelpsDesignerUI/pull/20) is merged/live, this can only be tested by modifying survey JSON via the Edit Raw Template. The surveys (1 each for RK version 1 and RK version 2) below have a QuestionStep and an InstructionStep, both with images.

To test `altImageText`, you can turn on Spoken Content either by triple-tapping the power button or via Settings > Accessibility > Spoken Content. Then you can tap on the image to hear the alternate text.

Expectations 
- Images appear after title and text, but before answer section in both the QuestionStep and Instruction Step
- When in Spoken Content mode on an iPhone, each image will have a description: QuestionStep - MDH logo - "MyDataHelps logo", FormStep - Framingham Heart Study logo - "eFHS logo"

<details>
  <summary>RK1 Question/Form Step Survey example</summary>

```
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "QuestionStep",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus.",
      "title": "Question Step",
      "identifier": "QuestionStep",
      "image": "https://play-lh.googleusercontent.com/NvRkVn1T5D1rjUryUdsn74p3TzfzesXER8SijXnwKezppm5m9OvwafeSx0jr4QF4uw",
      "imageAltText": "MyDataHelps logo",
      "answerFormat": {
        "type": "TextAnswerFormat",
        "multipleLines": false,
        "keyboardType": "Text"
      },
      "optional": false,
      "placeholder": "This is the placeholder",
      "useCardView": true
    },
    {
      "type": "FormStep",
      "identifier": "FormStep",
      "image": "https://rkstudio-customer-assets.s3.amazonaws.com/OFFSPRING/three-heart-logo.gif",
      "imageAltText": "eFHS logo",
      "formItems": [
        {
          "identifier": "FormItem1",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem2",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        }
      ],
      "optional": false,
      "title": "Form Step",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus."
    }
  ]
}
```

</details>
<details>
  <summary>RK2 Question/Form Step Survey example</summary>

```
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "rkVersion": 2,
  "steps": [
    {
      "type": "QuestionStep",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus.",
      "title": "Question Step",
      "identifier": "QuestionStep",
      "image": "https://play-lh.googleusercontent.com/NvRkVn1T5D1rjUryUdsn74p3TzfzesXER8SijXnwKezppm5m9OvwafeSx0jr4QF4uw",
      "imageAltText": "MyDataHelps logo",
      "answerFormat": {
        "type": "TextAnswerFormat",
        "multipleLines": false,
        "keyboardType": "Text"
      },
      "optional": false,
      "placeholder": "This is the placeholder",
      "useCardView": true
    },
    {
      "type": "FormStep",
      "identifier": "FormStep",
      "image": "https://rkstudio-customer-assets.s3.amazonaws.com/OFFSPRING/three-heart-logo.gif",
      "imageAltText": "eFHS logo",
      "formItems": [
        {
          "identifier": "FormItem1",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem2",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        }
      ],
      "optional": false,
      "title": "Form Step",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus."
    }
  ]
}
```

</details>