### PR TITLE
Fix most warnings for Xcode 14.3

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" ~> 1.0.3
+github "CareEvolution/MarkdownAttributedString" ~> 1.0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" ~> 1.0
+github "CareEvolution/MarkdownAttributedString" "eschramm/xcode14_3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" "eschramm/xcode14_3"
+github "CareEvolution/MarkdownAttributedString" ~> 1.0.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" "1.0.3"
+github "CareEvolution/MarkdownAttributedString" "1.0.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" "93f088faf63f877dc7efa6558253d03596e049e1"
+github "CareEvolution/MarkdownAttributedString" "1.0.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" "1.0.2"
+github "CareEvolution/MarkdownAttributedString" "93f088faf63f877dc7efa6558253d03596e049e1"

--- a/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
+++ b/ORK1Kit/ORK1Kit.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 		86C40D101A8D7C5C00081FAC /* ORK1DefaultFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7A1A8D7C5C00081FAC /* ORK1DefaultFont.h */; };
 		86C40D121A8D7C5C00081FAC /* ORK1Defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7B1A8D7C5C00081FAC /* ORK1Defines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D141A8D7C5C00081FAC /* ORK1Helpers_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7C1A8D7C5C00081FAC /* ORK1Helpers_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86C40D161A8D7C5C00081FAC /* ORK1Errors.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7D1A8D7C5C00081FAC /* ORK1Errors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86C40D161A8D7C5C00081FAC /* ORK1Errors.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7D1A8D7C5C00081FAC /* ORK1Errors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D181A8D7C5C00081FAC /* ORK1Errors.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40B7E1A8D7C5C00081FAC /* ORK1Errors.m */; };
 		86C40D1A1A8D7C5C00081FAC /* ORK1FormItem_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7F1A8D7C5C00081FAC /* ORK1FormItem_Internal.h */; };
 		86C40D1C1A8D7C5C00081FAC /* ORK1FormSectionTitleLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B801A8D7C5C00081FAC /* ORK1FormSectionTitleLabel.h */; };
@@ -331,7 +331,7 @@
 		86C40D5E1A8D7C5C00081FAC /* ORK1QuestionStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA11A8D7C5C00081FAC /* ORK1QuestionStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D601A8D7C5C00081FAC /* ORK1QuestionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40BA21A8D7C5C00081FAC /* ORK1QuestionStep.m */; };
 		86C40D621A8D7C5C00081FAC /* ORK1QuestionStep_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA31A8D7C5C00081FAC /* ORK1QuestionStep_Internal.h */; };
-		86C40D641A8D7C5C00081FAC /* ORK1QuestionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA41A8D7C5C00081FAC /* ORK1QuestionStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86C40D641A8D7C5C00081FAC /* ORK1QuestionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA41A8D7C5C00081FAC /* ORK1QuestionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D661A8D7C5C00081FAC /* ORK1QuestionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40BA51A8D7C5C00081FAC /* ORK1QuestionStepViewController.m */; };
 		86C40D681A8D7C5C00081FAC /* ORK1QuestionStepViewController_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA61A8D7C5C00081FAC /* ORK1QuestionStepViewController_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86C40D6A1A8D7C5C00081FAC /* ORK1Result.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA71A8D7C5C00081FAC /* ORK1Result.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3009,9 +3009,10 @@
 		3FFF18351829DB1D00167070 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = ORK1;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = researchkit.org;
 				TargetAttributes = {
 					86CC8E991AC09332001CCD89 = {
@@ -3664,7 +3665,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3687,6 +3688,8 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = ORK1Kit/ORK1Kit.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ORK1Kit;
@@ -3704,7 +3707,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3726,6 +3729,8 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = ORK1Kit/ORK1Kit.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ORK1Kit;

--- a/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/ORK1Kit.xcscheme
+++ b/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/ORK1Kit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
+++ b/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AccelerometerRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AccelerometerRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import HealthKit;
+#import <UIKit/UIKit.h>
+#import <HealthKit/HealthKit.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 #import <ORK1Kit/ORK1Recorder.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioRecorder.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import AVFoundation;
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1AudioStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1CountdownStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1CountdownStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1CountdownStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1CountdownStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1DataLogger.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1DataLogger.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Types.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1DeviceMotionRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1DeviceMotionRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1FitnessStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HealthQuantityTypeRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HealthQuantityTypeRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestPlaceStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestPlaceStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestPlaceStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestPlaceStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestRemoveStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestRemoveStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestRemoveStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1HolePegTestRemoveStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1LocationRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1LocationRecorder.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import CoreLocation;
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PSATStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PSATStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PSATStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PSATStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PedometerRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1PedometerRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 #import <ORK1Kit/ORK1OrderedTask.h>

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ReactionTimeStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ReactionTimeStep.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import AudioToolbox;
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1Recorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1Recorder.h
@@ -30,8 +30,8 @@
  */
 
 
-@import UIKit;
-@import HealthKit;
+#import <UIKit/UIKit.h>
+#import <HealthKit/HealthKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanMemoryStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanMemoryStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanMemoryStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanMemoryStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanTargetView.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1SpatialSpanTargetView.m
@@ -40,7 +40,7 @@
 
 static const UIEdgeInsets ORK1FlowerMargins = (UIEdgeInsets){12,12,12,12};
 static const CGSize ORK1FlowerBezierPathSize = (CGSize){90,90};
-static UIBezierPath *ORK1FlowerBezierPath() {
+static UIBezierPath *ORK1FlowerBezierPath(void) {
     UIBezierPath *bezierPath = UIBezierPath.bezierPath;
     [bezierPath moveToPoint: CGPointMake(58.8, 45)];
     [bezierPath addCurveToPoint: CGPointMake(51.9, 33.2) controlPoint1: CGPointMake(107.8, 41.8) controlPoint2: CGPointMake(79.3, -7.2)];
@@ -62,7 +62,7 @@ static UIBezierPath *ORK1FlowerBezierPath() {
 }
 
 static const CGSize ORK1CheckBezierPathSize = (CGSize){28,28};
-static UIBezierPath *ORK1CheckBezierPath() {
+static UIBezierPath *ORK1CheckBezierPath(void) {
     UIBezierPath *bezierPath = UIBezierPath.bezierPath;
     [bezierPath moveToPoint: CGPointMake(11.6, 19)];
     [bezierPath addCurveToPoint: CGPointMake(11.1, 18.8) controlPoint1: CGPointMake(11.4, 19) controlPoint2: CGPointMake(11.2, 18.9)];
@@ -82,7 +82,7 @@ static UIBezierPath *ORK1CheckBezierPath() {
 }
 
 static const CGSize ORK1ErrorBezierPathSize = (CGSize){28,28};
-static UIBezierPath *ORK1ErrorBezierPath() {
+static UIBezierPath *ORK1ErrorBezierPath(void) {
     UIBezierPath *bezier3Path = UIBezierPath.bezierPath;
     [bezier3Path moveToPoint: CGPointMake(15.1, 14)];
     [bezier3Path addLineToPoint: CGPointMake(18.8, 10.3)];

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1StroopStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1StroopStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TappingIntervalStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TappingIntervalStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TappingIntervalStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TappingIntervalStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryPracticeStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryPracticeStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryPracticeStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryPracticeStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ToneAudiometryStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchAnywhereStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchAnywhereStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchAnywhereStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchAnywhereStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchRecorder.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TouchRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Recorder.h>
 
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TowerOfHanoiStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TowerOfHanoiStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TrailmakingStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TrailmakingStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 #import <ORK1Kit/ORK1OrderedTask.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1WalkingTaskStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1WalkingTaskStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStep.h>
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1WalkingTaskStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1WalkingTaskStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1ActiveStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1BarGraphChartView.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1BarGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1GraphChartView.h>
 
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1ChartTypes.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1ChartTypes.h
@@ -32,7 +32,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1DiscreteGraphChartView.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1DiscreteGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1GraphChartView.h>
 
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1GraphChartView.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1GraphChartView.h
@@ -32,7 +32,7 @@
 */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1GraphChartView_Internal.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1GraphChartView_Internal.h
@@ -68,11 +68,11 @@ extern const CGFloat ORK1GraphChartViewScrubberMoveAnimationDuration;
 extern const CGFloat ORK1GraphChartViewAxisTickLength;
 extern const CGFloat ORK1GraphChartViewYAxisTickPadding;
 
-ORK1_INLINE CGFloat scalePixelAdjustment() {
+ORK1_INLINE CGFloat scalePixelAdjustment(void) {
     return (1.0 / [UIScreen mainScreen].scale);
 }
 
-ORK1_INLINE CAShapeLayer *graphLineLayer() {
+ORK1_INLINE CAShapeLayer *graphLineLayer(void) {
     CAShapeLayer *lineLayer = [CAShapeLayer layer];
     lineLayer.fillColor = [UIColor clearColor].CGColor;
     lineLayer.lineJoin = kCALineJoinRound;

--- a/ORK1Kit/ORK1Kit/Charts/ORK1LineGraphChartView.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1LineGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
  
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1GraphChartView.h>
 
 

--- a/ORK1Kit/ORK1Kit/Charts/ORK1PieChartView.h
+++ b/ORK1Kit/ORK1Kit/Charts/ORK1PieChartView.h
@@ -31,7 +31,7 @@
 */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 researchkit.org. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 #import <ORK1Kit/ORK1Defines.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.h
@@ -33,7 +33,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Types.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1AnswerFormat.m
@@ -50,7 +50,7 @@
 
 NSString *const EmailValidationRegularExpressionPattern = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}";
 
-id ORK1NullAnswerValue() {
+id ORK1NullAnswerValue(void) {
     return [NSNull null];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1BorderedButton.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1BorderedButton.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1TextButton.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1CompletionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1CompletionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1InstructionStep.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1CompletionStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1CompletionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1InstructionStepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ContinueButton.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1BorderedButton.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1CustomStepView.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1CustomStepView.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Defines.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Defines.h
@@ -28,8 +28,8 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 
 #if defined(__cplusplus)
 #  define ORK1_EXTERN extern "C" __attribute__((visibility("default")))

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentReviewStepViewController.h
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1DocumentSelectionStepViewController.h
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Errors.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Errors.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FormStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1HealthAnswerFormat.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1HealthAnswerFormat.h
@@ -29,7 +29,7 @@
  */
 
 
-@import HealthKit;
+#import <HealthKit/HealthKit.h>
 #import <ORK1Kit/ORK1AnswerFormat.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers.m
@@ -39,7 +39,7 @@
 #import <CoreText/CoreText.h>
 
 
-NSURL *ORK1CreateRandomBaseURL() {
+NSURL *ORK1CreateRandomBaseURL(void) {
     return [NSURL URLWithString:[NSString stringWithFormat:@"https://researchkit.%@/", [NSUUID UUID].UUIDString]];
 }
 
@@ -199,7 +199,7 @@ void ORK1EnableAutoLayoutForViews(NSArray *views) {
     }];
 }
 
-NSDateFormatter *ORK1ResultDateTimeFormatter() {
+NSDateFormatter *ORK1ResultDateTimeFormatter(void) {
     static NSDateFormatter *dateTimeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -210,7 +210,7 @@ NSDateFormatter *ORK1ResultDateTimeFormatter() {
     return dateTimeformatter;
 }
 
-NSDateFormatter *ORK1ResultTimeFormatter() {
+NSDateFormatter *ORK1ResultTimeFormatter(void) {
     static NSDateFormatter *timeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -221,7 +221,7 @@ NSDateFormatter *ORK1ResultTimeFormatter() {
     return timeformatter;
 }
 
-NSDateFormatter *ORK1ResultDateFormatter() {
+NSDateFormatter *ORK1ResultDateFormatter(void) {
     static NSDateFormatter *dateformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -232,7 +232,7 @@ NSDateFormatter *ORK1ResultDateFormatter() {
     return dateformatter;
 }
 
-NSDateFormatter *ORK1TimeOfDayLabelFormatter() {
+NSDateFormatter *ORK1TimeOfDayLabelFormatter(void) {
     static NSDateFormatter *timeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -244,7 +244,7 @@ NSDateFormatter *ORK1TimeOfDayLabelFormatter() {
     return timeformatter;
 }
 
-NSBundle *ORK1Bundle() {
+NSBundle *ORK1Bundle(void) {
     static NSBundle *bundle;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -253,7 +253,7 @@ NSBundle *ORK1Bundle() {
     return bundle;
 }
 
-NSBundle *ORK1DefaultLocaleBundle() {
+NSBundle *ORK1DefaultLocaleBundle(void) {
     static NSBundle *bundle;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -263,7 +263,7 @@ NSBundle *ORK1DefaultLocaleBundle() {
     return bundle;
 }
 
-NSDateComponentsFormatter *ORK1TimeIntervalLabelFormatter() {
+NSDateComponentsFormatter *ORK1TimeIntervalLabelFormatter(void) {
     static NSDateComponentsFormatter *durationFormatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -276,7 +276,7 @@ NSDateComponentsFormatter *ORK1TimeIntervalLabelFormatter() {
     return durationFormatter;
 }
 
-NSDateComponentsFormatter *ORK1DurationStringFormatter() {
+NSDateComponentsFormatter *ORK1DurationStringFormatter(void) {
     static NSDateComponentsFormatter *durationFormatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -289,7 +289,7 @@ NSDateComponentsFormatter *ORK1DurationStringFormatter() {
     return durationFormatter;
 }
 
-NSCalendar *ORK1TimeOfDayReferenceCalendar() {
+NSCalendar *ORK1TimeOfDayReferenceCalendar(void) {
     static NSCalendar *calendar;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -334,7 +334,7 @@ NSDate *ORK1TimeOfDayDateFromComponents(NSDateComponents *dateComponents) {
     return [ORK1TimeOfDayReferenceCalendar() dateFromComponents:dateComponents];
 }
 
-BOOL ORK1CurrentLocalePresentsFamilyNameFirst() {
+BOOL ORK1CurrentLocalePresentsFamilyNameFirst(void) {
     NSString *language = [[NSLocale preferredLanguages].firstObject substringToIndex:2];
     static dispatch_once_t onceToken;
     static NSArray *familyNameFirstLanguages = nil;
@@ -470,7 +470,7 @@ NSString *ORK1PathRelativeToURL(NSURL *url, NSURL *baseURL) {
     }
 }
 
-static NSURL *ORK1HomeDirectoryURL() {
+static NSURL *ORK1HomeDirectoryURL(void) {
     static NSURL *homeDirectoryURL = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -537,7 +537,7 @@ NSString *ORK1PaddingWithNumberOfSpaces(NSUInteger numberOfPaddingSpaces) {
     return [@"" stringByPaddingToLength:numberOfPaddingSpaces withString:@" " startingAtIndex:0];
 }
 
-NSNumberFormatter *ORK1DecimalNumberFormatter() {
+NSNumberFormatter *ORK1DecimalNumberFormatter(void) {
     NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
     numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     numberFormatter.maximumFractionDigits = NSDecimalNoScale;

--- a/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Private.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Helpers_Private.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ImageCaptureStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1InstructionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1KeychainWrapper.m
@@ -34,7 +34,7 @@
 #import "ORK1Helpers_Internal.h"
 
 
-static NSString *ORK1KeychainWrapperDefaultService() {
+static NSString *ORK1KeychainWrapperDefaultService(void) {
     static NSString *defaultService;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1NavigableOrderedTask.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1OrderedTask.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1OrderedTask.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Task.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Kit.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1PasscodeViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1Types.h>

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1QuestionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import CoreLocation;
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 #import <ORK1Kit/ORK1Types.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ResultPredicate.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result_Private.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result_Private.h
@@ -30,7 +30,7 @@
 
 
 #import <ORK1Kit/ORK1Result.h>
-@import MapKit;
+#import <MapKit/MapKit.h>
 
 @class ORK1PageStep;
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ReviewStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ReviewStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ReviewStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1SignatureStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SignatureStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1SignatureStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1SignatureStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Kit.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Skin.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Skin.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Skin.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Skin.m
@@ -72,7 +72,7 @@ ORK1CachedColorMethod(ork_darkGrayColor, 102.0 / 255.0, 102.0 / 255.0, 102.0 / 2
 
 @end
 
-static NSMutableDictionary *colors() {
+static NSMutableDictionary *colors(void) {
     static NSMutableDictionary *colors = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/ORK1Kit/ORK1Kit/Common/ORK1Step.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Step.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 #import <ORK1Kit/ORK1Types.h>
 #import <ORK1Kit/CEVRK1Theme.h>
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepNavigationRule.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepNavigationRule.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1TableStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TableStepViewController.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Task.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Task.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 #import <ORK1Kit/ORK1Types.h>
 
 #import <ORK1Kit/CEVRK1Theme.h>

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1TextButton.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TextButton.h
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Types.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Types.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1WaitStep.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WaitStep.h
@@ -38,7 +38,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1WaitStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WaitStepViewController.h
@@ -38,7 +38,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.h
@@ -28,8 +28,8 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
-@import WebKit;
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.h
@@ -30,7 +30,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSection.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSection.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSharingStep.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSharingStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1QuestionStep.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSharingStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSharingStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Kit.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSignature.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentSignature.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1VisualConsentStep.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1VisualConsentStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Consent/ORK1VisualConsentStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1VisualConsentStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1Defines.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStep.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1FormStep.h>
 
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1FormStepViewController.h>
 
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1RegistrationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1FormStep.h>
 
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStep.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ORK1Kit/ORK1Step.h>
 
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1VerificationStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ORK1Kit/ORK1StepViewController.h>
 
 

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -175,7 +175,7 @@
 		716B126520A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126320A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m */; };
 		716B126820A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126620A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h */; };
 		716B126920A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126720A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m */; };
-		71769E2920880C4500A19914 /* ORKdBHLToneAudiometryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2720880C4500A19914 /* ORKdBHLToneAudiometryResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		71769E2920880C4500A19914 /* ORKdBHLToneAudiometryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2720880C4500A19914 /* ORKdBHLToneAudiometryResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71769E2A20880C4500A19914 /* ORKdBHLToneAudiometryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2820880C4500A19914 /* ORKdBHLToneAudiometryResult.m */; };
 		71769E2D208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2B208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h */; };
 		71769E2E208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2C208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m */; };
@@ -383,7 +383,7 @@
 		86C40D101A8D7C5C00081FAC /* ORKDefaultFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7A1A8D7C5C00081FAC /* ORKDefaultFont.h */; };
 		86C40D121A8D7C5C00081FAC /* ORKDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7B1A8D7C5C00081FAC /* ORKDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D141A8D7C5C00081FAC /* ORKHelpers_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7C1A8D7C5C00081FAC /* ORKHelpers_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86C40D161A8D7C5C00081FAC /* ORKErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7D1A8D7C5C00081FAC /* ORKErrors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86C40D161A8D7C5C00081FAC /* ORKErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7D1A8D7C5C00081FAC /* ORKErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D181A8D7C5C00081FAC /* ORKErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40B7E1A8D7C5C00081FAC /* ORKErrors.m */; };
 		86C40D1A1A8D7C5C00081FAC /* ORKFormItem_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B7F1A8D7C5C00081FAC /* ORKFormItem_Internal.h */; };
 		86C40D1C1A8D7C5C00081FAC /* ORKFormSectionTitleLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B801A8D7C5C00081FAC /* ORKFormSectionTitleLabel.h */; };
@@ -416,7 +416,7 @@
 		86C40D5E1A8D7C5C00081FAC /* ORKQuestionStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA11A8D7C5C00081FAC /* ORKQuestionStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D601A8D7C5C00081FAC /* ORKQuestionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40BA21A8D7C5C00081FAC /* ORKQuestionStep.m */; };
 		86C40D621A8D7C5C00081FAC /* ORKQuestionStep_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA31A8D7C5C00081FAC /* ORKQuestionStep_Internal.h */; };
-		86C40D641A8D7C5C00081FAC /* ORKQuestionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA41A8D7C5C00081FAC /* ORKQuestionStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86C40D641A8D7C5C00081FAC /* ORKQuestionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA41A8D7C5C00081FAC /* ORKQuestionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D661A8D7C5C00081FAC /* ORKQuestionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40BA51A8D7C5C00081FAC /* ORKQuestionStepViewController.m */; };
 		86C40D681A8D7C5C00081FAC /* ORKQuestionStepViewController_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA61A8D7C5C00081FAC /* ORKQuestionStepViewController_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86C40D6A1A8D7C5C00081FAC /* ORKResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40BA71A8D7C5C00081FAC /* ORKResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -577,7 +577,7 @@
 		BA95AA9F20ACD0E700E7FF8E /* ORKAmslerGridContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = BA95AA9D20ACD0E700E7FF8E /* ORKAmslerGridContentView.m */; };
 		BABBB19D2093299A00CB29E5 /* ORKSurveyCardHeaderView.h in Headers */ = {isa = PBXBuildFile; fileRef = BABBB19B2093299A00CB29E5 /* ORKSurveyCardHeaderView.h */; };
 		BABBB19E2093299A00CB29E5 /* ORKSurveyCardHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = BABBB19C2093299A00CB29E5 /* ORKSurveyCardHeaderView.m */; };
-		BABBB1AE2097D97200CB29E5 /* ORKPDFViewerStep.h in Headers */ = {isa = PBXBuildFile; fileRef = BABBB1AC2097D97200CB29E5 /* ORKPDFViewerStep.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BABBB1AE2097D97200CB29E5 /* ORKPDFViewerStep.h in Headers */ = {isa = PBXBuildFile; fileRef = BABBB1AC2097D97200CB29E5 /* ORKPDFViewerStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BABBB1AF2097D97200CB29E5 /* ORKPDFViewerStep.m in Sources */ = {isa = PBXBuildFile; fileRef = BABBB1AD2097D97200CB29E5 /* ORKPDFViewerStep.m */; };
 		BABBB1B22097E16700CB29E5 /* ORKPDFViewerStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = BABBB1B02097E16700CB29E5 /* ORKPDFViewerStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BABBB1B32097E16700CB29E5 /* ORKPDFViewerStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BABBB1B12097E16700CB29E5 /* ORKPDFViewerStepViewController.m */; };
@@ -3523,9 +3523,10 @@
 		3FFF18351829DB1D00167070 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = ORK;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = researchkit.org;
 				TargetAttributes = {
 					86CC8E991AC09332001CCD89 = {
@@ -4252,7 +4253,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -4275,6 +4276,8 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = ResearchKit/ResearchKit.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ResearchKit;
@@ -4292,7 +4295,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -4314,6 +4317,8 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = ResearchKit/ResearchKit.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ResearchKit;

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit/ActiveTasks/ORKAccelerometerRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKAccelerometerRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKActiveStep.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import HealthKit;
+#import <UIKit/UIKit.h>
+#import <HealthKit/HealthKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 #import <ResearchKit/ORKRecorder.h>
 

--- a/ResearchKit/ActiveTasks/ORKAudioRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKAudioRecorder.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import AVFoundation;
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKAudioStep.h
+++ b/ResearchKit/ActiveTasks/ORKAudioStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKActiveStep.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKAudioStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKAudioStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKCountdownStep.h
+++ b/ResearchKit/ActiveTasks/ORKCountdownStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKCountdownStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKCountdownStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKDataLogger.h
+++ b/ResearchKit/ActiveTasks/ORKDataLogger.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKTypes.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKEnvironmentSPLMeterStep.h
+++ b/ResearchKit/ActiveTasks/ORKEnvironmentSPLMeterStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKFitnessStep.h
+++ b/ResearchKit/ActiveTasks/ORKFitnessStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKFitnessStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKFitnessStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKHealthClinicalTypeRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKHealthClinicalTypeRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 #import <Availability.h>
 

--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKHolePegTestPlaceStep.h
+++ b/ResearchKit/ActiveTasks/ORKHolePegTestPlaceStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKHolePegTestPlaceStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKHolePegTestPlaceStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKHolePegTestRemoveStep.h
+++ b/ResearchKit/ActiveTasks/ORKHolePegTestRemoveStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKHolePegTestRemoveStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKHolePegTestRemoveStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKLocationRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKLocationRecorder.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import CoreLocation;
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeStep.h
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeStep.h
@@ -30,8 +30,8 @@
  */
 
 
-@import Foundation;
-@import AudioToolbox;
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKPSATStep.h
+++ b/ResearchKit/ActiveTasks/ORKPSATStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKPSATStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKPSATStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKPedometerRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKPedometerRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.h
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 #import <ResearchKit/ORKOrderedTask.h>

--- a/ResearchKit/ActiveTasks/ORKReactionTimeStep.h
+++ b/ResearchKit/ActiveTasks/ORKReactionTimeStep.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import AudioToolbox;
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKRecorder.h
@@ -30,8 +30,8 @@
  */
 
 
-@import UIKit;
-@import HealthKit;
+#import <UIKit/UIKit.h>
+#import <HealthKit/HealthKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <Availability.h>
 

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStep.h
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanTargetView.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanTargetView.m
@@ -40,7 +40,7 @@
 
 static const UIEdgeInsets ORKFlowerMargins = (UIEdgeInsets){12,12,12,12};
 static const CGSize ORKFlowerBezierPathSize = (CGSize){90,90};
-static UIBezierPath *ORKFlowerBezierPath() {
+static UIBezierPath *ORKFlowerBezierPath(void) {
     UIBezierPath *bezierPath = UIBezierPath.bezierPath;
     [bezierPath moveToPoint: CGPointMake(58.8, 45)];
     [bezierPath addCurveToPoint: CGPointMake(51.9, 33.2) controlPoint1: CGPointMake(107.8, 41.8) controlPoint2: CGPointMake(79.3, -7.2)];
@@ -62,7 +62,7 @@ static UIBezierPath *ORKFlowerBezierPath() {
 }
 
 static const CGSize ORKCheckBezierPathSize = (CGSize){28,28};
-static UIBezierPath *ORKCheckBezierPath() {
+static UIBezierPath *ORKCheckBezierPath(void) {
     UIBezierPath *bezierPath = UIBezierPath.bezierPath;
     [bezierPath moveToPoint: CGPointMake(11.6, 19)];
     [bezierPath addCurveToPoint: CGPointMake(11.1, 18.8) controlPoint1: CGPointMake(11.4, 19) controlPoint2: CGPointMake(11.2, 18.9)];
@@ -82,7 +82,7 @@ static UIBezierPath *ORKCheckBezierPath() {
 }
 
 static const CGSize ORKErrorBezierPathSize = (CGSize){28,28};
-static UIBezierPath *ORKErrorBezierPath() {
+static UIBezierPath *ORKErrorBezierPath(void) {
     UIBezierPath *bezier3Path = UIBezierPath.bezierPath;
     [bezier3Path moveToPoint: CGPointMake(15.1, 14)];
     [bezier3Path addLineToPoint: CGPointMake(18.8, 10.3)];

--- a/ResearchKit/ActiveTasks/ORKSpeechInNoiseStep.h
+++ b/ResearchKit/ActiveTasks/ORKSpeechInNoiseStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.h
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKActiveStep.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKStreamingAudioRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKStreamingAudioRecorder.h
@@ -29,8 +29,8 @@
  */
 
 
-@import UIKit;
-@import AVFoundation;
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 #import <ResearchKit/ORKRecorder.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ResearchKit/ActiveTasks/ORKStroopStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKStroopStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalResult.h
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalResult.h
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKResult.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStep.h
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKTimedWalkResult.h
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkResult.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKResult.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKTimedWalkStep.h
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryStep.h
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKTouchAnywhereStep.h
+++ b/ResearchKit/ActiveTasks/ORKTouchAnywhereStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKTouchAnywhereStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKTouchAnywhereStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKTouchRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKTouchRecorder.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKRecorder.h>
 
 

--- a/ResearchKit/ActiveTasks/ORKTowerOfHanoiStep.h
+++ b/ResearchKit/ActiveTasks/ORKTowerOfHanoiStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKTrailmakingStep.h
+++ b/ResearchKit/ActiveTasks/ORKTrailmakingStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKActiveStep.h>
 #import <ResearchKit/ORKOrderedTask.h>
 

--- a/ResearchKit/ActiveTasks/ORKWalkingTaskStep.h
+++ b/ResearchKit/ActiveTasks/ORKWalkingTaskStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKWalkingTaskStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKWalkingTaskStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStep.h>
 

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 

--- a/ResearchKit/Charts/ORKBarGraphChartView.h
+++ b/ResearchKit/Charts/ORKBarGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKGraphChartView.h>
 
 

--- a/ResearchKit/Charts/ORKChartTypes.h
+++ b/ResearchKit/Charts/ORKChartTypes.h
@@ -32,7 +32,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.h
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKGraphChartView.h>
 
 

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -32,7 +32,7 @@
 */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -68,11 +68,11 @@ extern const CGFloat ORKGraphChartViewScrubberMoveAnimationDuration;
 extern const CGFloat ORKGraphChartViewAxisTickLength;
 extern const CGFloat ORKGraphChartViewYAxisTickPadding;
 
-ORK_INLINE CGFloat scalePixelAdjustment() {
+ORK_INLINE CGFloat scalePixelAdjustment(void) {
     return (1.0 / [UIScreen mainScreen].scale);
 }
 
-ORK_INLINE CAShapeLayer *graphLineLayer() {
+ORK_INLINE CAShapeLayer *graphLineLayer(void) {
     CAShapeLayer *lineLayer = [CAShapeLayer layer];
     lineLayer.fillColor = [UIColor clearColor].CGColor;
     lineLayer.lineJoin = kCALineJoinRound;

--- a/ResearchKit/Charts/ORKLineGraphChartView.h
+++ b/ResearchKit/Charts/ORKLineGraphChartView.h
@@ -30,7 +30,7 @@
  */
 
  
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKGraphChartView.h>
 
 

--- a/ResearchKit/Charts/ORKPieChartView.h
+++ b/ResearchKit/Charts/ORKPieChartView.h
@@ -31,7 +31,7 @@
 */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -33,7 +33,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKTypes.h>
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -51,7 +51,7 @@
 
 NSString *const EmailValidationRegularExpressionPattern = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}";
 
-id ORKNullAnswerValue() {
+id ORKNullAnswerValue(void) {
     return [NSNull null];
 }
 

--- a/ResearchKit/Common/ORKBorderedButton.h
+++ b/ResearchKit/Common/ORKBorderedButton.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKTextButton.h>
 
 

--- a/ResearchKit/Common/ORKCompletionStep.h
+++ b/ResearchKit/Common/ORKCompletionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKInstructionStep.h>
 
 

--- a/ResearchKit/Common/ORKCompletionStepViewController.h
+++ b/ResearchKit/Common/ORKCompletionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKInstructionStepViewController.h>
 

--- a/ResearchKit/Common/ORKContinueButton.h
+++ b/ResearchKit/Common/ORKContinueButton.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKBorderedButton.h>
 
 

--- a/ResearchKit/Common/ORKCustomStepView.h
+++ b/ResearchKit/Common/ORKCustomStepView.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKDefines.h
+++ b/ResearchKit/Common/ORKDefines.h
@@ -28,8 +28,8 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 
 #if defined(__cplusplus)
 #  define ORK_EXTERN extern "C" __attribute__((visibility("default")))

--- a/ResearchKit/Common/ORKErrors.h
+++ b/ResearchKit/Common/ORKErrors.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKFormStepViewController.h
+++ b/ResearchKit/Common/ORKFormStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 

--- a/ResearchKit/Common/ORKHealthAnswerFormat.h
+++ b/ResearchKit/Common/ORKHealthAnswerFormat.h
@@ -29,7 +29,7 @@
  */
 
 
-@import HealthKit;
+#import <HealthKit/HealthKit.h>
 #import <ResearchKit/ORKAnswerFormat.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -39,7 +39,7 @@
 #import <CoreText/CoreText.h>
 
 
-NSURL *ORKCreateRandomBaseURL() {
+NSURL *ORKCreateRandomBaseURL(void) {
     return [NSURL URLWithString:[NSString stringWithFormat:@"https://researchkit.%@/", [NSUUID UUID].UUIDString]];
 }
 
@@ -199,7 +199,7 @@ void ORKEnableAutoLayoutForViews(NSArray *views) {
     }];
 }
 
-NSDateFormatter *ORKResultDateTimeFormatter() {
+NSDateFormatter *ORKResultDateTimeFormatter(void) {
     static NSDateFormatter *dateTimeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -210,7 +210,7 @@ NSDateFormatter *ORKResultDateTimeFormatter() {
     return dateTimeformatter;
 }
 
-NSDateFormatter *ORKResultTimeFormatter() {
+NSDateFormatter *ORKResultTimeFormatter(void) {
     static NSDateFormatter *timeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -221,7 +221,7 @@ NSDateFormatter *ORKResultTimeFormatter() {
     return timeformatter;
 }
 
-NSDateFormatter *ORKResultDateFormatter() {
+NSDateFormatter *ORKResultDateFormatter(void) {
     static NSDateFormatter *dateformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -232,7 +232,7 @@ NSDateFormatter *ORKResultDateFormatter() {
     return dateformatter;
 }
 
-NSDateFormatter *ORKTimeOfDayLabelFormatter() {
+NSDateFormatter *ORKTimeOfDayLabelFormatter(void) {
     static NSDateFormatter *timeformatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -244,7 +244,7 @@ NSDateFormatter *ORKTimeOfDayLabelFormatter() {
     return timeformatter;
 }
 
-NSBundle *ORKBundle() {
+NSBundle *ORKBundle(void) {
     static NSBundle *bundle;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -253,7 +253,7 @@ NSBundle *ORKBundle() {
     return bundle;
 }
 
-NSBundle *ORKDefaultLocaleBundle() {
+NSBundle *ORKDefaultLocaleBundle(void) {
     static NSBundle *bundle;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -263,7 +263,7 @@ NSBundle *ORKDefaultLocaleBundle() {
     return bundle;
 }
 
-NSDateComponentsFormatter *ORKTimeIntervalLabelFormatter() {
+NSDateComponentsFormatter *ORKTimeIntervalLabelFormatter(void) {
     static NSDateComponentsFormatter *durationFormatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -276,7 +276,7 @@ NSDateComponentsFormatter *ORKTimeIntervalLabelFormatter() {
     return durationFormatter;
 }
 
-NSDateComponentsFormatter *ORKDurationStringFormatter() {
+NSDateComponentsFormatter *ORKDurationStringFormatter(void) {
     static NSDateComponentsFormatter *durationFormatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -289,7 +289,7 @@ NSDateComponentsFormatter *ORKDurationStringFormatter() {
     return durationFormatter;
 }
 
-NSCalendar *ORKTimeOfDayReferenceCalendar() {
+NSCalendar *ORKTimeOfDayReferenceCalendar(void) {
     static NSCalendar *calendar;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -334,7 +334,7 @@ NSDate *ORKTimeOfDayDateFromComponents(NSDateComponents *dateComponents) {
     return [ORKTimeOfDayReferenceCalendar() dateFromComponents:dateComponents];
 }
 
-BOOL ORKCurrentLocalePresentsFamilyNameFirst() {
+BOOL ORKCurrentLocalePresentsFamilyNameFirst(void) {
     NSString *language = [[NSLocale preferredLanguages].firstObject substringToIndex:2];
     static dispatch_once_t onceToken;
     static NSArray *familyNameFirstLanguages = nil;
@@ -470,7 +470,7 @@ NSString *ORKPathRelativeToURL(NSURL *url, NSURL *baseURL) {
     }
 }
 
-static NSURL *ORKHomeDirectoryURL() {
+static NSURL *ORKHomeDirectoryURL(void) {
     static NSURL *homeDirectoryURL = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -537,7 +537,7 @@ NSString *ORKPaddingWithNumberOfSpaces(NSUInteger numberOfPaddingSpaces) {
     return [@"" stringByPaddingToLength:numberOfPaddingSpaces withString:@" " startingAtIndex:0];
 }
 
-NSNumberFormatter *ORKDecimalNumberFormatter() {
+NSNumberFormatter *ORKDecimalNumberFormatter(void) {
     NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
     numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     numberFormatter.maximumFractionDigits = NSDecimalNoScale;

--- a/ResearchKit/Common/ORKHelpers_Private.h
+++ b/ResearchKit/Common/ORKHelpers_Private.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKImageCaptureStep.h
+++ b/ResearchKit/Common/ORKImageCaptureStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKImageCaptureStepViewController.h
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Common/ORKInstructionStep.h
+++ b/ResearchKit/Common/ORKInstructionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKInstructionStepViewController.h
+++ b/ResearchKit/Common/ORKInstructionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Common/ORKKeychainWrapper.h
+++ b/ResearchKit/Common/ORKKeychainWrapper.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKKeychainWrapper.m
+++ b/ResearchKit/Common/ORKKeychainWrapper.m
@@ -34,7 +34,7 @@
 #import "ORKHelpers_Internal.h"
 
 
-static NSString *ORKKeychainWrapperDefaultService() {
+static NSString *ORKKeychainWrapperDefaultService(void) {
     static NSString *defaultService;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/ResearchKit/Common/ORKNavigableOrderedTask.h
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKOrderedTask.h>
 
 

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKOrderedTask.h>
 
 

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKTask.h>
 
 

--- a/ResearchKit/Common/ORKPDFViewerStepViewController.h
+++ b/ResearchKit/Common/ORKPDFViewerStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Common/ORKPasscodeStep.h
+++ b/ResearchKit/Common/ORKPasscodeStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKPasscodeStepViewController.h
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ResearchKit.h>
 
 

--- a/ResearchKit/Common/ORKPasscodeViewController.h
+++ b/ResearchKit/Common/ORKPasscodeViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKTypes.h>

--- a/ResearchKit/Common/ORKQuestionResult.h
+++ b/ResearchKit/Common/ORKQuestionResult.h
@@ -30,7 +30,7 @@
 
 
 #import <ResearchKit/ORKResult.h>
-@import CoreLocation;
+#import <CoreLocation/CoreLocation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ResearchKit/Common/ORKQuestionResult_Private.h
+++ b/ResearchKit/Common/ORKQuestionResult_Private.h
@@ -30,7 +30,7 @@
 
 
 #import <ResearchKit/ORKQuestionResult.h>
-@import MapKit;
+#import <MapKit/MapKit.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKQuestionStepViewController.h
+++ b/ResearchKit/Common/ORKQuestionStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKTypes.h>
 
 

--- a/ResearchKit/Common/ORKResultPredicate.h
+++ b/ResearchKit/Common/ORKResultPredicate.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKReviewStep.h
+++ b/ResearchKit/Common/ORKReviewStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKReviewStepViewController.h
+++ b/ResearchKit/Common/ORKReviewStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Common/ORKSignatureStep.h
+++ b/ResearchKit/Common/ORKSignatureStep.h
@@ -30,7 +30,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKSignatureStepViewController.h
+++ b/ResearchKit/Common/ORKSignatureStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ResearchKit.h>
 
 

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -86,7 +86,7 @@ ORKCachedColorMethod(ork_borderGrayColor, 239.0 / 255.0, 239.0 / 255.0, 244.0 / 
 
 @end
 
-static NSMutableDictionary *colors() {
+static NSMutableDictionary *colors(void) {
     static NSMutableDictionary *colors = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 #import <ResearchKit/ORKTypes.h>
 
 

--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKStepViewController.h
+++ b/ResearchKit/Common/ORKStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKTableStep.h
+++ b/ResearchKit/Common/ORKTableStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKTableStepViewController.h
+++ b/ResearchKit/Common/ORKTableStepViewController.h
@@ -30,7 +30,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 

--- a/ResearchKit/Common/ORKTask.h
+++ b/ResearchKit/Common/ORKTask.h
@@ -29,8 +29,8 @@
  */
 
 
-@import Foundation;
-@import HealthKit;
+#import <Foundation/Foundation.h>
+#import <HealthKit/HealthKit.h>
 #import <ResearchKit/ORKTypes.h>
 
 

--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 

--- a/ResearchKit/Common/ORKTextButton.h
+++ b/ResearchKit/Common/ORKTextButton.h
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKTypes.h
+++ b/ResearchKit/Common/ORKTypes.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Common/ORKWaitStep.h
+++ b/ResearchKit/Common/ORKWaitStep.h
@@ -38,7 +38,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Common/ORKWaitStepViewController.h
+++ b/ResearchKit/Common/ORKWaitStepViewController.h
@@ -38,7 +38,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 

--- a/ResearchKit/Common/ORKWebViewStepViewController.h
+++ b/ResearchKit/Common/ORKWebViewStepViewController.h
@@ -28,8 +28,8 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import UIKit;
-@import WebKit;
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ResearchKit/Consent/ORKConsentDocument.h
+++ b/ResearchKit/Consent/ORKConsentDocument.h
@@ -30,7 +30,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 
 @class ORKHTMLPDFPageRenderer;

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Consent/ORKConsentSection.h
+++ b/ResearchKit/Consent/ORKConsentSection.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Consent/ORKConsentSharingStep.h
+++ b/ResearchKit/Consent/ORKConsentSharingStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKQuestionStep.h>
 
 

--- a/ResearchKit/Consent/ORKConsentSharingStepViewController.h
+++ b/ResearchKit/Consent/ORKConsentSharingStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKQuestionStepViewController.h>
 
 

--- a/ResearchKit/Consent/ORKConsentSignature.h
+++ b/ResearchKit/Consent/ORKConsentSignature.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 
 

--- a/ResearchKit/Consent/ORKVisualConsentStep.h
+++ b/ResearchKit/Consent/ORKVisualConsentStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.h
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKDefines.h>
 #import <ResearchKit/ORKStepViewController.h>
 

--- a/ResearchKit/Onboarding/ORKLoginStep.h
+++ b/ResearchKit/Onboarding/ORKLoginStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKFormStep.h>
 
 

--- a/ResearchKit/Onboarding/ORKLoginStepViewController.h
+++ b/ResearchKit/Onboarding/ORKLoginStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKFormStepViewController.h>
 
 

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKFormStep.h>
 
 

--- a/ResearchKit/Onboarding/ORKVerificationStep.h
+++ b/ResearchKit/Onboarding/ORKVerificationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import <ResearchKit/ORKStep.h>
 
 

--- a/ResearchKit/Onboarding/ORKVerificationStepViewController.h
+++ b/ResearchKit/Onboarding/ORKVerificationStepViewController.h
@@ -29,7 +29,7 @@
  */
 
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import <ResearchKit/ORKStepViewController.h>
 
 

--- a/Testing/ORKTest/ORKTest.xcodeproj/xcshareddata/xcschemes/ORKTest.xcscheme
+++ b/Testing/ORKTest/ORKTest.xcodeproj/xcshareddata/xcschemes/ORKTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Complication).xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Complication).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1430"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -64,10 +64,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -75,7 +73,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -84,10 +82,8 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -95,16 +91,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
-            BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
-            ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Notification).xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Notification).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1430"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -65,10 +65,8 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "ORKParkinsonStudy WatchKit Extension/Supporting Files/PushNotificationPayload.apns">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -76,7 +74,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -86,10 +84,8 @@
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "ORKParkinsonStudy WatchKit Extension/Supporting Files/PushNotificationPayload.apns">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -97,16 +93,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
-            BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
-            ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App.xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -63,10 +63,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -74,7 +72,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,10 +80,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ORKParkinsonStudy WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
@@ -93,16 +89,7 @@
             BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
-            BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
-            ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Updated to recommended compiler settings (but then reverted ENABLE_MODULE_VERIFIER = YES which removes the "module map is missing; there are private headers but no module map" warning). Rationale being that we're improving the code by resolving most of the warnings by the Module Verifier, but leaving that last one regarding the private module map for the future.
Errors fixed:
- use of 'https://github.com/import' in framework header is discouraged, including this header requires -fmodules
- public framework header includes private framework header ‘xxx’
Warnings fixed:
- A function declaration without a prototype is deprecated in all versions of C

# Testing
Have run through all the CEVResearchKit UI Tests which do a pretty good job of battle testing ResearchKit changes. No special testing needed outside of routine testing for this PR.