### PR TITLE
Customizable login button

### DIFF
--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.h
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.h
@@ -45,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 ORK1_CLASS_AVAILABLE
 @interface ORK1LoginStepViewController : ORK1FormStepViewController
 
+/// The title for the login button. Default value is supplied by ResearchKit; update this value to customize the button.
+@property (nonatomic, copy) NSString *loginButtonTitle;
+
 /**
  Action method for the forgot password button.
 

--- a/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.m
+++ b/ORK1Kit/ORK1Kit/Onboarding/ORK1LoginStepViewController.m
@@ -38,11 +38,25 @@
 #import "ORK1Helpers_Internal.h"
 
 
-@implementation ORK1LoginStepViewController
+@implementation ORK1LoginStepViewController {
+    NSString *_loginButtonTitle;
+}
 
 - (void)setContinueButtonItem:(UIBarButtonItem *)continueButtonItem {
     [super setContinueButtonItem:continueButtonItem];
-    continueButtonItem.title = ORK1LocalizedString(@"LOGIN_CONTINUE_BUTTON_TITLE", nil);
+    continueButtonItem.title = self.loginButtonTitle;
+}
+
+- (NSString *)loginButtonTitle {
+    if (!_loginButtonTitle) {
+        _loginButtonTitle = ORK1LocalizedString(@"LOGIN_CONTINUE_BUTTON_TITLE", nil);
+    }
+    return _loginButtonTitle;
+}
+
+- (void)setLoginButtonTitle:(NSString *)loginButtonTitle {
+    _loginButtonTitle = loginButtonTitle;
+    self.continueButtonItem.title = loginButtonTitle;
 }
 
 - (void)setSkipButtonItem:(UIBarButtonItem *)skipButtonItem {


### PR DESCRIPTION
The built-in ResearchKit translations for login buttons is "Login", but [we want to use "Log In"](https://github.com/CareEvolution/MyDataHelps-iOS/issues/1397). I opted to simply make this customizable so we can use the localized string that we already have in the MDH repo, rather than changing the translations in ResearchKit itself.

## Testing

This is tested as part of https://github.com/CareEvolution/MyDataHelps-iOS/pull/1400