### PR TITLE
Store originalFont for CEVRK1Label to make updateAppearance idempotent

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Label.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Label.h
@@ -16,5 +16,6 @@
 @interface CEVRK1Label: UILabel
 
 - (NSString * _Nullable)rawText;
+- (UIFont * _Nullable)originalFont;
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Label.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Label.m
@@ -12,6 +12,7 @@
 
 @implementation CEVRK1Label {
     NSString *_rawText;
+    UIFont *_originalFont;
 }
 
 - (void)setText:(NSString * _Nullable)text {
@@ -19,8 +20,17 @@
     [self updateAppearance];
 }
 
+- (void)setFont:(UIFont *)font {
+    _originalFont = font;
+    [super setFont:font];
+}
+
 - (NSString * _Nullable)rawText {
     return _rawText;
+}
+
+- (UIFont *)originalFont {
+    return _originalFont;
 }
 
 - (void)updateAppearance {

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1Theme.m
@@ -203,6 +203,7 @@ __weak static ORK1TaskViewController *sFallbackTaskViewController = nil;
             break;
     }
     NSMutableDictionary *attributes = [self textAttributesForView:label];
+    attributes[NSFontAttributeName] = label.originalFont;
     [self combineIntoAttributes:attributes textStyle:textStyle];
     label.attributedText = [[NSAttributedString alloc] initWithMarkdownRepresentation:[label rawText] attributes:attributes];
 }


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1323.

Using the same pattern as adopted when parsing Markdown, we'll hold onto the original value so if called multiple times we are having the same result.


### Testing
1. Configure test device to have text size configured at the size below (Settings > Accessibility > Display & Text Size > Larger Text) - 2 up from standard.
2. Run the survey from https://github.com/CareEvolution/MyDataHelps-iOS/issues/1322 and pay special attention that the footnote in the `ConsentPII_PIIContactInformation` step (where you are prompted for an address).
3. Verify the footnote hasn't creeped up inside to something seen in the screenshots for https://github.com/CareEvolution/MyDataHelps-iOS/issues/1323.

![Simulator Screenshot - iPhone 15 Pro - 2024-08-26 at 11 10 59](https://github.com/user-attachments/assets/665371fd-58b4-4b9a-91b1-e71eaaefe178)
