### PR TITLE
Customizable end-task prompts

### DIFF
--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
@@ -133,6 +133,19 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
  */
 - (BOOL)taskViewControllerShouldConfirmCancel:(ORK1TaskViewController *)taskViewController;
 
+@optional
+/// Asks the delegate for customized button titles for the discard task prompt button. If not implemented, default localized titles are used.
+/// @param taskViewController The calling `ORK1TaskViewController` instance.
+/// @param saveable Whether the task result can be saved. If true, the button is for discarding the results, otherwise the button is for ending the task.
+/// @return A localized string, or nil to use the default text.
+- (nullable NSString *)taskViewController:(ORK1TaskViewController *)taskViewController discardTaskButtonLocalizedTitle:(BOOL)saveable;
+
+@optional
+/// Asks the delegate for a customized button for cancelling an end-task prompt and remaining in the task.  If not implemented, a default "Cancel" title is used.
+/// @param taskViewController The calling `ORK1TaskViewController` instance.
+/// @return A localized string, or nil to use the default text.
+- (nullable NSString *)taskViewControllerCancelEndTaskButtonLocalizedTitle:(ORK1TaskViewController *)taskViewController;
+
 /**
  Asks the delegate if there is Learn More content for this step.
  

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.h
@@ -63,6 +63,16 @@ typedef NS_ENUM(NSInteger, ORK1TaskViewControllerFinishReason) {
     ORK1TaskViewControllerFinishReasonFailed
 };
 
+/// Configuration for customizing "end task"-related prompts during survey presentation. All properties are optional, a `nil` value indicates the ResearchKit default value should be used.
+@protocol ORK1EndTaskPromptConfiguration <NSObject>
+/// Button to dismiss a prompt and *not* end a task.
+@property (readonly, nullable) NSString *cancelEndTaskButtonLocalizedTitle;
+/// Button to confirm ending a task, for a task where results could be saved.
+@property (readonly, nullable) NSString *discardResultsButtonLocalizedTitle;
+/// Button to confirm ending a task, where there are no results to save.
+@property (readonly, nullable) NSString *confirmEndTaskButtonLocalizedTitle;
+@end
+
 /**
  The task view controller delegate is responsible for processing the results
  of the task, exerting some control over how the controller behaves, and providing
@@ -134,17 +144,10 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
 - (BOOL)taskViewControllerShouldConfirmCancel:(ORK1TaskViewController *)taskViewController;
 
 @optional
-/// Asks the delegate for customized button titles for the discard task prompt button. If not implemented, default localized titles are used.
+/// Asks the delegate for optional custom configuration for end-task prompts.
 /// @param taskViewController The calling `ORK1TaskViewController` instance.
-/// @param saveable Whether the task result can be saved. If true, the button is for discarding the results, otherwise the button is for ending the task.
-/// @return A localized string, or nil to use the default text.
-- (nullable NSString *)taskViewController:(ORK1TaskViewController *)taskViewController discardTaskButtonLocalizedTitle:(BOOL)saveable;
-
-@optional
-/// Asks the delegate for a customized button for cancelling an end-task prompt and remaining in the task.  If not implemented, a default "Cancel" title is used.
-/// @param taskViewController The calling `ORK1TaskViewController` instance.
-/// @return A localized string, or nil to use the default text.
-- (nullable NSString *)taskViewControllerCancelEndTaskButtonLocalizedTitle:(ORK1TaskViewController *)taskViewController;
+/// @return A custom configuration. If `nil` or not implemented, a default configuration is used.
+- (nullable id<ORK1EndTaskPromptConfiguration>)taskViewControllerEndTaskPromptConfiguration:(ORK1TaskViewController *)taskViewController;
 
 /**
  Asks the delegate if there is Learn More content for this step.

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1253,6 +1253,11 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         supportSaving = [self.delegate taskViewControllerSupportsSaveAndRestore:self];
     }
     
+    id <ORK1EndTaskPromptConfiguration> configuration = nil;
+    if ([self.delegate respondsToSelector:@selector(taskViewControllerEndTaskPromptConfiguration:)]) {
+        configuration = [self.delegate taskViewControllerEndTaskPromptConfiguration:self];
+    }
+    
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
                                                                    message:nil
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
@@ -1268,10 +1273,9 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                                                 }]];
     }
     
-    NSString *discardTitle = saveable ? ORK1LocalizedString(@"BUTTON_OPTION_DISCARD", nil) : ORK1LocalizedString(@"BUTTON_OPTION_STOP_TASK", nil);
-    if ([self.delegate respondsToSelector:@selector(taskViewController:discardTaskButtonLocalizedTitle:)]) {
-        discardTitle = [self.delegate taskViewController:self discardTaskButtonLocalizedTitle:saveable] ?: discardTitle;
-    }
+    NSString *discardTitle = saveable
+    ? (configuration.discardResultsButtonLocalizedTitle ?: ORK1LocalizedString(@"BUTTON_OPTION_DISCARD", nil))
+    : (configuration.confirmEndTaskButtonLocalizedTitle ?: ORK1LocalizedString(@"BUTTON_OPTION_STOP_TASK", nil));
     
     [alert addAction:[UIAlertAction actionWithTitle:discardTitle
                                               style:UIAlertActionStyleDestructive
@@ -1281,10 +1285,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                                                 });
                                             }]];
     
-    NSString *cancelTitle = ORK1LocalizedString(@"BUTTON_CANCEL", nil);
-    if ([self.delegate respondsToSelector:@selector(taskViewControllerCancelEndTaskButtonLocalizedTitle:)]) {
-        cancelTitle = [self.delegate taskViewControllerCancelEndTaskButtonLocalizedTitle:self] ?: cancelTitle;
-    }
+    NSString *cancelTitle = configuration.cancelEndTaskButtonLocalizedTitle ?: ORK1LocalizedString(@"BUTTON_CANCEL", nil);
     
     [alert addAction:[UIAlertAction actionWithTitle:cancelTitle
                                               style:UIAlertActionStyleCancel

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -1269,6 +1269,9 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     NSString *discardTitle = saveable ? ORK1LocalizedString(@"BUTTON_OPTION_DISCARD", nil) : ORK1LocalizedString(@"BUTTON_OPTION_STOP_TASK", nil);
+    if ([self.delegate respondsToSelector:@selector(taskViewController:discardTaskButtonLocalizedTitle:)]) {
+        discardTitle = [self.delegate taskViewController:self discardTaskButtonLocalizedTitle:saveable] ?: discardTitle;
+    }
     
     [alert addAction:[UIAlertAction actionWithTitle:discardTitle
                                               style:UIAlertActionStyleDestructive
@@ -1278,7 +1281,12 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                                                 });
                                             }]];
     
-    [alert addAction:[UIAlertAction actionWithTitle:ORK1LocalizedString(@"BUTTON_CANCEL", nil)
+    NSString *cancelTitle = ORK1LocalizedString(@"BUTTON_CANCEL", nil);
+    if ([self.delegate respondsToSelector:@selector(taskViewControllerCancelEndTaskButtonLocalizedTitle:)]) {
+        cancelTitle = [self.delegate taskViewControllerCancelEndTaskButtonLocalizedTitle:self] ?: cancelTitle;
+    }
+    
+    [alert addAction:[UIAlertAction actionWithTitle:cancelTitle
                                               style:UIAlertActionStyleCancel
                                             handler:nil]];
     


### PR DESCRIPTION
Adds an optional ORK1TaskViewControllerDelegate method to customize the "End Task"/"Discard Results" prompts shown when exiting a survey. In support of https://github.com/CareEvolution/MyDataHelps-iOS/pull/1399

Note that this was only needed for ORK1Kit, not ResearchKit v2, since these are used by the special `TaskManager` workflows that only use ORK1Kit. Actual ResearchKit surveys, for example, use other task delegates (e.g. RK1SurveyTaskInteraction) that already have their own taskViewControllerShouldConfirmCancel logic, and we don't currently have any requests to customize the button text for their end-task prompts.

## Testing

This is a dependency for https://github.com/CareEvolution/MyDataHelps-iOS/pull/1399 and all testing would be performed as part of that PR.