### PR TITLE
Remove custom Accessibility implementation for UITableViews

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableContainerView.m
@@ -457,26 +457,4 @@
     [self animateLayoutForKeyboardNotification:notification];
 }
 
-#pragma mark - Accessibility
-
-- (BOOL)isAccessibilityElement {
-    return NO;
-}
-
-- (NSArray *)accessibilityElements {
-    NSMutableArray *elements = [[NSMutableArray alloc] init];
-    
-    [elements addObject:_stepHeaderView];
-    if (_imageView) {
-        [elements addObject:_imageView];
-    }
-    // UITableViewCells are not accessibility elements by default - https://stackoverflow.com/questions/57365412/why-uitableviewcell-is-not-accessible-for-voiceover
-    for (UITableViewCell *cell in _tableView.visibleCells) {
-        [elements addObject:cell];
-    }
-    [elements addObject:_continueSkipContainerView];
-    
-    return elements;
-}
-
 @end

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -396,32 +396,4 @@ static const CGFloat CellBottomPadding = 20.0;
     [self animateLayoutForKeyboardNotification:notification];
 }
 
-#pragma mark - Accessibility
-
-/*
- In RK2, the ORKQuestionStep.text is placed in a view of a UITableView section header 😳.
- The section header view is not exposed to Accessibility currently.
- TODO: add the section header into the Accessibility group/chain
- */
-
-
-- (BOOL)isAccessibilityElement {
-    return NO;
-}
-
-- (NSArray *)accessibilityElements {
-    NSMutableArray *elements = [[NSMutableArray alloc] init];
-    
-    [elements addObject:_stepHeaderView];
-    if (_imageView) {
-        [elements addObject:_imageView];
-    }
-    // UITableViewCells are not accessibility elements by default - https://stackoverflow.com/questions/57365412/why-uitableviewcell-is-not-accessible-for-voiceover
-    for (UITableViewCell *cell in _tableView.visibleCells) {
-        [elements addObject:cell];
-    }
-    
-    return elements;
-}
-
 @end


### PR DESCRIPTION
After noticing [this change](https://github.com/CareEvolution/ResearchKit/pull/135) broke many of the UI Tests in CEVResearchKit, I did a little investigation into how iOS intends for Accessibility to work on a UITableView. A parent and child view in a hierarchy cannot both have `isAccessibilityElement` set to true so the most distant descendant/subview should only have this set. Each UITableViewCell must consider how it will implement this. If a cell has no controls, it may set at the cell level with a custom implementation to describe its content. ResearchKit already has this covered in its implementations. While I was attempting to only address cells visible on the screen, that is not how it normally works. When having VoiceOver cycle through the entire screen, it will read ALL the TableView's rows unless stopped.

## Testing
To validate that these changes improve Accessibility in a consistent manner with other iOS apps:
1. Open the Contacts app in iOS.
2. Tap on All Contacts to open a list of contacts.
3. Turn on VoiceOver (can [setup triple-tap of power button](https://www.wayaround.com/voiceover-101/))
4. Tap an element at the top of the screen like the Lists "back button". It should read that button.
5. Two-finger swipe down on the screen which will start reading the screen. Take note of the behavior of how it scrolls itself, reading the titles. A single tap on the screen will stop it and read that cell, selecting it.
6. Perform the same behavior (open the 2 surveys below, turn on VoiceOver, tap on "Step 1 of 2", two-finger swipe down).
7. VoiceOver should read the items in order and for the (old) MDH logo state "MyDataHelps logo, image" as it goes down the screen. 
8. Furthermore, tapping on any item, including the image should read its description.
9. Repeat for the second step (Form Step) in each survey and notice similar behavior.

<details>
  <summary>RK1 Question/Form Step Survey example</summary>

```
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "QuestionStep",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus.",
      "title": "Question Step",
      "identifier": "QuestionStep",
      "image": "https://play-lh.googleusercontent.com/NvRkVn1T5D1rjUryUdsn74p3TzfzesXER8SijXnwKezppm5m9OvwafeSx0jr4QF4uw",
      "imageAltText": "MyDataHelps logo",
      "answerFormat": {
        "type": "TextAnswerFormat",
        "multipleLines": false,
        "keyboardType": "Text"
      },
      "optional": false,
      "placeholder": "This is the placeholder",
      "useCardView": true
    },
    {
      "type": "FormStep",
      "identifier": "FormStep",
      "image": "https://rkstudio-customer-assets.s3.amazonaws.com/OFFSPRING/three-heart-logo.gif",
      "imageAltText": "eFHS logo",
      "formItems": [
        {
          "identifier": "FormItem1",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem2",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        },
{
          "identifier": "FormItem3",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem4",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        }
      ],
      "optional": false,
      "title": "Form Step",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus."
    }
  ]
}
```

</details>
<details>
  <summary>RK2 Question/Form Step Survey example</summary>

```
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "rkVersion": 2,
  "steps": [
    {
      "type": "QuestionStep",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus.",
      "title": "Question Step",
      "identifier": "QuestionStep",
      "image": "https://play-lh.googleusercontent.com/NvRkVn1T5D1rjUryUdsn74p3TzfzesXER8SijXnwKezppm5m9OvwafeSx0jr4QF4uw",
      "imageAltText": "MyDataHelps logo",
      "answerFormat": {
        "type": "TextAnswerFormat",
        "multipleLines": false,
        "keyboardType": "Text"
      },
      "optional": false,
      "placeholder": "This is the placeholder",
      "useCardView": true
    },
    {
      "type": "FormStep",
      "identifier": "FormStep",
      "image": "https://rkstudio-customer-assets.s3.amazonaws.com/OFFSPRING/three-heart-logo.gif",
      "imageAltText": "eFHS logo",
      "formItems": [
        {
          "identifier": "FormItem1",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem2",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        },
{
          "identifier": "FormItem3",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextAnswerFormat",
            "multipleLines": false,
            "keyboardType": "Text"
          },
          "optional": false,
          "text": "Text Question",
          "placeholder": "placeholder"
        },
        {
          "identifier": "FormItem4",
          "type": "FormItem",
          "answerFormat": {
            "type": "NumericAnswerFormat",
            "style": "Integer"
          },
          "optional": false,
          "text": "Integer"
        }
      ],
      "optional": false,
      "title": "Form Step",
      "text": "This is text. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus."
    }
  ]
}
```