### PR TITLE
Set documentReviewed to YES for autoAgree case

### DIFF
--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewStepViewController.m
@@ -110,6 +110,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // If autoAgree, _documentReviewed will never get set to YES since the workflow with buttons is bypassed
+    ORK1ConsentReviewStep* consentReviewStep = (ORK1ConsentReviewStep *)[self step];
+    if (consentReviewStep.autoAgree) {
+        _documentReviewed = YES;
+    }
+    
     // Prepare pageViewController
     _pageViewController = [[UIPageViewController alloc] initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll
                                                           navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -115,6 +115,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // If autoAgree, _documentReviewed will never get set to YES since the workflow with buttons is bypassed
+    ORKConsentReviewStep* consentReviewStep = (ORKConsentReviewStep *)[self step];
+    if (consentReviewStep.autoAgree) {
+        _documentReviewed = YES;
+    }
+    
     // Prepare pageViewController
     _pageViewController = [[UIPageViewController alloc] initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll
                                                           navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1322.

### Testing

See https://github.com/CareEvolution/MyDataHelps-iOS/issues/1322. Use the survey example linked there as a consent survey. After completing the survey, review the results in MDHD and see that the Result for the ConsentSignature_Consent step shows "Consented:" as "True" (not "False" as it was prior to this fix).