### PR TITLE
Don’t add tableview header if its calculated height is 0

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -186,9 +186,11 @@
         }
         
         CGSize headerSize = [baseView systemLayoutSizeFittingSize:(CGSize){_tableView.bounds.size.width,0} withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
-        baseView.bounds = (CGRect){{0,0}, headerSize};
         _tableView.tableHeaderView = nil;
-        _tableView.tableHeaderView = baseView;
+        if (headerSize.height > 0) {
+            baseView.bounds = (CGRect){{0,0}, headerSize};
+            _tableView.tableHeaderView = baseView;
+        }
     }
     
     {
@@ -200,11 +202,9 @@
         CGFloat contentInset = 0;
         contentInset = _tableView.adjustedContentInset.bottom + _tableView.adjustedContentInset.top;
         CGFloat boundsHeightUnused = _tableView.bounds.size.height - _tableView.contentSize.height - contentInset;
+        _tableView.scrollEnabled = YES;
         if (boundsHeightUnused > footerBounds.size.height) {
-            _tableView.scrollEnabled = YES;
             footerBounds.size.height = boundsHeightUnused;
-        } else {
-            _tableView.scrollEnabled = YES;
         }
         _realFooterView.frame = footerBounds;
         _tableView.tableFooterView = _realFooterView;


### PR DESCRIPTION
Re-fixes / Closes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1047 which experienced a regression from https://github.com/CareEvolution/ResearchKit/pull/135. 

Added a snapshot test for this situation in CEVResearchKit - https://github.com/CareEvolution/CEVResearchKit/pull/286.