### PR TITLE
Make submission of ORK[1]WebViewStep complete message idempotent

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1WebViewStepViewController.m
@@ -57,6 +57,7 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 @implementation ORK1WebViewStepViewController {
     NSString *_result;
     NSString *_originalResult;
+    BOOL _hasCompleted;
 }
 
 #pragma mark Public Interface
@@ -214,9 +215,10 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 /// Returns YES if the view controller should stop processing any other messages. Assumes that `shouldProcessScriptMessages` is true.
 /// - Parameter message: The message to process.
 - (BOOL)processScriptMessage:(WKScriptMessage *)message {
-    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {
+    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]] && !_hasCompleted) {
         _result = (NSString *)message.body;
         [self goForward];
+        _hasCompleted = YES;
         return YES;
     }
     

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -66,6 +66,7 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
     NSString *_originalResult;
     ORKNavigationContainerView *_navigationFooterView;
     NSArray<NSLayoutConstraint *> *_constraints;
+    BOOL _hasCompleted;
 }
 
 #pragma mark Public Interface
@@ -316,9 +317,10 @@ static NSString *const ResearchKitCompleteStepMessageName = @"ResearchKit";
 /// Returns YES if the view controller should stop processing any other messages. Assumes that `shouldProcessScriptMessages` is true.
 /// - Parameter message: The message to process.
 - (BOOL)processScriptMessage:(WKScriptMessage *)message {
-    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]]) {
+    if ([message.name isEqualToString:ResearchKitCompleteStepMessageName] && [message.body isKindOfClass:[NSString class]] && !_hasCompleted) {
         _result = (NSString *)message.body;
         [self goForward];
+        _hasCompleted = YES;
         return YES;
     }
     


### PR DESCRIPTION
In troubleshooting an issue, found that a WebViewStep was sending the complete step message more than once. This creates a race condition where a result gets [pushed into the internal "stack"](https://github.com/CareEvolution/ResearchKit/blob/7f9abbb130ee8199362c2872db5ccdfe85f59faf/ORK1Kit/ORK1Kit/Common/ORK1StepViewController.m#L286-L299) of step results of the wrong place because `[self goForward]` gets called while the stack of steps is different (WebViewStep is no longer the top-most step).

This creates an issue when a navigation rule predicate is evaluated where the stack now sees the original, correct step result marked as `isPreviousResult`, thus excluding it from calculation and possibly causing a predicate to return an incorrect evaluation.

By making this process only able to be called once, we can guard against programmer error in WebViewSteps. 

cc: @felideon 

## Testing

This can be tested using the following survey which will call the completion twice in rapid succession. In versions prior to this fix, if the incorrect path is chosen, it would still allow completion of the survey and not properly route you back to adjust your answer - i.e. the **Try Again** button takes you to the **Thank You** step.

Verify with this build that the if **Incorrect** is chosen, you are routed back to try again.

<details>
  <summary>Example Survey</summary>

```json
{
  "type": "RKStudioNavigableOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
    {
      "type": "FormStep",
      "text": "**Correct** - will allow the survey to be completed\n\n**Incorrect** - will reroute you back here to try again",
      "title": "Choose a Path",
      "identifier": "ChoosePath",
      "formItems": [
        {
          "identifier": "ChoosePath",
          "type": "FormItem",
          "answerFormat": {
            "type": "TextChoiceAnswerFormat",
            "textChoices": [
              {
                "type": "TextChoice",
                "value": "Correct",
                "text": "Correct"
              },
              {
                "type": "TextChoice",
                "value": "Incorrect",
                "text": "Incorrect"
              }
            ],
            "style": "Single"
          },
          "optional": false,
          "text": "Code"
        }
      ],
      "optional": false
    },
    {
      "type": "WebViewStep",
      "text": "",
      "title": "",
      "identifier": "VerifyChoice",
      "html": "<!DOCTYPE html>\n<html>\n    <script src=\"https://cdn.careevolution.com/mydatahelps-js/3.5.0/MyDataHelps.min.js\" integrity=\"sha384-F+CozurzqwQDtsvcUy/S1CcubJRXeUrHyXoA3ywKn398hI0jg+N2aI6fFq4YUC0I\" crossorigin=\"anonymous\"></script>\n<head>\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\">\n    <style>\n      body {\n        height: 95%;\n        position: relative;\t\t\t\t\n        font-family: Helvetica, Arial, sans-serif;\t\t\t\t\n        font-size: 1.2em;\n        text-align: center;\n      }\n\n      #message {\t\t\t\n        display: none;\n        padding-top: 80px;\n      }\n\n      #spinner {\n        border: 5px solid #f3f3f3;\n        border-top: 5px solid #366DBC;\n        border-radius: 50%;\n        width: 30px;\n        height: 30px;\n        animation: spin 1s linear infinite;\n        margin: 0 auto;\n      }\n\n      @keyframes spin {\n        0% { transform: rotate(0deg); }\n        100% { transform: rotate(360deg); }\n      }\n    </style>\n</head>\n<body>\n  <div id=\"spinner\"></div>\t\n  <div id=\"log\"></div>\n     <script type=\"text/javascript\">\n      function submit() {\n         MyDataHelps.getCurrentSurveyAnswers()\n            .then(function(results) {\n                results.reverse();\n                const registrationCode = results.find((answer) => answer.stepIdentifier === 'ChoosePath' && answer.resultIdentifier === 'ChoosePath').answers[0];\n           \n                if (registrationCode == 'Correct') {\n                    MyDataHelps.completeStep(\"choice-verified\");\n                } else {\n                    MyDataHelps.completeStep(\"choice-failed\");\n                }\n        });\n    }\n\n    window.onload = submit;\n    submit();       \n</script>\n</body>\n</html>",
      "excludeFromProgressCalculation": true
    },
    {
      "type": "InstructionStep",
      "text": "The code you entered does not match with site records. Please go back and review your participant identifier and ensure you have entered the correct verification code.",
      "title": "Something went wrong",
      "identifier": "VerificationFailed",
      "nextButtonText": "Try Again",
      "skipNavigationRule": {
        "type": "PredicateSkipStepNavigationRule",
        "resultPredicate": {
          "resultIdentifier": "VerifyChoice",
          "stepIdentifier": null,
          "type": "WebViewResultPredicate",
          "expectedString": "choice-verified"
        }
      },
      "navigationRule": {
        "type": "PredicateStepNavigationRule",
        "resultPredicateDestinations": [
          {
            "type": "ResultPredicateDestination",
            "destinationStepIdentifier": "ChoosePath",
            "resultPredicate": {
              "resultIdentifier": "VerifyChoice",
              "stepIdentifier": null,
              "type": "WebViewResultPredicate",
              "expectedString": "choice-failed"
            }
          }
        ]
      }
    },
    {
      "type": "InstructionStep",
      "text": "You may now start completing your study tasks.",
      "title": "Thank you!",
      "identifier": "Thankyou",
      "navigationRule": {
        "type": "DirectStepNavigationRule",
        "destinationStepIdentifier": "FinishStep.Complete"
      }
    }
  ],
  "styles": {
    "progressBarColor": "#5381c3",
    "nextButtonBackgroundColor": "#5381c3",
    "nextButtonTextColor": "#FFFFFF",
    "titleAlignment": "Left",
    "textAlignment": "Left",
    "detailTextAlignment": "Left"
  },
  "neverStoreProgress": false,
  "progressIndicatorType": "Bar"
}
```
</details>