### PR TITLE
Fix crash related to AppDelegate

### DIFF
--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
@@ -78,7 +78,7 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
 }
 
 -(void)resizeConstraints {
-    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([UIApplication sharedApplication].windows.firstObject);
     if (screenType == ORKScreenTypeiPhone5 ) {
         NormalizeButtonSize = 70.0;
         BackgroundViewSpaceMultiplier = 1.75;

--- a/ResearchKit/ActiveTasks/ORKStroopContentView.m
+++ b/ResearchKit/ActiveTasks/ORKStroopContentView.m
@@ -61,7 +61,7 @@ static const CGFloat buttonStackViewSpacing = 20.0;
         [_colorLabel setFont:[UIFont systemFontOfSize:60]];
         [_colorLabel setAdjustsFontSizeToFitWidth:YES];
         
-        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([UIApplication sharedApplication].windows.firstObject);
         
         if (screenType == ORKScreenTypeiPhone5) {
             labelWidth = 200.0;
@@ -144,7 +144,7 @@ static const CGFloat buttonStackViewSpacing = 20.0;
         
         _buttonStackView.axis = UILayoutConstraintAxisVertical;
         
-        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([UIApplication sharedApplication].windows.firstObject);
         
         if (screenType == ORKScreenTypeiPhone6) {
             minimumButtonHeight = 150.0;

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -179,6 +179,36 @@ void ORKAdjustHeightForLabel(UILabel *label) {
     label.frame = rect;
 }
 
+#if TARGET_OS_IOS
+UIColor *ORKWindowTintColor(UIWindow *window) {
+    UIColor *windowTintColor = window.tintColor;
+    if (!windowTintColor) {
+        return nil;
+    }
+    
+    //Return nil if the window tint color is clear
+    CGFloat redColor;
+    CGFloat blueColor;
+    CGFloat greenColor;
+    CGFloat alpha;
+    
+    [window.tintColor getRed:&redColor green:&greenColor blue:&blueColor alpha:&alpha];
+    
+    if (redColor == 0 && blueColor == 0 && greenColor == 0 && alpha == 0) {
+        return nil;
+    }
+    
+    return windowTintColor;
+}
+
+UIColor *ORKViewTintColor(UIView *view) {
+    UIColor *existingTintColor = view.tintColor ? : [UIColor systemBlueColor];
+    UIColor *tintColor = ORKWindowTintColor(view.window) ? : existingTintColor;
+
+    return tintColor;
+}
+#endif
+
 UIImage *ORKImageWithColor(UIColor *color) {
     CGRect rect = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
     UIGraphicsBeginImageContext(rect.size);

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -170,6 +170,11 @@ ORK_EXTERN NSString *ORKFileProtectionFromMode(ORKFileProtectionMode mode);
 CGFloat ORKExpectedLabelHeight(UILabel *label);
 void ORKAdjustHeightForLabel(UILabel *label);
 
+#if TARGET_OS_IOS
+UIColor * _Nullable ORKWindowTintColor(UIWindow *window);
+UIColor * ORKViewTintColor(UIView *view);
+#endif
+
 // build a image with color
 UIImage *ORKImageWithColor(UIColor *color);
 

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -267,6 +267,14 @@ static const CGFloat shadowHeight = 0.75;
     [self arrangeSubStacks];
 }
 
+- (void)didMoveToWindow {
+    _appTintColor = ORKViewTintColor(self);
+    
+    _cancelButton.normalTintColor = _appTintColor;
+    _continueButton.normalTintColor = _appTintColor;
+    _skipButton.normalTintColor = _appTintColor;
+}
+
 - (void)setupGrandparentStackView {
     if (!_grandparentStackView) {
         _grandparentStackView = [[UIStackView alloc] init];
@@ -351,7 +359,6 @@ static const CGFloat shadowHeight = 0.75;
             [_parentStackView addArrangedSubview:subStack];
         }
     }
-    _appTintColor = [UIApplication sharedApplication].windows.firstObject.tintColor;
     [self setupContinueButton];
     [self setupCancelButton];
     [self setupSkipButton];

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -351,7 +351,7 @@ static const CGFloat shadowHeight = 0.75;
             [_parentStackView addArrangedSubview:subStack];
         }
     }
-    _appTintColor = [[UIApplication sharedApplication].delegate window].tintColor;
+    _appTintColor = [UIApplication sharedApplication].windows.firstObject.tintColor;
     [self setupContinueButton];
     [self setupCancelButton];
     [self setupSkipButton];

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -178,7 +178,7 @@ NSString *const ORKAmslerGridCalibrationRightIdentifier = @"amsler.grid.calibrat
                                    intendedUseDescription:(NSString *)intendedUseDescription
                                                   options:(ORKPredefinedTaskOption)options {
     NSMutableArray *steps = [NSMutableArray array];
-    UIColor *tintColor = [[[UIApplication sharedApplication] delegate] window].tintColor ? : ORKColor(ORKBlueHighlightColorKey);
+    UIColor *tintColor = [UIApplication sharedApplication].windows.firstObject.tintColor ? : ORKColor(ORKBlueHighlightColorKey);
 
     if (!(options & ORKPredefinedTaskOptionExcludeInstructions)) {
         {


### PR DESCRIPTION
Several lines of ResearchKit v2 code get a UIWindow instance via the AppDelegate instance. This causes a crash in apps with a newer UIScene/SwiftUI lifecycle: the `[UIApplicationDelegate window]` selector is not guaranteed to exist.

Pulled in some recent updates to the main ResearchKit fork to implement this fix.

<img width="588" height="175" alt="image" src="https://github.com/user-attachments/assets/14b6b63a-821c-4537-bbee-1dacdc62a833" />

## Testing

Launch basically any ResearchKit v2 survey, and ensure the app does not immediately crash.