### PR TITLE
Fixes saveOnArrival for ORK[1]OrderedTasks

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.m
@@ -167,7 +167,11 @@ ORK1TaskProgress ORK1TaskProgressMake(NSUInteger current, NSUInteger total) {
 - (ORK1Step *)stepAfterStep:(ORK1Step *)step withResult:(ORK1TaskResult *)result {
     NSArray *steps = _steps;
     
-    if (steps.count <= 0 || step.saveOnArrival) {
+    if (steps.count <= 0) {
+        return nil;
+    }
+    
+    if (step.saveOnArrival && ![self isKindOfClass:[ORK1NavigableOrderedTask class]]) {
         return nil;
     }
     

--- a/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.m
@@ -167,7 +167,7 @@ ORK1TaskProgress ORK1TaskProgressMake(NSUInteger current, NSUInteger total) {
 - (ORK1Step *)stepAfterStep:(ORK1Step *)step withResult:(ORK1TaskResult *)result {
     NSArray *steps = _steps;
     
-    if (steps.count <= 0) {
+    if (steps.count <= 0 || step.saveOnArrival) {
         return nil;
     }
     

--- a/ResearchKit/Common/ORKInstructionStepViewController.m
+++ b/ResearchKit/Common/ORKInstructionStepViewController.m
@@ -77,7 +77,9 @@
     }
     _navigationFooterView.continueButtonItem = self.continueButtonItem;
     _navigationFooterView.continueEnabled = YES;
-    _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+    if (!self.step.saveOnArrival) {
+        _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+    }
     _navigationFooterView.hidden = self.isBeingReviewed;
     _navigationFooterView.footnoteLabel.text = [self instructionStep].footnote;
     [_navigationFooterView updateContinueAndSkipEnabled];

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -31,6 +31,7 @@
 
 
 #import "ORKOrderedTask.h"
+#import "ORKNavigableOrderedTask.h"
 
 #import "ORKActiveStep_Internal.h"
 #import "ORKStep_Private.h"
@@ -119,7 +120,11 @@
 - (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
     NSArray *steps = _steps;
     
-    if (steps.count <= 0 || step.saveOnArrival) {
+    if (steps.count <= 0) {
+        return nil;
+    }
+    
+    if (step.saveOnArrival && ![self isKindOfClass:[ORKNavigableOrderedTask class]]) {
         return nil;
     }
     

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -119,7 +119,7 @@
 - (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
     NSArray *steps = _steps;
     
-    if (steps.count <= 0) {
+    if (steps.count <= 0 || step.saveOnArrival) {
         return nil;
     }
     

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1292,6 +1292,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
         stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
+    } else if (stepViewController.cancelButtonItem && stepViewController.step.saveOnArrival) {
+        stepViewController.cancelButtonItem = nil;
     }
     
     if ([self.delegate respondsToSelector:@selector(taskViewController:hasLearnMoreForStep:)] &&
@@ -1709,6 +1711,8 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
             
             if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
                 stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
+            } else if (stepViewController.cancelButtonItem && stepViewController.step.saveOnArrival) {
+                stepViewController.cancelButtonItem = nil;
             }
             
             if ([self.delegate respondsToSelector:@selector(taskViewController:hasLearnMoreForStep:)] &&

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1292,8 +1292,6 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     if (stepViewController.cancelButtonItem == nil && !stepViewController.step.saveOnArrival) {
         stepViewController.cancelButtonItem = [self defaultCancelButtonItem];
-    } else if (stepViewController.cancelButtonItem && stepViewController.step.saveOnArrival) {
-        stepViewController.cancelButtonItem = nil;
     }
     
     if ([self.delegate respondsToSelector:@selector(taskViewController:hasLearnMoreForStep:)] &&

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -176,8 +176,15 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
      CEVHACK - This fixes a bug that affects RK2 where the cancel button did nothing - because the view cycle is different than
      other subclasses of ORKStepViewController. Setting the cancelButtonItem on the _navigationFooterView needs to happen AFTER
      the super class ORKStepViewController has had a chance to create it.
+     
+     Also, don't attempt to set _navigationFooterView.cancelButtonItem = nil - as a side-effect it will update the text of the button
+     that will make it show as it exists regardless of whether it is nil or not. But tapping on the button, or invisible button
+     will have no effect because if _navigatorFooterView.cancelButtonItem is nil, the target-action chain messages nil.
      */
-    _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+    
+    if (!self.step.saveOnArrival) {
+        _navigationFooterView.cancelButtonItem = self.cancelButtonItem;
+    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1167.

In the process of testing on RK2, another bug surfaced - the cancel button still appears on saveOnArrival steps. The fix focuses only on the 3 expected step types support saveOnArrival from the original specs: InstructionStep, CompletionStep, and WebViewStep.

## Testing
Using a survey that has no skip or navigation rules (e.g., QA - QA Team > **End of Survey - Instruction step with validation test** or **End of Survey - Webview step with validation test**), validate that when the `saveOnArrival` step is reached, that the Done/Continue button is a Done button, no Cancel button exists - essentially no way to advance to a further step.