### PR TITLE
Update default footnote style to match web

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1FootnoteLabel.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1FootnoteLabel.m
@@ -38,7 +38,7 @@
 
 + (UIFont *)defaultFont {
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleFootnote];
-    const CGFloat defaultSize = 12;
+    const CGFloat defaultSize = 13;  // size for UIFontTextStyleFootnote with default Dynamic Text size (detent 4 of 7 in Accessibility > Larger Text, Larger Accessibility Sizes turned off
     return [UIFont systemFontOfSize:[[descriptor objectForKey:UIFontDescriptorSizeAttribute] doubleValue] - defaultSize + ORK1GetMetricForWindow(ORK1ScreenMetricFontSizeFootnote, nil)];
 }
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1NavigationContainerView.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1NavigationContainerView.m
@@ -71,6 +71,7 @@
             _footnoteLabel = [ORK1FootnoteLabel new];
             _footnoteLabel.numberOfLines = 0;
             _footnoteLabel.textAlignment = NSTextAlignmentCenter;
+            _footnoteLabel.textColor = ORK1RGB(0x666666);
             _footnoteLabel.translatesAutoresizingMaskIntoConstraints = NO;
             
             [self addSubview:_footnoteLabel];

--- a/ORK1Kit/ORK1Kit/Common/ORK1Skin.swift
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Skin.swift
@@ -283,7 +283,7 @@ enum ORK1MetricType {
             .choiceCellLabelLastBaselineToLabelFirstBaseline : 24.0,
             .choiceCellLastBaselineToBottom                  : 24.0,
             .continueButtonHeightRegular                     : 44.0,
-            .fontSizeFootnote                                : 12.0,
+            .fontSizeFootnote                                : 14.0,
             .fontSizeSubheadline                             : 17.0,
             .fontSizeSurveyHeadline                          : 30.0,
             .maxFontSizeSurveyHeadline                       : 32.0,


### PR DESCRIPTION
Closes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1192.

Added a comment to help understand the font size determination which is a little tricky to follow. Ultimately, we're taking the desired size from ORK1Skin and adjusting for Dynamic Text.

|**Before**|**After**|
|---|---|
|![before](https://github.com/ResearchKit/ResearchKit/assets/1008462/cecf7bc8-6bca-49bd-ae55-48652537aa72)|![after](https://github.com/ResearchKit/ResearchKit/assets/1008462/9506629f-3a51-4751-971e-ae8d7b91dbaa)|

## Testing
- Verify that default foot note appears like web (14 pt, centered, gray), e.g. use an InstructionStep in a survey that has footnote text.
- Verify override styles still work, e.g. use an InstructionStep in a survey that has footnote text and override the styling for the footnote and verify the overrides still work as expected.
