### PR TITLE
Make NSAssert simply an if clause to allow mismatched defaultValue

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1ChoiceAnswerFormatHelper.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1ChoiceAnswerFormatHelper.m
@@ -147,11 +147,12 @@
             }
             
             if (nil == matchedChoice) {
-                NSAssert([answerValue isKindOfClass:[NSNumber class]], @"");
-                if (_isValuePicker) {
-                    matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue + 1];
-                } else {
-                    matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue];
+                if ([answerValue isKindOfClass:[NSNumber class]]) {
+                    if (_isValuePicker) {
+                        matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue + 1];
+                    } else {
+                        matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue];
+                    }
                 }
             }
             

--- a/ResearchKit/Common/ORKChoiceAnswerFormatHelper.m
+++ b/ResearchKit/Common/ORKChoiceAnswerFormatHelper.m
@@ -148,11 +148,12 @@
             }
             
             if (nil == matchedChoice) {
-                NSAssert([answerValue isKindOfClass:[NSNumber class]], @"");
-                if (_isValuePicker) {
-                    matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue + 1];
-                } else {
-                    matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue];
+                if ([answerValue isKindOfClass:[NSNumber class]]) {
+                    if (_isValuePicker) {
+                        matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue + 1];
+                    } else {
+                        matchedChoice = _choices[((NSNumber *)answerValue).unsignedIntegerValue];
+                    }
                 }
             }
             


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1314.

While the fix is relatively simple, following the logic upstream to understand risk of regression bugs is not. Regardless, I feel confident this fixes the issue by de-escalating a mismatched defaultValue of an ORK[1]AnswerFormat (which is technically not stored there, but we [pluck them out on deserialization](https://github.com/CareEvolution/CEVResearchKit/blob/a80e1278f1299bbbcd2a5ae68a12b879cd7e6540/CEVResearchKit/RKJSONDefinitions/RK1JSONTasks.swift#L320)) from an `NSAssert` to a simple check. I ran though the UITests as well which does a battery of tests on basic RK functionality.

## Testing
Verify the following survey doesn't crash on iOS. It has a defaultValue ("garbage") which doesn't match any of the TextChoice values.

Also regression testing of survey functionality of iOS would be helpful, in particular the following:
- surveys with valid defaultValues
- navigation forward and backward to verify previous answers reappear correctly
- restoring saved surveys and validating answers restore correctly

```json
{
  "type": "RKStudioOrderedTask",
  "name": "Survey",
  "identifier": "Survey",
  "steps": [
      {
        "identifier": "AFib",
        "type": "QuestionStep",
        "answerFormat": {
          "type": "TextChoiceAnswerFormat",
          "textChoices": [
            {
              "type": "TextChoice",
              "value": "1",
              "text": "Yes"
            },
            {
              "type": "TextChoice",
              "value": "0",
              "text": "No"
            }
          ],
          "style": "Single",
          "customField": "afib",
          "descriptionStyle": "",
          "defaultValue": "garbage"
        },
        "optional": false,
        "text": "Do you have atrial fibrillation (AFib)?"
      }
  ]
}
```
