### PR TITLE
Add htmlWithSignatures

### DIFF
--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.h
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.h
@@ -131,6 +131,11 @@ ORK1_CLASS_AVAILABLE
  */
 - (void)addSignature:(ORK1ConsentSignature *)signature;
 
+/**
+ Produces an HTML version of the consent document with signature images embedded.
+ */
+@property (nonatomic, readonly) NSString *htmlWithSignatures;
+
 /// @name Alternative content provision
 
 /**

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentDocument.m
@@ -88,6 +88,10 @@
     [_signatures addObject:signature];
 }
 
+- (NSString *)htmlWithSignatures {
+    return [self htmlForMobile:NO withTitle:nil detail:nil];
+}
+
 - (void)makePDFWithCompletionHandler:(void (^)(NSData *data, NSError *error))completionBlock {
     [_writer writePDFFromHTML:[self htmlForMobile:NO withTitle:nil detail:nil]
           withCompletionBlock:^(NSData *data, NSError *error) {

--- a/ResearchKit/Consent/ORKConsentDocument.h
+++ b/ResearchKit/Consent/ORKConsentDocument.h
@@ -132,6 +132,11 @@ ORK_CLASS_AVAILABLE
  */
 - (void)addSignature:(ORKConsentSignature *)signature;
 
+/**
+ Produces an HTML version of the consent document with signature images embedded.
+ */
+@property (nonatomic, readonly) NSString *htmlWithSignatures;
+
 /// @name Alternative content provision
 
 /**

--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -89,6 +89,10 @@
     [_signatures addObject:signature];
 }
 
+- (NSString *)htmlWithSignatures {
+    return [self htmlForMobile:NO title:nil detail:nil];
+}
+
 - (void)makePDFWithCompletionHandler:(void (^)(NSData *data, NSError *error))completionBlock {
     [_writer writePDFFromHTML:[self htmlForMobile:NO title:nil detail:nil]
           completionBlock:^(NSData *data, NSError *error) {


### PR DESCRIPTION
Support for https://github.com/CareEvolution/MyDataHelps-iOS/pull/1201

Just adds a public method to provide access to the same HTML that's generated as the initial step of PDF rendering.

## Testing

See https://github.com/CareEvolution/MyDataHelps-iOS/pull/1201