### PR TITLE
Accept Xcode auto-gen 18 changes for localization in .xcstrings

### DIFF
--- a/ResearchKit/Localized/ResearchKit.xcstrings
+++ b/ResearchKit/Localized/ResearchKit.xcstrings
@@ -2,7 +2,7 @@
   "sourceLanguage" : "en",
   "strings" : {
     "ADDITIONAL_INFO_SECTION_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -283,7 +283,7 @@
       }
     },
     "AMSLER_GRID_INSTRUCTION_DETAIL_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -546,7 +546,7 @@
       }
     },
     "AMSLER_GRID_INSTRUCTION_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -809,7 +809,7 @@
       }
     },
     "AMSLER_GRID_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1072,7 +1072,7 @@
       }
     },
     "AMSLER_GRID_LEFT_EYE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1335,7 +1335,7 @@
       }
     },
     "AMSLER_GRID_RIGHT_EYE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1599,7 +1599,7 @@
     },
     "AMSLER_GRID_TITLE" : {
       "comment" : "Amsler Grid Task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1862,7 +1862,7 @@
       }
     },
     "AUDIO_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2143,7 +2143,7 @@
       }
     },
     "AUDIO_GENERIC_ERROR_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2424,7 +2424,7 @@
       }
     },
     "AUDIO_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2705,7 +2705,7 @@
       }
     },
     "AUDIO_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2986,7 +2986,7 @@
       }
     },
     "AUDIO_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -3267,7 +3267,7 @@
       }
     },
     "AUDIO_LEVEL_CHECK_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -3549,7 +3549,7 @@
     },
     "AUDIO_TASK_TITLE" : {
       "comment" : "Audio active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -3830,7 +3830,7 @@
       }
     },
     "AUDIO_TOO_LOUD_ACTION_NEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -4111,7 +4111,7 @@
       }
     },
     "AUDIO_TOO_LOUD_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -4392,7 +4392,7 @@
       }
     },
     "AUDIO_TOO_LOUD_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -4673,7 +4673,7 @@
       }
     },
     "AX_AMSLER_GRID_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -4936,7 +4936,7 @@
       }
     },
     "AX_AMSLER_GRID_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -5199,7 +5199,7 @@
       }
     },
     "AX_ANNOUNCE_BEGIN_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -5480,7 +5480,7 @@
       }
     },
     "AX_AUDIO_BAR_GRAPH" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -5743,7 +5743,7 @@
       }
     },
     "AX_BUTTON_ANNOTATE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -6007,7 +6007,7 @@
     },
     "AX_BUTTON_BACK" : {
       "comment" : "Accessibility",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -6288,7 +6288,7 @@
       }
     },
     "AX_BUTTON_HIDE_PDF_THUMBNAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -6551,7 +6551,7 @@
       }
     },
     "AX_BUTTON_HIDE_SEARCH" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -6814,7 +6814,7 @@
       }
     },
     "AX_BUTTON_SHARE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7077,7 +7077,7 @@
       }
     },
     "AX_BUTTON_SHOW_PDF_THUMBNAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7340,7 +7340,7 @@
       }
     },
     "AX_BUTTON_SHOW_SEARCH" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7603,7 +7603,7 @@
       }
     },
     "AX_COMPLETION_ILLUSTRATION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7867,7 +7867,7 @@
     },
     "AX_dBHL_TONE_AUDIOMETRY_INTRO_TEXT" : {
       "comment" : "This contains the visual text, followed by a VoiceOver-specific description.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -7884,7 +7884,7 @@
       }
     },
     "AX_DISMISS_KEYBOARD_CUSTOM_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -7901,7 +7901,7 @@
       }
     },
     "AX_GRAPH_AND_SEPARATOR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -8182,7 +8182,7 @@
       }
     },
     "AX_GRAPH_POINT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -8463,7 +8463,7 @@
       }
     },
     "AX_GRAPH_RANGE_FORMAT_%@_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -8744,7 +8744,7 @@
       }
     },
     "AX_GRAPH_STACK_PREFIX" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9025,7 +9025,7 @@
       }
     },
     "AX_IMAGE_CAPTURE_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9306,7 +9306,7 @@
       }
     },
     "AX_IMAGE_CAPTURED_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9587,7 +9587,7 @@
       }
     },
     "AX_IMAGE_ILLUSTRATION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "es_419" : {
           "stringUnit" : {
@@ -9616,7 +9616,7 @@
       }
     },
     "AX_SELECTED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9897,7 +9897,7 @@
       }
     },
     "AX_SIGNVIEW_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -10178,7 +10178,7 @@
       }
     },
     "AX_SIGNVIEW_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -10459,7 +10459,7 @@
       }
     },
     "AX_SIGNVIEW_SIGNED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -10740,7 +10740,7 @@
       }
     },
     "AX_SIGNVIEW_UNSIGNED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -11021,7 +11021,7 @@
       }
     },
     "AX_SLIDER_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -11302,7 +11302,7 @@
       }
     },
     "AX_SPEECH_RECOGNITION_START_RECORDING_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -11565,7 +11565,7 @@
       }
     },
     "AX_SPEECH_RECOGNITION_WAVEFORM" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -11828,7 +11828,7 @@
       }
     },
     "AX_TAP_BUTTON_1_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11845,7 +11845,7 @@
       }
     },
     "AX_TAP_BUTTON_2_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11862,7 +11862,7 @@
       }
     },
     "AX_TAP_BUTTON_DIRECT_TOUCH_ANNOUNCEMENT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11879,7 +11879,7 @@
       }
     },
     "AX_TAP_BUTTON_DIRECT_TOUCH_AREA" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11896,7 +11896,7 @@
       }
     },
     "AX_TAP_BUTTON_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11914,7 +11914,7 @@
     },
     "AX_TAPPING_INSTRUCTION_VOICEOVER" : {
       "comment" : "This contains the visual text, followed by a VoiceOver-specific description.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11931,7 +11931,7 @@
       }
     },
     "AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11948,7 +11948,7 @@
       }
     },
     "AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11965,7 +11965,7 @@
       }
     },
     "AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_HINT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -11982,7 +11982,7 @@
       }
     },
     "AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -12000,7 +12000,7 @@
     },
     "AX_TONE_AUDIOMETRY_PREP_TEXT_VOICEOVER" : {
       "comment" : "This contains the visual text, followed by a VoiceOver-specific description, followed by the visual text on the following page (since VoiceOver users may not have a chance to hear the visual text before needing to perform the actions).",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -12017,7 +12017,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_INVALID_MOVE_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -12298,7 +12298,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_PLACE_DISK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -12579,7 +12579,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_SELECT_DISK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -12860,7 +12860,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_TARGET_DISK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -13141,7 +13141,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_TOWER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -13422,7 +13422,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_TOWER_CONTAINS" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -13703,7 +13703,7 @@
       }
     },
     "AX_TOWER_OF_HANOI_TOWER_EMPTY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -13985,7 +13985,7 @@
     },
     "AX_TRAILMAKING_CALL_TO_ACTION_VOICEOVER" : {
       "comment" : "This contains the visual text, followed by a VoiceOver-specific description.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -14002,7 +14002,7 @@
       }
     },
     "AX_UNLABELED_IMAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -14283,7 +14283,7 @@
       }
     },
     "AX_UNSELECTED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -14564,7 +14564,7 @@
       }
     },
     "AX_VIDEO_CAPTURE_COMPLETE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -14827,7 +14827,7 @@
       }
     },
     "AX_VIDEO_CAPTURE_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -15109,7 +15109,7 @@
     },
     "AX_VIDEO_CAPTURED_LABEL" : {
       "comment" : "Unsorted",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "es_419" : {
           "stringUnit" : {
@@ -15138,7 +15138,7 @@
       }
     },
     "AX.MEMORY.TILE.ACTIVE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -15419,7 +15419,7 @@
       }
     },
     "AX.MEMORY.TILE.CORRECT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -15700,7 +15700,7 @@
       }
     },
     "AX.MEMORY.TILE.INCORRECT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -15981,7 +15981,7 @@
       }
     },
     "AX.MEMORY.TILE.LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -16262,7 +16262,7 @@
       }
     },
     "AX.MEMORY.TILE.QUIESCENT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -16543,7 +16543,7 @@
       }
     },
     "BLOOD_TYPE_A-" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -16825,7 +16825,7 @@
     },
     "BLOOD_TYPE_A+" : {
       "comment" : "Blood types",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -17106,7 +17106,7 @@
       }
     },
     "BLOOD_TYPE_AB-" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -17387,7 +17387,7 @@
       }
     },
     "BLOOD_TYPE_AB+" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -17668,7 +17668,7 @@
       }
     },
     "BLOOD_TYPE_B-" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -17949,7 +17949,7 @@
       }
     },
     "BLOOD_TYPE_B+" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -18230,7 +18230,7 @@
       }
     },
     "BLOOD_TYPE_O-" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -18511,7 +18511,7 @@
       }
     },
     "BLOOD_TYPE_O+" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -18793,7 +18793,7 @@
     },
     "BOOL_NO" : {
       "comment" : "Boolean answer strings",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -19074,7 +19074,7 @@
       }
     },
     "BOOL_YES" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -19356,7 +19356,7 @@
     },
     "BUTTON_AGREE" : {
       "comment" : "Button titles",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -19637,7 +19637,7 @@
       }
     },
     "BUTTON_APPLY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -19900,7 +19900,7 @@
       }
     },
     "BUTTON_CANCEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -20181,7 +20181,7 @@
       }
     },
     "BUTTON_CLEAR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -20462,7 +20462,7 @@
       }
     },
     "BUTTON_CLEAR_ANSWER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -20743,7 +20743,7 @@
       }
     },
     "BUTTON_COPYRIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21006,7 +21006,7 @@
       }
     },
     "BUTTON_DISAGREE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21287,7 +21287,7 @@
       }
     },
     "BUTTON_DONE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21568,7 +21568,7 @@
       }
     },
     "BUTTON_GET_STARTED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21849,7 +21849,7 @@
       }
     },
     "BUTTON_LEARN_MORE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -22130,7 +22130,7 @@
       }
     },
     "BUTTON_NEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -22411,7 +22411,7 @@
       }
     },
     "BUTTON_OK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -22692,7 +22692,7 @@
       }
     },
     "BUTTON_OPTION_DISCARD" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -22973,7 +22973,7 @@
       }
     },
     "BUTTON_OPTION_SAVE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -23254,7 +23254,7 @@
       }
     },
     "BUTTON_OPTION_STOP_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -23535,7 +23535,7 @@
       }
     },
     "BUTTON_READ_ONLY_MODE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -23816,7 +23816,7 @@
       }
     },
     "BUTTON_SAVE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -24097,7 +24097,7 @@
       }
     },
     "BUTTON_SKIP" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -24378,7 +24378,7 @@
       }
     },
     "BUTTON_SKIP_QUESTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -24659,7 +24659,7 @@
       }
     },
     "BUTTON_START_TIMER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -24941,7 +24941,7 @@
     },
     "CAMERA_UNAVAILABLE_MESSAGE" : {
       "comment" : "Camera not available during multitasking",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -25223,7 +25223,7 @@
     },
     "CAPTURE_BUTTON_CAPTURE_IMAGE" : {
       "comment" : "Image capture step.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -25505,7 +25505,7 @@
     },
     "CAPTURE_BUTTON_CAPTURE_VIDEO" : {
       "comment" : "Video capture step.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -25786,7 +25786,7 @@
       }
     },
     "CAPTURE_BUTTON_RECAPTURE_IMAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -26067,7 +26067,7 @@
       }
     },
     "CAPTURE_BUTTON_RECAPTURE_VIDEO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -26348,7 +26348,7 @@
       }
     },
     "CAPTURE_BUTTON_STOP_CAPTURE_VIDEO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -26629,7 +26629,7 @@
       }
     },
     "CAPTURE_ERROR_CAMERA_NOT_FOUND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -26910,7 +26910,7 @@
       }
     },
     "CAPTURE_ERROR_CANNOT_WRITE_FILE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27191,7 +27191,7 @@
       }
     },
     "CAPTURE_ERROR_NO_OUTPUT_DIRECTORY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27472,7 +27472,7 @@
       }
     },
     "CAPTURE_ERROR_NO_PERMISSIONS" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27754,7 +27754,7 @@
     },
     "CHART_NO_DATA_TEXT" : {
       "comment" : "Charts",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28035,7 +28035,7 @@
       }
     },
     "CONFIRM_PASSWORD_ERROR_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28316,7 +28316,7 @@
       }
     },
     "CONFIRM_PASSWORD_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28597,7 +28597,7 @@
       }
     },
     "CONFIRM_PASSWORD_FORM_ITEM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28878,7 +28878,7 @@
       }
     },
     "CONSENT_DOC_LINE_DATE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -29160,7 +29160,7 @@
     },
     "CONSENT_DOC_LINE_PRINTED_NAME" : {
       "comment" : "Lines beneath typewritten signatures on documents. Argument is the title of the signatory, e.g. \"Participant's Signature\"",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -29441,7 +29441,7 @@
       }
     },
     "CONSENT_DOC_LINE_SIGNATURE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -29722,7 +29722,7 @@
       }
     },
     "CONSENT_LEARN_MORE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -30003,7 +30003,7 @@
       }
     },
     "CONSENT_NAME_FAMILY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -30284,7 +30284,7 @@
       }
     },
     "CONSENT_NAME_GIVEN" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -30565,7 +30565,7 @@
       }
     },
     "CONSENT_NAME_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -30847,7 +30847,7 @@
     },
     "CONSENT_NAME_TITLE" : {
       "comment" : "Informed consent process.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -31128,7 +31128,7 @@
       }
     },
     "CONSENT_PAGE_NUMBER_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -31409,7 +31409,7 @@
       }
     },
     "CONSENT_REVIEW_ALERT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -31690,7 +31690,7 @@
       }
     },
     "CONSENT_REVIEW_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -31971,7 +31971,7 @@
       }
     },
     "CONSENT_REVIEW_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -32252,7 +32252,7 @@
       }
     },
     "CONSENT_SECTION_DATA_GATHERING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -32533,7 +32533,7 @@
       }
     },
     "CONSENT_SECTION_DATA_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -32814,7 +32814,7 @@
       }
     },
     "CONSENT_SECTION_PRIVACY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -33095,7 +33095,7 @@
       }
     },
     "CONSENT_SECTION_STUDY_SURVEY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -33376,7 +33376,7 @@
       }
     },
     "CONSENT_SECTION_STUDY_TASKS" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -33657,7 +33657,7 @@
       }
     },
     "CONSENT_SECTION_TIME_COMMITMENT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -33939,7 +33939,7 @@
     },
     "CONSENT_SECTION_WELCOME" : {
       "comment" : "Consent section titles.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -34220,7 +34220,7 @@
       }
     },
     "CONSENT_SECTION_WITHDRAWING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -34501,7 +34501,7 @@
       }
     },
     "CONSENT_SHARE_ONLY_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -34782,7 +34782,7 @@
       }
     },
     "CONSENT_SHARE_WIDELY_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35063,7 +35063,7 @@
       }
     },
     "CONSENT_SHARING_DESCRIPTION_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35345,7 +35345,7 @@
     },
     "CONSENT_SHARING_TITLE" : {
       "comment" : "Consent sharing step",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35626,7 +35626,7 @@
       }
     },
     "CONSENT_SIGNATURE_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35907,7 +35907,7 @@
       }
     },
     "CONSENT_SIGNATURE_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -36188,7 +36188,7 @@
       }
     },
     "CONSENT_SIGNATURE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -36470,7 +36470,7 @@
     },
     "COUNTDOWN_LABEL" : {
       "comment" : "General active tasks.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -36751,7 +36751,7 @@
       }
     },
     "COUNTDOWN_SPOKEN_REMAINING_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -37032,7 +37032,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -37295,7 +37295,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -37558,7 +37558,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_ONBOARDING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -37821,7 +37821,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_ONBOARDING_QUESTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38084,7 +38084,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_OPTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38347,7 +38347,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_OPTION_NO_PREFERENCE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38610,7 +38610,7 @@
       }
     },
     "dBHL_TONE_AUDIOMETRY_OPTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38874,7 +38874,7 @@
     },
     "dBHL_TONE_AUDIOMETRY_TASK_TITLE" : {
       "comment" : "dBHL Tone audiometry active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -39137,7 +39137,7 @@
       }
     },
     "DOB_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -39418,7 +39418,7 @@
       }
     },
     "DOB_FORM_ITEM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -39699,7 +39699,7 @@
       }
     },
     "EMAIL_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -39981,7 +39981,7 @@
     },
     "EMAIL_FORM_ITEM_TITLE" : {
       "comment" : "Registration step",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40262,7 +40262,7 @@
       }
     },
     "ENVIRONMENTSPL_CALCULATING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40525,7 +40525,7 @@
       }
     },
     "ENVIRONMENTSPL_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40788,7 +40788,7 @@
       }
     },
     "ENVIRONMENTSPL_THRESHOLD" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -41052,7 +41052,7 @@
     },
     "ENVIRONMENTSPL_TITLE" : {
       "comment" : "Environment SPL",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -41315,7 +41315,7 @@
       }
     },
     "ENVIRONMENTSPL_UNIT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -41578,7 +41578,7 @@
       }
     },
     "ERROR_DATALOGGER_COULD_NOT_FREE_SPACE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -41859,7 +41859,7 @@
       }
     },
     "ERROR_DATALOGGER_COULD_NOT_MAORK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -42141,7 +42141,7 @@
     },
     "ERROR_DATALOGGER_CREATE_FILE" : {
       "comment" : "Potentially user visible error messages.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -42422,7 +42422,7 @@
       }
     },
     "ERROR_DATALOGGER_MULTIPLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -42703,7 +42703,7 @@
       }
     },
     "ERROR_DATALOGGER_SET_ATTRIBUTE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -42984,7 +42984,7 @@
       }
     },
     "ERROR_RECORDER_NO_DATA" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -43265,7 +43265,7 @@
       }
     },
     "ERROR_RECORDER_NO_OUTPUT_DIRECTORY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -43546,7 +43546,7 @@
       }
     },
     "FAMILY_NAME_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -43827,7 +43827,7 @@
       }
     },
     "FITNESS_DISTANCE_TITLE_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -44108,7 +44108,7 @@
       }
     },
     "FITNESS_HEARTRATE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -44389,7 +44389,7 @@
       }
     },
     "FITNESS_INTRO_2_TEXT_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -44670,7 +44670,7 @@
       }
     },
     "FITNESS_INTRO_TEXT_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -44951,7 +44951,7 @@
       }
     },
     "FITNESS_SIT_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -45233,7 +45233,7 @@
     },
     "FITNESS_TASK_TITLE" : {
       "comment" : "Fitness active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -45514,7 +45514,7 @@
       }
     },
     "FITNESS_WALK_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -45796,7 +45796,7 @@
     },
     "FITZPATRICK_SKIN_TYPE_I" : {
       "comment" : "Fitzpatrick Skin types",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -46059,7 +46059,7 @@
       }
     },
     "FITZPATRICK_SKIN_TYPE_II" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -46322,7 +46322,7 @@
       }
     },
     "FITZPATRICK_SKIN_TYPE_III" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -46585,7 +46585,7 @@
       }
     },
     "FITZPATRICK_SKIN_TYPE_IV" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -46848,7 +46848,7 @@
       }
     },
     "FITZPATRICK_SKIN_TYPE_V" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -47111,7 +47111,7 @@
       }
     },
     "FITZPATRICK_SKIN_TYPE_VI" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -47374,7 +47374,7 @@
       }
     },
     "FORGOT_PASSWORD_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -47656,7 +47656,7 @@
     },
     "GENDER_FEMALE" : {
       "comment" : "Gender values.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -47937,7 +47937,7 @@
       }
     },
     "GENDER_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -48218,7 +48218,7 @@
       }
     },
     "GENDER_FORM_ITEM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -48499,7 +48499,7 @@
       }
     },
     "GENDER_MALE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -48780,7 +48780,7 @@
       }
     },
     "GENDER_OTHER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -49061,7 +49061,7 @@
       }
     },
     "GIVEN_NAME_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -49342,7 +49342,7 @@
       }
     },
     "HOLE_PEG_TEST_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -49623,7 +49623,7 @@
       }
     },
     "HOLE_PEG_TEST_INTRO_TEXT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -49904,7 +49904,7 @@
       }
     },
     "HOLE_PEG_TEST_INTRO_TEXT_2_LEFT_HAND_FIRST_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -50185,7 +50185,7 @@
       }
     },
     "HOLE_PEG_TEST_INTRO_TEXT_2_RIGHT_HAND_FIRST_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -50466,7 +50466,7 @@
       }
     },
     "HOLE_PEG_TEST_PLACE_INSTRUCTION_LEFT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -50747,7 +50747,7 @@
       }
     },
     "HOLE_PEG_TEST_PLACE_INSTRUCTION_RIGHT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -51028,7 +51028,7 @@
       }
     },
     "HOLE_PEG_TEST_REMOVE_INSTRUCTION_LEFT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -51309,7 +51309,7 @@
       }
     },
     "HOLE_PEG_TEST_REMOVE_INSTRUCTION_RIGHT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -51590,7 +51590,7 @@
       }
     },
     "HOLE_PEG_TEST_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -51871,7 +51871,7 @@
       }
     },
     "HOLE_PEG_TEST_TEXT_2" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -52153,7 +52153,7 @@
     },
     "HOLE_PEG_TEST_TITLE_%@" : {
       "comment" : "Hole peg test active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -52435,7 +52435,7 @@
     },
     "INVALID_EMAIL_ALERT_MESSAGE" : {
       "comment" : "Alert for invalid email address value",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -52717,7 +52717,7 @@
     },
     "KEYCHAIN_ADD_ERROR_MESSAGE" : {
       "comment" : "Keychain wrapper",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -52998,7 +52998,7 @@
       }
     },
     "KEYCHAIN_DELETE_ERROR_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -53279,7 +53279,7 @@
       }
     },
     "KEYCHAIN_FIND_ERROR_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -53560,7 +53560,7 @@
       }
     },
     "KEYCHAIN_UPDATE_ERROR_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -53841,7 +53841,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_SPOKEN_INSTRUCTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -54104,7 +54104,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_SPOKEN_INSTRUCTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -54367,7 +54367,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_0_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -54630,7 +54630,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_0_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -54893,7 +54893,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_1_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -55156,7 +55156,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_1_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -55419,7 +55419,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_2_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -55682,7 +55682,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_2_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -55945,7 +55945,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_3_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -56208,7 +56208,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TEXT_INSTRUCTION_3_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -56472,7 +56472,7 @@
     },
     "KNEE_RANGE_OF_MOTION_TITLE_LEFT" : {
       "comment" : "Knee Range of Motion active task",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -56735,7 +56735,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TITLE_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -56998,7 +56998,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TOUCH_ANYWHERE_STEP_INSTRUCTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -57261,7 +57261,7 @@
       }
     },
     "KNEE_RANGE_OF_MOTION_TOUCH_ANYWHERE_STEP_INSTRUCTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -57524,7 +57524,7 @@
       }
     },
     "LEARN_MORE_CONSENT_SHARING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -57806,7 +57806,7 @@
     },
     "LEARN_MORE_DATA_GATHERING" : {
       "comment" : "Consent section learn more",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -58087,7 +58087,7 @@
       }
     },
     "LEARN_MORE_DATA_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -58368,7 +58368,7 @@
       }
     },
     "LEARN_MORE_PRIVACY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -58649,7 +58649,7 @@
       }
     },
     "LEARN_MORE_STUDY_SURVEY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -58930,7 +58930,7 @@
       }
     },
     "LEARN_MORE_TASKS" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -59211,7 +59211,7 @@
       }
     },
     "LEARN_MORE_TIME_COMMITMENT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -59492,7 +59492,7 @@
       }
     },
     "LEARN_MORE_WELCOME" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -59773,7 +59773,7 @@
       }
     },
     "LEARN_MORE_WITHDRAWING" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -60055,7 +60055,7 @@
     },
     "LIMB_LEFT" : {
       "comment" : "Limb values.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -60318,7 +60318,7 @@
       }
     },
     "LIMB_OPTION_LEFT_OR_RIGHT_ERROR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -60581,7 +60581,7 @@
       }
     },
     "LIMB_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -60844,7 +60844,7 @@
       }
     },
     "LOCATION_ERROR_GEOCODE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -61125,7 +61125,7 @@
       }
     },
     "LOCATION_ERROR_GEOCODE_NETWORK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -61406,7 +61406,7 @@
       }
     },
     "LOCATION_ERROR_MESSAGE_DENIED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -61687,7 +61687,7 @@
       }
     },
     "LOCATION_ERROR_MESSAGE_LOCATION_UNKNOWN" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -61968,7 +61968,7 @@
       }
     },
     "LOCATION_ERROR_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -62250,7 +62250,7 @@
     },
     "LOCATION_QUESTION_PLACEHOLDER" : {
       "comment" : "Alerts for invalid location coordinates",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -62532,7 +62532,7 @@
     },
     "LOGIN_CONTINUE_BUTTON_TITLE" : {
       "comment" : "Login step",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -62814,7 +62814,7 @@
     },
     "MEASURING_UNIT_CM" : {
       "comment" : "Measuring unit abbreviations",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -63095,7 +63095,7 @@
       }
     },
     "MEASURING_UNIT_FT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -63376,7 +63376,7 @@
       }
     },
     "MEASURING_UNIT_IN" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -63657,7 +63657,7 @@
       }
     },
     "MEASURING_UNIT_KG" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -63920,7 +63920,7 @@
       }
     },
     "MEASURING_UNIT_LB" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -64183,7 +64183,7 @@
       }
     },
     "MEASURING_UNIT_OZ" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -64446,7 +64446,7 @@
       }
     },
     "MEMORY_GAME_COMPLETE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -64727,7 +64727,7 @@
       }
     },
     "MEMORY_GAME_COMPLETE_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -65008,7 +65008,7 @@
       }
     },
     "MEMORY_GAME_COMPLETE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -65289,7 +65289,7 @@
       }
     },
     "MEMORY_GAME_COPYRIGHT_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -65552,7 +65552,7 @@
       }
     },
     "MEMORY_GAME_FAILED_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -65833,7 +65833,7 @@
       }
     },
     "MEMORY_GAME_FAILED_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -66114,7 +66114,7 @@
       }
     },
     "MEMORY_GAME_GAMEPLAY_REVERSE_TITLE_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -66395,7 +66395,7 @@
       }
     },
     "MEMORY_GAME_GAMEPLAY_TITLE_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -66676,7 +66676,7 @@
       }
     },
     "MEMORY_GAME_ITEM_COUNT_TITLE_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -66957,7 +66957,7 @@
       }
     },
     "MEMORY_GAME_PAUSED_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -67238,7 +67238,7 @@
       }
     },
     "MEMORY_GAME_PAUSED_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -67519,7 +67519,7 @@
       }
     },
     "MEMORY_GAME_PLAYBACK_TITLE_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -67800,7 +67800,7 @@
       }
     },
     "MEMORY_GAME_SCORE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -68081,7 +68081,7 @@
       }
     },
     "MEMORY_GAME_TIMEOUT_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -68362,7 +68362,7 @@
       }
     },
     "MEMORY_GAME_TIMEOUT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -68643,7 +68643,7 @@
       }
     },
     "NULL_ANSWER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -68924,7 +68924,7 @@
       }
     },
     "PASAT_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -69206,7 +69206,7 @@
     },
     "PASAT_TITLE" : {
       "comment" : "PSAT active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -69487,7 +69487,7 @@
       }
     },
     "PASSCODE_AUTHENTICATED_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -69768,7 +69768,7 @@
       }
     },
     "PASSCODE_CONFIRM_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -70049,7 +70049,7 @@
       }
     },
     "PASSCODE_CONFIRM_NEW_ENTRY_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -70330,7 +70330,7 @@
       }
     },
     "PASSCODE_FORGOT_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -70611,7 +70611,7 @@
       }
     },
     "PASSCODE_INVALID_ALERT_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -70892,7 +70892,7 @@
       }
     },
     "PASSCODE_INVALID_ALERT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -71173,7 +71173,7 @@
       }
     },
     "PASSCODE_NEW_ENTRY_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -71454,7 +71454,7 @@
       }
     },
     "PASSCODE_OLD_ENTRY_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -71736,7 +71736,7 @@
     },
     "PASSCODE_PROMPT_MESSAGE" : {
       "comment" : "Passcode step",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72017,7 +72017,7 @@
       }
     },
     "PASSCODE_SAVED_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72298,7 +72298,7 @@
       }
     },
     "PASSCODE_TEXTFIELD_ACCESSIBILITY_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72579,7 +72579,7 @@
       }
     },
     "PASSCODE_TEXTFIELD_ACCESSIBILTIY_VALUE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72860,7 +72860,7 @@
       }
     },
     "PASSCODE_TEXTFIELD_INVALID_INPUT_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -73141,7 +73141,7 @@
       }
     },
     "PASSCODE_TOUCH_ID_ERROR_ALERT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -73422,7 +73422,7 @@
       }
     },
     "PASSCODE_TOUCH_ID_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -73703,7 +73703,7 @@
       }
     },
     "PASSWORD_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -73984,7 +73984,7 @@
       }
     },
     "PASSWORD_FORM_ITEM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -74265,7 +74265,7 @@
       }
     },
     "PAVSAT_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -74546,7 +74546,7 @@
       }
     },
     "PAVSAT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -74827,7 +74827,7 @@
       }
     },
     "PHONE_NUMBER_FORM_ITEM_PLACEHOLDER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -75090,7 +75090,7 @@
       }
     },
     "PHONE_NUMBER_FORM_ITEM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -75353,7 +75353,7 @@
       }
     },
     "PLACEHOLDER_IMAGE_CHOICES" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -75634,7 +75634,7 @@
       }
     },
     "PLACEHOLDER_LONG_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -75916,7 +75916,7 @@
     },
     "PLACEHOLDER_TEXT_OR_NUMBER" : {
       "comment" : "Default placeholders to request answers in a questionnaire.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -76197,7 +76197,7 @@
       }
     },
     "PSAT_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -76478,7 +76478,7 @@
       }
     },
     "PSAT_INITIAL_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -76759,7 +76759,7 @@
       }
     },
     "PSAT_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -77040,7 +77040,7 @@
       }
     },
     "PSAT_INTRO_TEXT_2_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -77321,7 +77321,7 @@
       }
     },
     "PSAT_NO_DIGIT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -77602,7 +77602,7 @@
       }
     },
     "PVSAT_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -77883,7 +77883,7 @@
       }
     },
     "PVSAT_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -78164,7 +78164,7 @@
       }
     },
     "RANGE_ALERT_MESSAGE_ABOVE_MAXIMUM" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -78445,7 +78445,7 @@
       }
     },
     "RANGE_ALERT_MESSAGE_BELOW_MAXIMUM" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -78726,7 +78726,7 @@
       }
     },
     "RANGE_ALERT_MESSAGE_OTHER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -79008,7 +79008,7 @@
     },
     "RANGE_ALERT_TITLE" : {
       "comment" : "Alert for out of range values.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -79290,7 +79290,7 @@
     },
     "RANGE_OF_MOTION_TITLE" : {
       "comment" : "Range of Motion active task",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -79553,7 +79553,7 @@
       }
     },
     "REACTION_TIME_NORMALIZED_TASK_ACTIVE_STEP_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -79570,7 +79570,7 @@
       }
     },
     "REACTION_TIME_TASK_ACTIVE_STEP_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -79851,7 +79851,7 @@
       }
     },
     "REACTION_TIME_TASK_ATTEMPTS_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -80132,7 +80132,7 @@
       }
     },
     "REACTION_TIME_TASK_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -80413,7 +80413,7 @@
       }
     },
     "REACTION_TIME_TASK_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -80694,7 +80694,7 @@
       }
     },
     "REACTION_TIME_TASK_INTRO_TEXT_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -80975,7 +80975,7 @@
       }
     },
     "REACTION_TIME_TASK_NORM_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -80993,7 +80993,7 @@
     },
     "REACTION_TIME_TASK_TITLE" : {
       "comment" : "Reaction time active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -81274,7 +81274,7 @@
       }
     },
     "RESEND_EMAIL_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -81555,7 +81555,7 @@
       }
     },
     "RESEND_EMAIL_LABEL_MESSAGE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -81836,7 +81836,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_SPOKEN_INSTRUCTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -82099,7 +82099,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_SPOKEN_INSTRUCTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -82362,7 +82362,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_0_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -82625,7 +82625,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_0_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -82888,7 +82888,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_1_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -83151,7 +83151,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_1_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -83414,7 +83414,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_2_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -83677,7 +83677,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_2_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -83940,7 +83940,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_3_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -84203,7 +84203,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TEXT_INSTRUCTION_3_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -84467,7 +84467,7 @@
     },
     "SHOULDER_RANGE_OF_MOTION_TITLE_LEFT" : {
       "comment" : "Shoulder Range of Motion active task",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -84730,7 +84730,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TITLE_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -84993,7 +84993,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TOUCH_ANYWHERE_STEP_INSTRUCTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -85256,7 +85256,7 @@
       }
     },
     "SHOULDER_RANGE_OF_MOTION_TOUCH_ANYWHERE_STEP_INSTRUCTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -85519,7 +85519,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -85800,7 +85800,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_INTRO_2_TEXT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86081,7 +86081,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_INTRO_2_TEXT_REVERSE_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86362,7 +86362,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_INTRO_TEXT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86643,7 +86643,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_TARGET_PLURAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86924,7 +86924,7 @@
       }
     },
     "SPATIAL_SPAN_MEMORY_TARGET_STANDALONE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -87206,7 +87206,7 @@
     },
     "SPATIAL_SPAN_MEMORY_TITLE" : {
       "comment" : "Spatial span memory active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -87487,7 +87487,7 @@
       }
     },
     "SPEECH_IN_NOISE_CALIBRATION_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -87750,7 +87750,7 @@
       }
     },
     "SPEECH_IN_NOISE_CALIBRATION_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -88013,7 +88013,7 @@
       }
     },
     "SPEECH_IN_NOISE_DETAIL_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -88276,7 +88276,7 @@
       }
     },
     "SPEECH_IN_NOISE_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -88539,7 +88539,7 @@
       }
     },
     "SPEECH_IN_NOISE_SPEAK_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -88802,7 +88802,7 @@
       }
     },
     "SPEECH_IN_NOISE_SPEAK_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -89066,7 +89066,7 @@
     },
     "SPEECH_IN_NOISE_START_AUDIO_LABEL" : {
       "comment" : "Speech In Noise active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -89329,7 +89329,7 @@
       }
     },
     "SPEECH_IN_NOISE_STEP_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -89592,7 +89592,7 @@
       }
     },
     "SPEECH_IN_NOISE_STEP_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -89855,7 +89855,7 @@
       }
     },
     "SPEECH_IN_NOISE_STOP_AUDIO_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -90118,7 +90118,7 @@
       }
     },
     "SPEECH_IN_NOISE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -90381,7 +90381,7 @@
       }
     },
     "SPEECH_RECOGNITION_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -90644,7 +90644,7 @@
       }
     },
     "SPEECH_RECOGNITION_FAILED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -90907,7 +90907,7 @@
       }
     },
     "SPEECH_RECOGNITION_INIT_FAILURE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -91170,7 +91170,7 @@
       }
     },
     "SPEECH_RECOGNITION_INTRO_2_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -91433,7 +91433,7 @@
       }
     },
     "SPEECH_RECOGNITION_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -91696,7 +91696,7 @@
       }
     },
     "SPEECH_RECOGNITION_QUESTION_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -91959,7 +91959,7 @@
       }
     },
     "SPEECH_RECOGNITION_QUESTION_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -92222,7 +92222,7 @@
       }
     },
     "SPEECH_RECOGNITION_START_RECORD_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -92485,7 +92485,7 @@
       }
     },
     "SPEECH_RECOGNITION_STOP_RECORD_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -92748,7 +92748,7 @@
       }
     },
     "SPEECH_RECOGNITION_TRANSCRIPTION_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -93012,7 +93012,7 @@
     },
     "SPEECH_TASK_TITLE" : {
       "comment" : "Speech Recognition active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -93276,7 +93276,7 @@
     },
     "STEP_PROGRESS_FORMAT" : {
       "comment" : "Progress indication (in navigation bar).",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -93557,7 +93557,7 @@
       }
     },
     "STROOP_COLOR_BLACK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -93580,7 +93580,7 @@
       }
     },
     "STROOP_COLOR_BLUE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -93843,7 +93843,7 @@
       }
     },
     "STROOP_COLOR_BLUE_INITIAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -94106,7 +94106,7 @@
       }
     },
     "STROOP_COLOR_GREEN" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -94369,7 +94369,7 @@
       }
     },
     "STROOP_COLOR_GREEN_INITIAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -94632,7 +94632,7 @@
       }
     },
     "STROOP_COLOR_RED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -94895,7 +94895,7 @@
       }
     },
     "STROOP_COLOR_RED_INITIAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -95158,7 +95158,7 @@
       }
     },
     "STROOP_COLOR_YELLOW" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -95421,7 +95421,7 @@
       }
     },
     "STROOP_COLOR_YELLOW_INITIAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -95684,7 +95684,7 @@
       }
     },
     "STROOP_TASK_INTRO1_DETAIL_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -95947,7 +95947,7 @@
       }
     },
     "STROOP_TASK_INTRO2_DETAIL_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -96210,7 +96210,7 @@
       }
     },
     "STROOP_TASK_STEP_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -96474,7 +96474,7 @@
     },
     "STROOP_TASK_TITLE" : {
       "comment" : "Stroop active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -96737,7 +96737,7 @@
       }
     },
     "TAP_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -97018,7 +97018,7 @@
       }
     },
     "TAPPING_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -97299,7 +97299,7 @@
       }
     },
     "TAPPING_CALL_TO_ACTION_NEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -97580,7 +97580,7 @@
       }
     },
     "TAPPING_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -97861,7 +97861,7 @@
       }
     },
     "TAPPING_INSTRUCTION_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -98142,7 +98142,7 @@
       }
     },
     "TAPPING_INSTRUCTION_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -98423,7 +98423,7 @@
       }
     },
     "TAPPING_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -98704,7 +98704,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -98985,7 +98985,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_LEFT_FIRST" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -99266,7 +99266,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_LEFT_SECOND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -99547,7 +99547,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_MOST_AFFECTED" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -99828,7 +99828,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_REST_PHONE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -100109,7 +100109,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_RIGHT_FIRST" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -100390,7 +100390,7 @@
       }
     },
     "TAPPING_INTRO_TEXT_2_RIGHT_SECOND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -100671,7 +100671,7 @@
       }
     },
     "TAPPING_SKIP_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -100953,7 +100953,7 @@
     },
     "TAPPING_TASK_TITLE" : {
       "comment" : "Tapping active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -101234,7 +101234,7 @@
       }
     },
     "TAPPING_TASK_TITLE_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -101515,7 +101515,7 @@
       }
     },
     "TAPPING_TASK_TITLE_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -101796,7 +101796,7 @@
       }
     },
     "TASK_COMPLETE_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -102077,7 +102077,7 @@
       }
     },
     "TASK_COMPLETE_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -102359,7 +102359,7 @@
     },
     "TEXT_ANSWER_EXCEEDING_MAX_LENGTH_ALERT_MESSAGE" : {
       "comment" : "Alert for exceeding length limit in text answer",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -102640,7 +102640,7 @@
       }
     },
     "TIME_OUT_BODY" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -102657,7 +102657,7 @@
       }
     },
     "TIME_OUT_END_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -102674,7 +102674,7 @@
       }
     },
     "TIME_OUT_RESTART_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -102691,7 +102691,7 @@
       }
     },
     "TIME_OUT_TILE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -102708,7 +102708,7 @@
       }
     },
     "TIMED_WALK_FORM_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -102989,7 +102989,7 @@
       }
     },
     "TIMED_WALK_FORM_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -103270,7 +103270,7 @@
       }
     },
     "TIMED_WALK_INSTRUCTION_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -103551,7 +103551,7 @@
       }
     },
     "TIMED_WALK_INSTRUCTION_2" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -103832,7 +103832,7 @@
       }
     },
     "TIMED_WALK_INSTRUCTION_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -104113,7 +104113,7 @@
       }
     },
     "TIMED_WALK_INSTRUCTION_TURN" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -104376,7 +104376,7 @@
       }
     },
     "TIMED_WALK_INTRO_2_DETAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -104657,7 +104657,7 @@
       }
     },
     "TIMED_WALK_INTRO_2_TEXT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -104938,7 +104938,7 @@
       }
     },
     "TIMED_WALK_INTRO_DETAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -105219,7 +105219,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -105500,7 +105500,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE_2" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -105781,7 +105781,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE_3" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -106062,7 +106062,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE_4" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -106343,7 +106343,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE_5" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -106624,7 +106624,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_CHOICE_6" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -106905,7 +106905,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -107186,7 +107186,7 @@
       }
     },
     "TIMED_WALK_QUESTION_2_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -107467,7 +107467,7 @@
       }
     },
     "TIMED_WALK_QUESTION_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -107749,7 +107749,7 @@
     },
     "TIMED_WALK_TITLE" : {
       "comment" : "Timed walk active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -108030,7 +108030,7 @@
       }
     },
     "TONE_AUDIOMETRY_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -108311,7 +108311,7 @@
       }
     },
     "TONE_AUDIOMETRY_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -108592,7 +108592,7 @@
       }
     },
     "TONE_AUDIOMETRY_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -108873,7 +108873,7 @@
       }
     },
     "TONE_AUDIOMETRY_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -109154,7 +109154,7 @@
       }
     },
     "TONE_AUDIOMETRY_LABEL_LEFT_EAR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -109417,7 +109417,7 @@
       }
     },
     "TONE_AUDIOMETRY_LABEL_RIGHT_EAR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -109680,7 +109680,7 @@
       }
     },
     "TONE_AUDIOMETRY_PREP_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -109962,7 +109962,7 @@
     },
     "TONE_AUDIOMETRY_TASK_TITLE" : {
       "comment" : "Tone audiometry active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -110243,7 +110243,7 @@
       }
     },
     "TONE_LABEL_%@_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -110524,7 +110524,7 @@
       }
     },
     "TONE_LABEL_%@_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -110805,7 +110805,7 @@
       }
     },
     "TOTAL_TAPS_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -111086,7 +111086,7 @@
       }
     },
     "TOUCH_ANYWHERE_LABEL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -111349,7 +111349,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_ACTIVE_STEP_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -111630,7 +111630,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_ACTIVE_STEP_PROGRESS_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -111911,7 +111911,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_ACTIVE_STEP_SKIP_BUTTON_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -112192,7 +112192,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -112473,7 +112473,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -112754,7 +112754,7 @@
       }
     },
     "TOWER_OF_HANOI_TASK_TASK_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -113036,7 +113036,7 @@
     },
     "TOWER_OF_HANOI_TASK_TITLE" : {
       "comment" : "Tower of Hanoi active task",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -113317,7 +113317,7 @@
       }
     },
     "TRAILMAKING_CALL_TO_ACTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -113580,7 +113580,7 @@
       }
     },
     "TRAILMAKING_ERROR" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -113843,7 +113843,7 @@
       }
     },
     "TRAILMAKING_ERROR_PLURAL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -114106,7 +114106,7 @@
       }
     },
     "TRAILMAKING_INTENDED_USE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -114369,7 +114369,7 @@
       }
     },
     "TRAILMAKING_INTENDED_USE2_A" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -114632,7 +114632,7 @@
       }
     },
     "TRAILMAKING_INTENDED_USE2_B" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -114895,7 +114895,7 @@
       }
     },
     "TRAILMAKING_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -115158,7 +115158,7 @@
       }
     },
     "TRAILMAKING_LETTER_A" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -115421,7 +115421,7 @@
       }
     },
     "TRAILMAKING_LETTER_B" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -115684,7 +115684,7 @@
       }
     },
     "TRAILMAKING_LETTER_C" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -115947,7 +115947,7 @@
       }
     },
     "TRAILMAKING_LETTER_D" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -116210,7 +116210,7 @@
       }
     },
     "TRAILMAKING_LETTER_E" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -116473,7 +116473,7 @@
       }
     },
     "TRAILMAKING_LETTER_F" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -116737,7 +116737,7 @@
     },
     "TRAILMAKING_TASK_TITLE" : {
       "comment" : "Trail making task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -117000,7 +117000,7 @@
       }
     },
     "TRAILMAKING_TIMER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -117263,7 +117263,7 @@
       }
     },
     "TREMOR_SKIP_LEFT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -117544,7 +117544,7 @@
       }
     },
     "TREMOR_SKIP_NEITHER" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -117825,7 +117825,7 @@
       }
     },
     "TREMOR_SKIP_RIGHT_HAND" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -118106,7 +118106,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_BEND_ARM_INSTRUCTION_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -118387,7 +118387,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_BEND_ARM_INTRO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -118668,7 +118668,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_BEND_ARM_INTRO_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -118949,7 +118949,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_BEND_ARM_INTRO_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -119230,7 +119230,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_EXTEND_ARM_INSTRUCTION_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -119511,7 +119511,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_EXTEND_ARM_INTRO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -119792,7 +119792,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_EXTEND_ARM_INTRO_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -120073,7 +120073,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_EXTEND_ARM_INTRO_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -120354,7 +120354,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_FINISHED_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -120635,7 +120635,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_IN_LAP_INSTRUCTION_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -120916,7 +120916,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_IN_LAP_INTRO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -121197,7 +121197,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_IN_LAP_INTRO_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -121478,7 +121478,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_IN_LAP_INTRO_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -121759,7 +121759,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -122040,7 +122040,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_SWITCH_HANDS_LEFT_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -122321,7 +122321,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_SWITCH_HANDS_RIGHT_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -122602,7 +122602,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TOUCH_NOSE_INSTRUCTION_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -122883,7 +122883,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TOUCH_NOSE_INTRO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -123164,7 +123164,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TOUCH_NOSE_INTRO_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -123445,7 +123445,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TOUCH_NOSE_INTRO_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -123726,7 +123726,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TURN_WRIST_INSTRUCTION_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -124007,7 +124007,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TURN_WRIST_INTRO" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -124288,7 +124288,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TURN_WRIST_INTRO_LEFT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -124569,7 +124569,7 @@
       }
     },
     "TREMOR_TEST_ACTIVE_STEP_TURN_WRIST_INTRO_RIGHT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -124850,7 +124850,7 @@
       }
     },
     "TREMOR_TEST_COMPLETED_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -125131,7 +125131,7 @@
       }
     },
     "TREMOR_TEST_INTRO_1_DETAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -125412,7 +125412,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DEFAULT_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -125693,7 +125693,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_1_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -125974,7 +125974,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_2_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -126255,7 +126255,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_3_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -126536,7 +126536,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_4_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -126817,7 +126817,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_5_TASK" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -127098,7 +127098,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_DETAIL_DEFAULT_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -127379,7 +127379,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_LEFT_HAND_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -127660,7 +127660,7 @@
       }
     },
     "TREMOR_TEST_INTRO_2_RIGHT_HAND_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -127941,7 +127941,7 @@
       }
     },
     "TREMOR_TEST_SKIP_QUESTION_BOTH_HANDS_%@" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -128223,7 +128223,7 @@
     },
     "TREMOR_TEST_TITLE" : {
       "comment" : "Tremor test active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -128505,7 +128505,7 @@
     },
     "VERIFICATION_NAV_TITLE" : {
       "comment" : "Verification step",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -128786,7 +128786,7 @@
       }
     },
     "VERIFICATION_STEP_TITLE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -129067,7 +129067,7 @@
       }
     },
     "WALK_BACK_AND_FORTH_FINISHED_VOICE" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -129348,7 +129348,7 @@
       }
     },
     "WALK_BACK_AND_FORTH_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -129629,7 +129629,7 @@
       }
     },
     "WALK_BACK_AND_FORTH_STAND_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -129910,7 +129910,7 @@
       }
     },
     "WALK_INTRO_2_DETAIL" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -130191,7 +130191,7 @@
       }
     },
     "WALK_INTRO_2_DETAIL_BACK_AND_FORTH_INSTRUCTION" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -130472,7 +130472,7 @@
       }
     },
     "WALK_INTRO_2_TEXT_%ld" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -130754,7 +130754,7 @@
     },
     "WALK_INTRO_2_TEXT_BACK_AND_FORTH_INSTRUCTION" : {
       "comment" : "Short walk back and forth.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -131035,7 +131035,7 @@
       }
     },
     "WALK_INTRO_TEXT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -131316,7 +131316,7 @@
       }
     },
     "WALK_OUTBOUND_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -131597,7 +131597,7 @@
       }
     },
     "WALK_RETURN_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -131878,7 +131878,7 @@
       }
     },
     "WALK_STAND_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -132159,7 +132159,7 @@
       }
     },
     "WALK_STAND_VOICE_INSTRUCTION_FORMAT" : {
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -132441,7 +132441,7 @@
     },
     "WALK_TASK_TITLE" : {
       "comment" : "Short walk active task.",
-      "extractionState" : "migrated",
+      "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {


### PR DESCRIPTION
This appears to be an Xcode 18 change where all the strings' `extractionState`  has changed: `migrated` -> `manual`. I don't see any issues in simply accepting these to minimize noise in builds.