### PR TITLE
Add ability to force recorders to complete before allowing step to advance for ActiveSteps

### DIFF
--- a/ORK1Kit/ORK1Kit/ActiveTasks/CEV1RangeOfMotionStepViewController.swift
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/CEV1RangeOfMotionStepViewController.swift
@@ -37,9 +37,8 @@ public class CEV1RangeOfMotionStepViewController: ORK1RangeOfMotionStepViewContr
             result.flexed = lowestAngle
             result.extended = highestAngle
         }
-        result.fileResult = self.fileResult
         
-        stepResult?.results = (self.addedResults ?? []) + [result]
+        stepResult?.results = (stepResult?.results ?? []) + [result]
         
         return stepResult
     }

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.h
@@ -219,6 +219,12 @@ The default value of this property is `NO`.
  */
 @property (nonatomic, copy, nullable) NSArray<ORK1RecorderConfiguration *> *recorderConfigurations;
 
+/**
+ A Boolean value that indicates whether the step must wait for all recorders to complete, returning a result
+ or error before allowing the step to proceed.
+ */
+@property (nonatomic) BOOL recordersMustCompleteBeforeAdvancingStep;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStep.m
@@ -102,6 +102,7 @@
     step.spokenInstruction = self.spokenInstruction;
     step.finishedSpokenInstruction = self.finishedSpokenInstruction;
     step.recorderConfigurations = [self.recorderConfigurations copy];
+    step.recordersMustCompleteBeforeAdvancingStep = self.recordersMustCompleteBeforeAdvancingStep;
     step.image = self.image;
     step.imageAltText = self.imageAltText;
     return step;
@@ -126,6 +127,7 @@
         ORK1_DECODE_IMAGE(aDecoder, image);
         ORK1_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK1_DECODE_OBJ_ARRAY(aDecoder, recorderConfigurations, ORK1RecorderConfiguration);
+        ORK1_DECODE_BOOL(aDecoder, recordersMustCompleteBeforeAdvancingStep);
     }
     return self;
 }
@@ -148,6 +150,7 @@
     ORK1_ENCODE_OBJ(aCoder, spokenInstruction);
     ORK1_ENCODE_OBJ(aCoder, finishedSpokenInstruction);
     ORK1_ENCODE_OBJ(aCoder, recorderConfigurations);
+    ORK1_ENCODE_BOOL(aCoder, recordersMustCompleteBeforeAdvancingStep);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -170,7 +173,8 @@
             (self.shouldVibrateOnStart == castObject.shouldVibrateOnStart) &&
             (self.shouldVibrateOnFinish == castObject.shouldVibrateOnFinish) &&
             (self.shouldContinueOnFinish == castObject.shouldContinueOnFinish) &&
-            (self.shouldUseNextAsSkipButton == castObject.shouldUseNextAsSkipButton));
+            (self.shouldUseNextAsSkipButton == castObject.shouldUseNextAsSkipButton) &&
+            (self.recordersMustCompleteBeforeAdvancingStep == castObject.recordersMustCompleteBeforeAdvancingStep));
 }
 
 - (NSSet<HKObjectType *> *)requestedHealthKitTypesForReading {

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.h
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.h
@@ -211,6 +211,12 @@ ORK1_CLASS_AVAILABLE
  */
 - (void)finish;
 
+/**
+ Triggers the step to advance once the recorders have completed;
+ - Parameter stepDidFinishOnly: do not explicity call goForward on self when recorders are done (for steps that goForward without calling finish)
+ */
+- (void)goForwardOnceRecordersHaveCompleted:(BOOL)stepDidFinishOnly;
+
 /// @name Recorder life cycle
 
 /**

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.m
@@ -414,8 +414,8 @@
             [self stepDidFinish];
         } else {
             _recordersCheckLoopCount += 1;
+            NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
                 [self goForwardOnceRecordersHaveCompleted:stepDidFinishOnly];
             });
         }

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ActiveStepViewController.m
@@ -59,6 +59,9 @@
 
     NSArray *_recorderResults;
     
+    NSMutableSet *_recordersRunning;     // only accessed on the main queue
+    NSInteger _recordersCheckLoopCount;  // only accessed on the main queue
+    
     SystemSoundID _alertSound;
     NSURL *_alertSoundURL;
     BOOL _hasSpokenHalfwayCountdown;
@@ -76,6 +79,8 @@
     self = [super initWithStep:step];
     if (self) {
         _recorderResults = [NSArray new];
+        _recordersRunning = [NSMutableSet new];
+        _recordersCheckLoopCount = 0;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -292,6 +297,9 @@
     for (ORK1Recorder *recorder in self.recorders) {
         [recorder viewController:self willStartStepWithView:self.customViewContainer];
         [recorder start];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [_recordersRunning addObject:recorder];
+        });
     }
 }
 
@@ -381,10 +389,37 @@
     }
     if (!self.activeStep.startsFinished) {
         if (self.activeStep.shouldContinueOnFinish) {
-            [self goForward];
+            if (self.activeStep.recordersMustCompleteBeforeAdvancingStep) {
+                [self goForwardOnceRecordersHaveCompleted:NO];
+            } else {
+                [self goForward];
+            }
         }
     }
     [self stepDidFinish];
+}
+
+- (void)goForwardOnceRecordersHaveCompleted:(BOOL)stepDidFinishOnly {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([_recordersRunning count] == 0) {
+            if (!stepDidFinishOnly) {
+                [self goForward];
+            }
+            [self stepDidFinish];
+        } else if (_recordersCheckLoopCount > 10) {
+            NSLog(@"Recorders are still not complete after 10 wait cycles, data may be lost in final result.");
+            if (!stepDidFinishOnly) {
+                [self goForward];
+            }
+            [self stepDidFinish];
+        } else {
+            _recordersCheckLoopCount += 1;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
+                [self goForwardOnceRecordersHaveCompleted:stepDidFinishOnly];
+            });
+        }
+    });
 }
 
 - (void)dealloc {
@@ -470,6 +505,9 @@
 
 - (void)recorder:(ORK1Recorder *)recorder didCompleteWithResult:(ORK1Result *)result {
     _recorderResults = [_recorderResults arrayByAddingObject:result];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_recordersRunning removeObject:recorder];
+    });
     [self notifyDelegateOnResultChange];
 }
 
@@ -488,6 +526,9 @@
             self.outputDirectory == nil) {
             [strongDelegate stepViewControllerDidFail:self withError:error];
         }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [_recordersRunning removeObject:recorder];
+        });
     }
 }
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStep.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStep.m
@@ -50,6 +50,7 @@
         self.shouldContinueOnFinish = YES;
         self.shouldStartTimerAutomatically = YES;
         self.limbOption = limbOption;
+        self.recordersMustCompleteBeforeAdvancingStep = YES;
     }
     return self;
 }

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1RangeOfMotionStepViewController.m
@@ -175,12 +175,6 @@
     _lastAngle = angle;
 }
 
-#pragma mark - ORK1RecorderDelegate
-
-- (void)recorder:(ORK1Recorder *)recorder didCompleteWithResult:(ORK1Result *)result {
-    self.fileResult = (ORK1FileResult *)result;
-}
-
 /*
  When the device is in Portrait mode, we need to get the attitude's pitch
  to determine the device's angle. attitude.pitch doesn't return all
@@ -209,14 +203,12 @@
 
 - (ORK1Result *)result {
     ORK1StepResult *stepResult = [super result];
-    
-    ORK1RangeOfMotionResult *result = [[ORK1RangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
-    result.flexed = _flexedAngle;
-    result.extended = result.flexed - _rangeOfMotionAngle;
-    result.fileResult = _fileResult;
-    
-    stepResult.results = [self.addedResults arrayByAddingObject:result] ? : @[result];
-    
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
+    ORK1RangeOfMotionResult *rangeOfMotionResult = [[ORK1RangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
+    rangeOfMotionResult.flexed = _flexedAngle;
+    rangeOfMotionResult.extended = rangeOfMotionResult.flexed - _rangeOfMotionAngle;
+    [results addObject:rangeOfMotionResult];
+    stepResult.results = [results copy];
     return stepResult;
 }
 

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ShoulderRangeOfMotionStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1ShoulderRangeOfMotionStepViewController.m
@@ -40,11 +40,14 @@
 - (ORK1Result *)result {
     ORK1StepResult *stepResult = [super result];
     
-    ORK1RangeOfMotionResult *result = [[ORK1RangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
-    result.flexed = 90.0 - _flexedAngle;
-    result.extended = result.flexed + _rangeOfMotionAngle;
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
     
-    stepResult.results = [self.addedResults arrayByAddingObject:result] ? : @[result];
+    ORK1RangeOfMotionResult *rangeOfMotionResult = [[ORK1RangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
+    rangeOfMotionResult.flexed = 90.0 - _flexedAngle;
+    rangeOfMotionResult.extended = rangeOfMotionResult.flexed + _rangeOfMotionAngle;
+    [results addObject:rangeOfMotionResult];
+    
+    stepResult.results = [results copy];
     
     return stepResult;
 }

--- a/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.m
+++ b/ORK1Kit/ORK1Kit/ActiveTasks/ORK1TimedWalkStepViewController.m
@@ -90,10 +90,15 @@
     self.timerUpdateInterval = 0.1f;
 }
 
-- (void)finish {
+// The ORK1TimedWalkStepViewController expects the Next button to trigger goForward and doesn't call finish explicitly
+- (void)goForward {
+    [super stopRecorders];
+    [super goForwardOnceRecordersHaveCompleted:YES];
+}
+
+- (void)stepDidFinish {
     [super finish];
-    
-    [self goForward];
+    [super goForward];
 }
 
 - (void)countDownTimerFired:(ORK1ActiveStepTimer *)timer finished:(BOOL)finished {

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.h
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.h
@@ -327,11 +327,6 @@ ORK1_CLASS_AVAILABLE
   */
 @property (nonatomic, assign) double extended;
 
-/**
- The recorder output - usually the device motion recorder.
-  */
-@property (nonatomic, strong) ORK1FileResult *fileResult;
-
 @end
 
 

--- a/ORK1Kit/ORK1Kit/Common/ORK1Result.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1Result.m
@@ -258,7 +258,6 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     [super encodeWithCoder:aCoder];
     ORK1_ENCODE_DOUBLE(aCoder, flexed);
     ORK1_ENCODE_DOUBLE(aCoder, extended);
-    ORK1_ENCODE_OBJ(aCoder, fileResult);
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
@@ -266,7 +265,6 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     if (self) {
         ORK1_DECODE_DOUBLE(aDecoder, flexed);
         ORK1_DECODE_DOUBLE(aDecoder, extended);
-        ORK1_DECODE_OBJ_CLASS(aDecoder, fileResult, ORK1FileResult);
     }
     return self;
 }
@@ -280,24 +278,18 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     __typeof(self) castObject = object;
     return (isParentSame &&
             self.flexed == castObject.flexed &&
-            self.extended == castObject.extended &&
-            ORK1EqualObjects(self.fileResult, castObject.fileResult));
-}
-
-- (NSUInteger)hash {
-    return super.hash ^ self.fileResult.hash;
+            self.extended == castObject.extended);
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORK1RangeOfMotionResult *result = [super copyWithZone:zone];
     result.flexed = self.flexed;
     result.extended = self.extended;
-    result.fileResult = self.fileResult;
     return result;
 }
 
 - (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
-    return [NSString stringWithFormat:@"<%@: flexion: %f; extension: %f; fileResult: %@>", self.class.description, self.flexed, self.extended, self.fileResult.description];
+    return [NSString stringWithFormat:@"<%@: flexion: %f; extension: %f>", self.class.description, self.flexed, self.extended];
 }
 
 @end

--- a/ResearchKit/ActiveTasks/CEVRangeOfMotionStepViewController.swift
+++ b/ResearchKit/ActiveTasks/CEVRangeOfMotionStepViewController.swift
@@ -37,9 +37,8 @@ public class CEVRangeOfMotionStepViewController: ORKRangeOfMotionStepViewControl
             result.flexed = lowestAngle
             result.extended = highestAngle
         }
-        result.fileResult = self.fileResult
         
-        stepResult?.results = (self.addedResults ?? []) + [result]
+        stepResult?.results = (stepResult?.results ?? []) + [result]
         
         return stepResult
     }

--- a/ResearchKit/ActiveTasks/ORKActiveStep.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.h
@@ -228,6 +228,12 @@ The default value of this property is `NO`.
 */
 @property (nonatomic, assign) BOOL isPractice;
 
+/**
+ A Boolean value that indicates whether the step must wait for all recorders to complete, returning a result
+ or error before allowing the step to proceed.
+ */
+@property (nonatomic) BOOL recordersMustCompleteBeforeAdvancingStep;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKActiveStep.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.m
@@ -102,6 +102,7 @@
     step.spokenInstruction = self.spokenInstruction;
     step.finishedSpokenInstruction = self.finishedSpokenInstruction;
     step.recorderConfigurations = [self.recorderConfigurations copy];
+    step.recordersMustCompleteBeforeAdvancingStep = self.recordersMustCompleteBeforeAdvancingStep;
     step.image = self.image;
     step.imageAltText = self.imageAltText;
     step.isPractice = self.isPractice;
@@ -128,6 +129,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, imageAltText, NSString);
         ORK_DECODE_OBJ_ARRAY(aDecoder, recorderConfigurations, ORKRecorderConfiguration);
         ORK_DECODE_BOOL(aDecoder, isPractice);
+        ORK_DECODE_BOOL(aDecoder, recordersMustCompleteBeforeAdvancingStep);
     }
     return self;
 }
@@ -151,6 +153,7 @@
     ORK_ENCODE_OBJ(aCoder, finishedSpokenInstruction);
     ORK_ENCODE_OBJ(aCoder, recorderConfigurations);
     ORK_ENCODE_BOOL(aCoder, isPractice);
+    ORK_ENCODE_BOOL(aCoder, recordersMustCompleteBeforeAdvancingStep);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -174,7 +177,8 @@
             (self.shouldVibrateOnFinish == castObject.shouldVibrateOnFinish) &&
             (self.shouldContinueOnFinish == castObject.shouldContinueOnFinish) &&
             (self.shouldUseNextAsSkipButton == castObject.shouldUseNextAsSkipButton) &&
-            (self.isPractice == castObject.isPractice));
+            (self.isPractice == castObject.isPractice) &&
+            (self.recordersMustCompleteBeforeAdvancingStep == castObject.recordersMustCompleteBeforeAdvancingStep));
 }
 
 - (NSSet<HKObjectType *> *)requestedHealthKitTypesForReading {

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.h
@@ -211,6 +211,12 @@ ORK_CLASS_AVAILABLE
  */
 - (void)finish;
 
+/**
+ Triggers the step to advance once the recorders have completed;
+ - Parameter stepDidFinishOnly: do not explicity call goForward on self when recorders are done (for steps that goForward without calling finish)
+ */
+- (void)goForwardOnceRecordersHaveCompleted:(BOOL)stepDidFinishOnly;
+
 /// @name Recorder life cycle
 
 /**

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
@@ -489,8 +489,8 @@
             [self stepDidFinish];
         } else {
             _recordersCheckLoopCount += 1;
+            NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
                 [self goForwardOnceRecordersHaveCompleted:stepDidFinishOnly];
             });
         }

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
@@ -59,6 +59,8 @@
     ORKActiveStepTimer *_activeStepTimer;
 
     NSArray *_recorderResults;
+    NSMutableSet *_recordersRunning;
+    NSInteger _recordersCheckLoopCount;
     
     SystemSoundID _alertSound;
     NSURL *_alertSoundURL;
@@ -78,6 +80,8 @@
     self = [super initWithStep:step];
     if (self) {
         _recorderResults = [NSArray new];
+        _recordersRunning = [NSMutableSet new];
+        _recordersCheckLoopCount = 0;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -367,6 +371,9 @@
     for (ORKRecorder *recorder in self.recorders) {
         [recorder viewController:self willStartStepWithView:self.customViewContainer];
         [recorder start];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [_recordersRunning addObject:recorder];
+        });
     }
 }
 
@@ -457,9 +464,37 @@
     if (!self.activeStep.startsFinished) {
         if (self.activeStep.shouldContinueOnFinish) {
             [self goForward];
+            if (self.activeStep.recordersMustCompleteBeforeAdvancingStep) {
+                [self goForwardOnceRecordersHaveCompleted:NO];
+            } else {
+                [self goForward];
+            }
         }
     }
     [self stepDidFinish];
+}
+
+- (void)goForwardOnceRecordersHaveCompleted:(BOOL)stepDidFinishOnly {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([_recordersRunning count] == 0) {
+            if (!stepDidFinishOnly) {
+                [self goForward];
+            }
+            [self stepDidFinish];
+        } else if (_recordersCheckLoopCount > 10) {
+            NSLog(@"Recorders are still not complete after 10 wait cycles, data may be lost in final result.");
+            if (!stepDidFinishOnly) {
+                [self goForward];
+            }
+            [self stepDidFinish];
+        } else {
+            _recordersCheckLoopCount += 1;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                NSLog(@"Waiting for [%lu] recorders to complete...", [_recordersRunning count]);
+                [self goForwardOnceRecordersHaveCompleted:stepDidFinishOnly];
+            });
+        }
+    });
 }
 
 - (void)dealloc {
@@ -553,6 +588,9 @@
 
 - (void)recorder:(ORKRecorder *)recorder didCompleteWithResult:(ORKResult *)result {
     _recorderResults = [_recorderResults arrayByAddingObject:result];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_recordersRunning removeObject:recorder];
+    });
     [self notifyDelegateOnResultChange];
 }
 
@@ -571,6 +609,9 @@
             self.outputDirectory == nil) {
             [strongDelegate stepViewControllerDidFail:self withError:error];
         }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [_recordersRunning removeObject:recorder];
+        });
     }
 }
 

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionResult.h
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionResult.h
@@ -54,11 +54,6 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, assign) double extended;
 
-/**
- The recorder output - usually the device motion recorder.
-  */
-@property (nonatomic, strong) ORKFileResult *fileResult;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionResult.m
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionResult.m
@@ -42,7 +42,6 @@
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_DOUBLE(aCoder, flexed);
     ORK_ENCODE_DOUBLE(aCoder, extended);
-    ORK_ENCODE_OBJ(aCoder, fileResult);
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
@@ -50,7 +49,6 @@
     if (self) {
         ORK_DECODE_DOUBLE(aDecoder, flexed);
         ORK_DECODE_DOUBLE(aDecoder, extended);
-        ORK_DECODE_OBJ_CLASS(aDecoder, fileResult, ORKFileResult);
     }
     return self;
 }
@@ -64,24 +62,18 @@
     __typeof(self) castObject = object;
     return (isParentSame &&
             self.flexed == castObject.flexed &&
-            self.extended == castObject.extended &&
-            ORKEqualObjects(self.fileResult, castObject.fileResult));
-}
-
-- (NSUInteger)hash {
-    return super.hash ^ self.fileResult.hash;
+            self.extended == castObject.extended);
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKRangeOfMotionResult *result = [super copyWithZone:zone];
     result.flexed = self.flexed;
     result.extended = self.extended;
-    result.fileResult = self.fileResult;
     return result;
 }
 
 - (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
-    return [NSString stringWithFormat:@"<%@: flexion: %f; extension: %f; fileResult: %@>", self.class.description, self.flexed, self.extended, self.fileResult.description];
+    return [NSString stringWithFormat:@"<%@: flexion: %f; extension: %f>", self.class.description, self.flexed, self.extended];
 }
 
 @end

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.m
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.m
@@ -50,6 +50,7 @@
         self.shouldContinueOnFinish = YES;
         self.shouldStartTimerAutomatically = YES;
         self.limbOption = limbOption;
+        self.recordersMustCompleteBeforeAdvancingStep = YES;
     }
     return self;
 }

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionStepViewController.m
@@ -177,12 +177,6 @@
     _lastAngle = angle;
 }
 
-#pragma mark - ORKRecorderDelegate
-
-- (void)recorder:(ORKRecorder *)recorder didCompleteWithResult:(ORKResult *)result {
-    self.fileResult = (ORKFileResult *)result;
-}
-
 /*
  When the device is in Portrait mode, we need to get the attitude's pitch
  to determine the device's angle. attitude.pitch doesn't return all
@@ -211,14 +205,12 @@
 
 - (ORKResult *)result {
     ORKStepResult *stepResult = [super result];
-    
-    ORKRangeOfMotionResult *result = [[ORKRangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
-    result.flexed = _flexedAngle;
-    result.extended = result.flexed - _rangeOfMotionAngle;
-    result.fileResult = _fileResult;
-    
-    stepResult.results = [self.addedResults arrayByAddingObject:result] ? : @[result];
-    
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
+    ORKRangeOfMotionResult *rangeOfMotionResult = [[ORKRangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
+    rangeOfMotionResult.flexed = _flexedAngle;
+    rangeOfMotionResult.extended = rangeOfMotionResult.flexed - _rangeOfMotionAngle;
+    [results addObject:rangeOfMotionResult];
+    stepResult.results = [results copy];
     return stepResult;
 }
 

--- a/ResearchKit/ActiveTasks/ORKShoulderRangeOfMotionStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKShoulderRangeOfMotionStepViewController.m
@@ -43,11 +43,14 @@
 - (ORKResult *)result {
     ORKStepResult *stepResult = [super result];
     
-    ORKRangeOfMotionResult *result = [[ORKRangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
-    result.flexed = 90.0 - _flexedAngle;
-    result.extended = result.flexed + _rangeOfMotionAngle;
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
     
-    stepResult.results = [self.addedResults arrayByAddingObject:result] ? : @[result];
+    ORKRangeOfMotionResult *rangeOfMotionResult = [[ORKRangeOfMotionResult alloc] initWithIdentifier:self.step.identifier];
+    rangeOfMotionResult.flexed = 90.0 - _flexedAngle;
+    rangeOfMotionResult.extended = rangeOfMotionResult.flexed + _rangeOfMotionAngle;
+    [results addObject:rangeOfMotionResult];
+    
+    stepResult.results = [results copy];
     
     return stepResult;
 }

--- a/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTimedWalkStepViewController.m
@@ -91,10 +91,15 @@
     self.timerUpdateInterval = 0.1f;
 }
 
-- (void)finish {
+// The ORKTimedWalkStepViewController expects the Next button to trigger goForward and doesn't call finish explicitly
+- (void)goForward {
+    [super stopRecorders];
+    [super goForwardOnceRecordersHaveCompleted:YES];
+}
+
+- (void)stepDidFinish {
     [super finish];
-    
-    [self goForward];
+    [super goForward];
 }
 
 - (void)countDownTimerFired:(ORKActiveStepTimer *)timer finished:(BOOL)finished {


### PR DESCRIPTION
Closes https://github.com/CareEvolution/MyDataHelps-iOS/issues/1437. 

The root cause of this bug is that the recorders completing and adding their results to the results array races with the completion/advancement of the TimedWalkStep. While the file results do eventually write in the expected location and append their result, if the current step of the task is not the same, the result gets appended to the ORK[1]TaskViewController's `_managedResults` dictionary with an [index](https://github.com/CareEvolution/ResearchKit/blob/04173246df27b3d89c55456fd080c03009ff1c8e/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m#L777-L783) that will never be reached when [enumerating for the final task result](https://github.com/CareEvolution/ResearchKit/blob/04173246df27b3d89c55456fd080c03009ff1c8e/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m#L739-L753) returned to the delegate.

In order to prevent this from happening, we need to make the recorders are returning results deterministically and before the advancing of the step. In reviewing the ORK[1]ActiveStepViewController, it appears that the intent was for the ActiveTask to call `finish` which then eventually calls `goForward` to proceed with navigation. However, the `ORK[1]TimedWalkStep` (and now CE-deprecated ORK1ReactionTimeStep - the newer version does not use recorders) goes about this differently - explicitly setting `continueEnabled` to `YES` to show a "Next" button. The result of this is that the `goForward` is called at the ORK1StepViewController level inverting the order of operations inside the ORK[1]ActiveTaskViewController. This means the step advances before finish is called and the recorders end up writing to a unique key (due to the stack count of identifiers at that time) that will not match the expected count when the step has not advanced.

Consequently, at the same time, it was found that Consumers was not deserializing the explicitly included recorder file inside the ORK[1]RangeOfMotionResult. It seems gratuitous to have to vend that FileResult inside the custom structure versus letting ORK[1]ActiveTask handle the recorders as is and funnel all recorder actions to happen there where we could more directly prevent the race condition.

The race condition an be short circuited with a simple async with delay call on the main queue via GCD, but it's not truly deterministic. Originally, I attempted to force any call to finish to be gated by validating all the recorders have completed, but this now affects ANY subclass of ActiveTask greatly increasing the testing surface area of the change.  Instead, the approach presented here limits the scope by adding a BOOL to the ORK[1]ActiveStep hierarchy and only gating if this is set. 

This technique is used to improve the RangeOfMotion results - delegating the handling of recorders to the ORK[1]ActiveTaskViewController. This would allow more flexibility to add additional recorders in the future using a more standard architecture.

The ORK[1]TimedWalk still required more work to capture the events and force a determined order to let the ActiveStepViewController handle the recorders. Now, the TimedWalkStepViewController will capture the `goForward` call from the Next button and stop the recorders, then call directly into `goForwardOnceRecordersHaveCompleted:` which preserves the current behavior of not calling finish directly, but forcing the recorders to complete before advancing the step.

## Testing:
Testing the following "predefined" ActiveTasks should demonstrate consistent inclusion of the FileResults in the export for the following Tasks in MDHD:
- Range of Motion (Knee)
    - Device Motion recorder
- Range of Motion (Shoulder)
    - Device Motion recorder 
- Timed Walk
    - Accelerometer recorder
    - Device Motion recorder
    - Location recorder
    - Pedometer recorder
By performing each task, and generating an export you should see a file per included recorder (as defined above).

Regression testing to ensure no loss of function should also be performed on other ActiveTasks such as:
- Stroop
    - no recorders
- Short Walk (Gait and Balance)
    - Accelerometer recorder
    - Device Motion recorder
    - Pedometer recorder
