### PR TITLE
iOS 26/27/Liquid Glass compatibility

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "CareEvolution/MarkdownAttributedString" "1.0.4"
+github "CareEvolution/MarkdownAttributedString" "1.0.5"

--- a/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/ORK1Kit.xcscheme
+++ b/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/ORK1Kit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
+++ b/ORK1Kit/ORK1Kit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.h
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.h
@@ -16,6 +16,8 @@
 
 @interface CEVRK1NavigationBarProgressView : UIView
 
-- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme;
+@property (nonatomic, readonly) float progress;
+
+- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme animated:(BOOL)animated;
 
 @end

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
@@ -27,17 +27,29 @@
 
 - (void)createConstraints {
     _progressView = [[UIProgressView alloc] initWithFrame:CGRectZero];
-    _progressView.backgroundColor = [UIColor whiteColor];
     _progressView.progress = 0;
     self.accessibilityElements = @[_progressView];
     self.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_progressView];
     _progressView.translatesAutoresizingMaskIntoConstraints = NO;
     
-    [NSLayoutConstraint activateConstraints:@[
-        [_progressView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:0], //10],
-        [_progressView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:0], //-30],
-    ]];
+    if (@available(iOS 26.0, *)) {
+        _progressView.backgroundColor = [UIColor whiteColor];
+        [NSLayoutConstraint activateConstraints:@[
+            [_progressView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:0], //10],
+            [_progressView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:0], //-30],
+        ]];
+    } else {
+        // This forces the bar to stretch so the ORK1ProgressView will attempt to take up the entire available width
+        NSLayoutConstraint *widthConstraint = [self.widthAnchor constraintEqualToConstant:200];
+        widthConstraint.priority = UILayoutPriorityDefaultHigh;
+        [NSLayoutConstraint activateConstraints:@[
+            [_progressView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:10],
+            [_progressView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-30],
+            [_progressView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+            widthConstraint
+        ]];
+    }
 }
 
 - (float)progress {

--- a/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
+++ b/ORK1Kit/ORK1Kit/Common/CEVRK1NavigationBarProgressView.m
@@ -27,25 +27,25 @@
 
 - (void)createConstraints {
     _progressView = [[UIProgressView alloc] initWithFrame:CGRectZero];
+    _progressView.backgroundColor = [UIColor whiteColor];
     _progressView.progress = 0;
     self.accessibilityElements = @[_progressView];
     self.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_progressView];
     _progressView.translatesAutoresizingMaskIntoConstraints = NO;
     
-    // This forces the bar to stretch so the ORK1ProgressView will attempt to take up the entire available width
-    NSLayoutConstraint *widthConstraint = [self.widthAnchor constraintEqualToConstant:200];
-    widthConstraint.priority = UILayoutPriorityDefaultHigh;
     [NSLayoutConstraint activateConstraints:@[
-                                             [_progressView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:10],
-                                             [_progressView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-30],
-                                             [_progressView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-                                             widthConstraint
-     ]];
+        [_progressView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:0], //10],
+        [_progressView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:0], //-30],
+    ]];
 }
 
-- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme {
-    _progressView.progress = progress;
+- (float)progress {
+    return _progressView.progress;
+}
+
+- (void)setProgress:(float)progress withTheme:(nullable CEVRK1Theme *)theme animated:(BOOL)animated {
+    [_progressView setProgress:progress animated:animated];
     if (theme.progressBarColor) {
         _progressView.tintColor = theme.progressBarColor;
     }

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -279,7 +279,6 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     self.taskRunUUID = taskRunUUID;
     
-    [self.childNavigationController.navigationBar setShadowImage:[UIImage new]];
     self.hairline = [self findHairlineViewUnder:self.childNavigationController.navigationBar];
     self.hairline.alpha = 0.0f;
     self.childNavigationController.toolbar.clipsToBounds = YES;
@@ -1037,13 +1036,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                     } else {  // Linear
                         calculatedProgress = (float)taskProgress.current / (float)taskProgress.total;
                     }
-                    [strongSelf.progressView setProgress:calculatedProgress withTheme:[CEVRK1Theme themeForElement:strongSelf.currentStepViewController]];
-                    strongSelf.pageViewController.navigationItem.titleView = strongSelf.progressView;
-                    
-                    // for UITesting, we will add a title that will not display, but should appear via accessibility
-                    NSUInteger progressPercent = (NSUInteger)(calculatedProgress * 100);
-                    strongSelf.pageViewController.navigationItem.title = [NSString stringWithFormat:@"ProgressBar:%@", @(progressPercent)];
-                    
+                    [strongSelf.progressView setProgress:calculatedProgress withTheme:[CEVRK1Theme themeForElement:strongSelf.currentStepViewController] animated:animated];
+                    [strongSelf configureProgressView];
                 } else {
                     strongSelf.pageViewController.navigationItem.titleView = nil;
                     strongSelf.pageViewController.navigationItem.title = [NSString localizedStringWithFormat:ORK1LocalizedString(@"STEP_PROGRESS_FORMAT", nil) ,ORK1LocalizedStringFromNumber(@(taskProgress.current)), ORK1LocalizedStringFromNumber(@(taskProgress.total))];
@@ -1056,6 +1050,35 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         // Collect toolbarItems
         [strongSelf collectToolbarItemsFromViewController:viewController];
     }];
+}
+
+- (void)configureProgressView {
+    if (@available(iOS 26.0, *)) {
+        self.pageViewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+        self.pageViewController.navigationItem.title = nil;
+        
+        CEVRK1NavigationBarProgressView *progressView = self.progressView;
+        if (!progressView.superview) {
+            NSLog(@"configure progress");
+            UINavigationBar *navigationBar = self.childNavigationController.navigationBar;
+            navigationBar.opaque = YES;
+            navigationBar.translucent = NO;
+            
+            progressView.translatesAutoresizingMaskIntoConstraints = NO;
+            [navigationBar addSubview:progressView];
+            [NSLayoutConstraint activateConstraints:@[
+                [NSLayoutConstraint constraintWithItem:progressView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:navigationBar attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0],
+                [NSLayoutConstraint constraintWithItem:progressView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:navigationBar.safeAreaLayoutGuide attribute:NSLayoutAttributeLeftMargin multiplier:1.0 constant:10],
+                [NSLayoutConstraint constraintWithItem:progressView attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:navigationBar.safeAreaLayoutGuide attribute:NSLayoutAttributeRightMargin multiplier:1.0 constant:-10]
+            ]];
+        }
+    } else {
+        self.pageViewController.navigationItem.titleView = self.progressView;
+        
+        // for UITesting, we will add a title that will not display, but should appear via accessibility
+        NSUInteger progressPercent = (NSUInteger)(self.progressView.progress * 100);
+        self.pageViewController.navigationItem.title = [NSString stringWithFormat:@"ProgressBar:%@", @(progressPercent)];
+    }
 }
 
 - (BOOL)shouldPresentStep:(ORK1Step *)step {

--- a/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
+++ b/ORK1Kit/ORK1Kit/Common/ORK1TaskViewController.m
@@ -283,6 +283,11 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     self.hairline.alpha = 0.0f;
     self.childNavigationController.toolbar.clipsToBounds = YES;
     
+    if (@available(iOS 26.0, *)) {
+        // ResearchKit views render poorly with translucent navigation bars on iOS 26
+        self.childNavigationController.navigationBar.backgroundColor = [UIColor whiteColor];
+    }
+    
     // Ensure taskRunUUID has non-nil valuetaskRunUUID
     (void)[self taskRunUUID];
     self.restorationClass = [ORK1TaskViewController class];
@@ -1026,6 +1031,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                 // remove any progress
                 strongSelf.pageViewController.navigationItem.titleView = nil;
                 strongSelf.pageViewController.navigationItem.title = nil;
+                strongSelf.progressView.hidden = YES;
             } else {
                 ORK1OrderedTask *orderedTask = (ORK1OrderedTask *)strongSelf.task;
                 if (orderedTask.progressIndicatorStyle == CEVRK1TaskProgressIndicatorStyleBar) {
@@ -1038,9 +1044,11 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                     }
                     [strongSelf.progressView setProgress:calculatedProgress withTheme:[CEVRK1Theme themeForElement:strongSelf.currentStepViewController] animated:animated];
                     [strongSelf configureProgressView];
+                    strongSelf.progressView.hidden = NO;
                 } else {
                     strongSelf.pageViewController.navigationItem.titleView = nil;
                     strongSelf.pageViewController.navigationItem.title = [NSString localizedStringWithFormat:ORK1LocalizedString(@"STEP_PROGRESS_FORMAT", nil) ,ORK1LocalizedStringFromNumber(@(taskProgress.current)), ORK1LocalizedStringFromNumber(@(taskProgress.total))];
+                    strongSelf.progressView.hidden = YES;
                 }
             }
         }

--- a/ORK1Kit/ORK1Kit/Common/UIBarButtonItem+ORK1BarButtonItem.m
+++ b/ORK1Kit/ORK1Kit/Common/UIBarButtonItem+ORK1BarButtonItem.m
@@ -37,19 +37,9 @@
 @implementation UIBarButtonItem (ORK1BarButtonItem)
 
 + (UIBarButtonItem *)ork_backBarButtonItemWithTarget:(id)target action:(SEL)selector {
-    NSString *regularImageName = @"arrowLeft";
-    NSString *landscapeImageName = @"arrowLeftLandscape";
-
-    if ([UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft ) {
-        regularImageName = @"arrowRight";
-        landscapeImageName = @"arrowRightLandscape";
-    }
-    
-    UIImage *image = [UIImage imageNamed:regularImageName inBundle:ORK1Bundle() compatibleWithTraitCollection:nil];
-    UIImage *landscapeImage = [UIImage imageNamed:landscapeImageName inBundle:ORK1Bundle() compatibleWithTraitCollection:nil];
+    UIImage *image = [UIImage systemImageNamed:@"chevron.backward"];
     UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:image
-                                               landscapeImagePhone:landscapeImage
-                                                             style:UIBarButtonItemStyleDone
+                                                             style:UIBarButtonItemStylePlain
                                                             target:target
                                                             action:selector];
     item.accessibilityLabel = ORK1LocalizedString(@"AX_BUTTON_BACK", nil);

--- a/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.m
+++ b/ORK1Kit/ORK1Kit/Consent/ORK1ConsentReviewController.m
@@ -60,7 +60,7 @@
         _delegate = delegate;
         _webViewFinishedLoading = NO;
         
-        _agreeButton = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"BUTTON_AGREE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(ack)];
+        _agreeButton = [[UIBarButtonItem alloc] initWithTitle:ORK1LocalizedString(@"BUTTON_AGREE", nil) style:UIBarButtonItemStyleDone target:self action:@selector(ack)];
         if (requiresScrollToBottom) {
             _agreeButton.enabled = NO;
             _agreeButton.accessibilityHint = @"must scroll to the bottom to enable this button";

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit/Common/ORKAnswerTextField.m
+++ b/ResearchKit/Common/ORKAnswerTextField.m
@@ -68,11 +68,17 @@
     UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc]
                                       initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                       target:nil action:nil];
-    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc]
-                                   initWithBarButtonSystemItem:UIBarButtonSystemItemDone
-                                   target:self action:@selector(keyboardAccessoryViewDoneButtonPressed)];
+    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_DONE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(keyboardAccessoryViewDoneButtonPressed)];
+    
+    if (@available(iOS 26.0, *)) {
+        doneButton.hidesSharedBackground = YES;
+        accessoryViewWithDoneButton.backgroundColor = ORKColor(ORKToolBarTintColorKey);
+        doneButton.tintColor = ORKViewTintColor(self);
+    } else {
+        [accessoryViewWithDoneButton setBarTintColor:ORKColor(ORKBackgroundColorKey)];
+    }
+    
     accessoryViewWithDoneButton.items = @[flexibleSpace, doneButton];
-    [accessoryViewWithDoneButton setBarTintColor:ORKColor(ORKBackgroundColorKey)];
     self.inputAccessoryView = accessoryViewWithDoneButton;
 }
 

--- a/ResearchKit/Common/ORKAnswerTextView.m
+++ b/ResearchKit/Common/ORKAnswerTextView.m
@@ -84,11 +84,17 @@
     UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc]
                                       initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                       target:nil action:nil];
-    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc]
-                                   initWithBarButtonSystemItem:UIBarButtonSystemItemDone
-                                   target:self action:@selector(keyboardAccessoryViewDoneButtonPressed)];
+    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"BUTTON_DONE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(keyboardAccessoryViewDoneButtonPressed)];
+    
+    if (@available(iOS 26.0, *)) {
+        doneButton.hidesSharedBackground = YES;
+        accessoryViewWithDoneButton.backgroundColor = ORKColor(ORKToolBarTintColorKey);
+        doneButton.tintColor = ORKViewTintColor(self);
+    } else {
+        [accessoryViewWithDoneButton setBarTintColor:ORKColor(ORKBackgroundColorKey)];
+    }
+    
     accessoryViewWithDoneButton.items = @[flexibleSpace, doneButton];
-    [accessoryViewWithDoneButton setBarTintColor:ORKColor(ORKBackgroundColorKey)];
     self.inputAccessoryView = accessoryViewWithDoneButton;
 }
 

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -456,7 +456,11 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     [progressLabelNavigationItem setText:text];
     
-    return [[UIBarButtonItem alloc] initWithCustomView:progressLabelNavigationItem];
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithCustomView:progressLabelNavigationItem];
+    if (@available(iOS 26.0, *)) {
+        item.hidesSharedBackground = YES;
+    }
+    return item;
 }
 
 - (void)requestHealthStoreAccessWithReadTypes:(NSSet *)readTypes

--- a/ResearchKit/Common/UIBarButtonItem+ORKBarButtonItem.m
+++ b/ResearchKit/Common/UIBarButtonItem+ORKBarButtonItem.m
@@ -37,19 +37,9 @@
 @implementation UIBarButtonItem (ORKBarButtonItem)
 
 + (UIBarButtonItem *)ork_backBarButtonItemWithTarget:(id)target action:(SEL)selector {
-    NSString *regularImageName = @"arrowLeft";
-    NSString *landscapeImageName = @"arrowLeftLandscape";
-
-    if ([UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft ) {
-        regularImageName = @"arrowRight";
-        landscapeImageName = @"arrowRightLandscape";
-    }
-    
-    UIImage *image = [UIImage imageNamed:regularImageName inBundle:ORKBundle() compatibleWithTraitCollection:nil];
-    UIImage *landscapeImage = [UIImage imageNamed:landscapeImageName inBundle:ORKBundle() compatibleWithTraitCollection:nil];
+    UIImage *image = [UIImage systemImageNamed:@"chevron.backward"];
     UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:image
-                                               landscapeImagePhone:landscapeImage
-                                                             style:UIBarButtonItemStyleDone
+                                                             style:UIBarButtonItemStylePlain
                                                             target:target
                                                             action:selector];
     item.accessibilityLabel = ORKLocalizedString(@"AX_BUTTON_BACK", nil);

--- a/Testing/ORKTest/ORKTest.xcodeproj/xcshareddata/xcschemes/ORKTest.xcscheme
+++ b/Testing/ORKTest/ORKTest.xcodeproj/xcshareddata/xcschemes/ORKTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
+++ b/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
@@ -81,7 +81,7 @@
 		246DFA261BEAE26200591E9A /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = en_GB.lproj/Localizable.strings; sourceTree = "<group>"; };
 		246DFA271BEAE27000591E9A /* en-AU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU"; path = en_AU.lproj/Localizable.strings; sourceTree = "<group>"; };
 		246DFA281BEAE2A800591E9A /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = zh_HK.lproj/Localizable.strings; sourceTree = "<group>"; };
-		3E39B9E81ABF675000C2ABE5 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		3E39B9E81ABF675000C2ABE5 /* readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
 		3E39B9FA1ABF682D00C2ABE5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		3E39B9FD1ABF683700C2ABE5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		3E39B9FF1ABF683F00C2ABE5 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -152,7 +152,7 @@
 		869230B51AAA890A00BFE11B = {
 			isa = PBXGroup;
 			children = (
-				3E39B9E81ABF675000C2ABE5 /* README.md */,
+				3E39B9E81ABF675000C2ABE5 /* readme.md */,
 				BC2A3C9E1C58E81500DA64B7 /* Frameworks */,
 				869230C01AAA890A00BFE11B /* ORKCatalog */,
 				869230BF1AAA890A00BFE11B /* Products */,

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Complication).xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Complication).xcscheme
@@ -70,7 +70,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -88,7 +87,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Notification).xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App (Notification).xcscheme
@@ -71,7 +71,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -90,7 +89,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App.xcscheme
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/xcshareddata/xcschemes/ORKParkinsonStudy WatchKit App.xcscheme
@@ -69,7 +69,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -86,7 +85,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BA87DBAF20B80FFD004ACAFF"
             BuildableName = "ORKParkinsonStudy WatchKit App.app"
-            BlueprintName = "ORKParkinsonStudy WatchKit App"
             ReferencedContainer = "container:ORKParkinsonStudy.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>


### PR DESCRIPTION
_Requires Xcode 27_

Various toolbar/button changes to support iOS 26/27 and Liquid Glass (none of these changes apply for devices running iOS 18 or earlier):

- Nav bar is explicitly opaque: various ResearchKit internal views (table views, etc.) have some layout peculiarities with margins/safe area underneath navigation bars, which produce ugly visual artifacts when using the default translucent toolbar look with liquid glass. Task view controllers configure an opaque navigation bar to avoid this (hard-coded to white; we have decided we will not support dark mode in ResearchKit)
- ResearchKit V1 linear style progress bar: moved from the center (title) position in the nav bar to below the nav bar. I couldn't get the progress bar to stay nicely centered in the title position, and overall I think the new position looks better.
- ResearchKit V2: text fields attach a "Done" button to the accessory bar above the software keyboard. Made adjustments to this to have it effectively use the iOS 18 look. I couldn't find a Liquid Glass appearance that looked good
- Adjustments to various bar button items to get the best appearance with Liquid Glass

Enhancement:

- Linear style progress bar in V1 surveys: progress changes are now animated

Asking for feedback or contrary opinions on design choices:

- Do we like having liquid glass toolbar items in ResearchKit surveys, overall?
- Cancel button: I opted for a text "Cancel" inside a liquid glass capsule. iOS does have a system cancel button that's a large "X" but I thought an explicit "Cancel" label was better for surveys.

## Developer testing with Xcode (before this is fully integrated into MyDataHelps)

The easiest way to test is to use the [corresponding CEVResearchKit PR](https://github.com/CareEvolution/CEVResearchKit/pull/310), and run the CEVRKUITestVehicle app on a simulator or device. Suggested surveys: ConsentStep FormStep, FullBattery, ProgressOptions, QuestionStepText, QuestionStepTextAllowMultipleLinesInput. Don't forget to toggle the "version 2" switch to test both versions of ResearchKit.

## QA testing

TODO

## Screenshots

Each set of screenshots shows (1) the current appearance / iOS 18 appearance with this PR, (2) various UI bugs with Xcode 27 without the fixes in this PR, (3) the final UI rendered with this PR.

#### Basic bar buttons and progress bar

<img width="2090" height="1440" alt="RK1 bar items" src="https://github.com/user-attachments/assets/e20765fe-3565-4775-9c8a-a0f8279e5ebd" />

#### Save/discard prompt

<img width="2059" height="1368" alt="Save discard" src="https://github.com/user-attachments/assets/f8b8287b-aa5a-426b-a61a-47eaee104d24" />

#### Navigation bar opacity

Note the bug in the center screenshot: a hard edge halfway down the nav bar.

<img width="2090" height="1440" alt="Opaque bar" src="https://github.com/user-attachments/assets/ea34eab3-3875-4ae2-9772-f4f16b58efa2" />

#### RK1 text-style progress indicator alternative

<img width="2059" height="1368" alt="X of Y progress" src="https://github.com/user-attachments/assets/76a74521-91af-4f36-b260-03be8a2f8660" />

#### RK2 "Done" button above keyboard

<img width="2059" height="1368" alt="RK2 accessory" src="https://github.com/user-attachments/assets/e42186e8-7c51-4e30-b9f9-f97c9c70bd7f" />
